### PR TITLE
PRC-56 : Session cleanup for create contact journey

### DIFF
--- a/server/@types/express/index.d.ts
+++ b/server/@types/express/index.d.ts
@@ -11,7 +11,6 @@ export declare module 'express-session' {
     prisonId: string
     prisonName: string
     search: string
-    journey: object
     createContactJourneys: Record<string, CreateContactJourney>
   }
 }

--- a/server/@types/journeys/index.d.ts
+++ b/server/@types/journeys/index.d.ts
@@ -1,6 +1,7 @@
 declare module journeys {
   export interface CreateContactJourney {
     id: string
+    lastTouched: Date
     names?: ContactNames
     dateOfBirth?: DateOfBirth
   }

--- a/server/routes/contacts/create/createContactMiddleware.test.ts
+++ b/server/routes/contacts/create/createContactMiddleware.test.ts
@@ -16,12 +16,16 @@ describe('createContactMiddleware', () => {
       res = { redirect: jest.fn() } as unknown as Response
     })
 
-    it('should proceed if the journey is in the session', () => {
+    it('should proceed if the journey is in the session and update the last touched date', () => {
       const next = jest.fn()
+      const lastTouchedBeforeCall = new Date(2020, 1, 1)
       req.session.createContactJourneys = {}
-      req.session.createContactJourneys[journeyId] = { id: journeyId }
+      req.session.createContactJourneys[journeyId] = { id: journeyId, lastTouched: lastTouchedBeforeCall }
       ensureInCreateContactJourney()(req, res, next)
       expect(next).toHaveBeenCalledTimes(1)
+      expect(req.session.createContactJourneys[journeyId].lastTouched.getTime()).toBeGreaterThan(
+        lastTouchedBeforeCall.getTime(),
+      )
     })
     it('should return to start if the journey is not in the session', () => {
       const next = jest.fn()

--- a/server/routes/contacts/create/createContactMiddleware.ts
+++ b/server/routes/contacts/create/createContactMiddleware.ts
@@ -9,6 +9,8 @@ const ensureInCreateContactJourney = (): RequestHandler => {
     if (!req.session.createContactJourneys[journeyId]) {
       return res.redirect('/contacts/create/start')
     }
+    req.session.createContactJourneys[journeyId].lastTouched = new Date()
+
     return next()
   }
 }

--- a/server/routes/contacts/create/enter-dob/createContactEnterDobController.test.ts
+++ b/server/routes/contacts/create/enter-dob/createContactEnterDobController.test.ts
@@ -24,6 +24,7 @@ beforeEach(() => {
       session.createContactJourneys = {}
       session.createContactJourneys[journeyId] = {
         id: journeyId,
+        lastTouched: new Date(),
         names: {
           lastName: 'last',
           firstName: 'first',

--- a/server/routes/contacts/create/enter-name/createContactEnterNameController.test.ts
+++ b/server/routes/contacts/create/enter-name/createContactEnterNameController.test.ts
@@ -24,6 +24,7 @@ beforeEach(() => {
       session.createContactJourneys = {}
       session.createContactJourneys[journeyId] = {
         id: journeyId,
+        lastTouched: new Date(),
       }
     },
   })

--- a/server/routes/contacts/create/start/startCreateContactJourneyController.test.ts
+++ b/server/routes/contacts/create/start/startCreateContactJourneyController.test.ts
@@ -1,8 +1,10 @@
 import type { Express } from 'express'
 import request from 'supertest'
 import { SessionData } from 'express-session'
+import { v4 as uuidv4 } from 'uuid'
 import { appWithAllRoutes, user } from '../../../testutils/appSetup'
 import AuditService, { Page } from '../../../../services/auditService'
+import CreateContactJourney = journeys.CreateContactJourney
 
 jest.mock('../../../../services/auditService')
 
@@ -10,6 +12,7 @@ const auditService = new AuditService(null) as jest.Mocked<AuditService>
 
 let app: Express
 let session: Partial<SessionData>
+let preExistingJourneysToAddToSession: Array<CreateContactJourney>
 
 beforeEach(() => {
   app = appWithAllRoutes({
@@ -19,6 +22,12 @@ beforeEach(() => {
     userSupplier: () => user,
     sessionReceiver: (receivedSession: Partial<SessionData>) => {
       session = receivedSession
+      if (preExistingJourneysToAddToSession) {
+        session.createContactJourneys = {}
+        preExistingJourneysToAddToSession.forEach((journey: CreateContactJourney) => {
+          session.createContactJourneys[journey.id] = journey
+        })
+      }
     },
   })
 })
@@ -43,5 +52,81 @@ describe('GET /contacts/create/start', () => {
     expect(response.status).toEqual(302)
     expect(response.headers.location).toContain('/contacts/create/enter-name/')
     expect(Object.entries(session.createContactJourneys)).toHaveLength(1)
+  })
+
+  it('should not remove any existing other journeys in the session', async () => {
+    // Given
+    auditService.logPageView.mockResolvedValue(null)
+
+    // When
+    const response = await request(app).get('/contacts/create/start')
+
+    // Then
+    expect(auditService.logPageView).toHaveBeenCalledWith(Page.CREATE_CONTACT_START_PAGE, {
+      who: user.username,
+      correlationId: expect.any(String),
+    })
+    expect(response.status).toEqual(302)
+    expect(response.headers.location).toContain('/contacts/create/enter-name/')
+    expect(Object.entries(session.createContactJourneys)).toHaveLength(1)
+  })
+
+  it('should not remove any existing other journeys in the session', async () => {
+    // Given
+    auditService.logPageView.mockResolvedValue(null)
+    preExistingJourneysToAddToSession = [
+      {
+        id: uuidv4(),
+        lastTouched: new Date(),
+        names: {
+          lastName: 'foo',
+          firstName: 'bar',
+        },
+      },
+    ]
+
+    // When
+    const response = await request(app).get('/contacts/create/start')
+    const { location } = response.headers
+
+    // Then
+    expect(auditService.logPageView).toHaveBeenCalledWith(Page.CREATE_CONTACT_START_PAGE, {
+      who: user.username,
+      correlationId: expect.any(String),
+    })
+    expect(response.status).toEqual(302)
+    expect(location).toContain('/contacts/create/enter-name/')
+    expect(Object.entries(session.createContactJourneys)).toHaveLength(2)
+    const newId = location.substring(location.lastIndexOf('/') + 1)
+    expect(session.createContactJourneys[newId].id).toEqual(newId)
+    expect(session.createContactJourneys[newId].lastTouched).toBeTruthy()
+  })
+
+  it('should remove the oldest if there will be more than 5 journeys', async () => {
+    // Given
+    auditService.logPageView.mockResolvedValue(null)
+    preExistingJourneysToAddToSession = [
+      { id: 'old', lastTouched: new Date(2024, 1, 1, 11, 30) },
+      { id: 'middle-aged', lastTouched: new Date(2024, 1, 1, 12, 30) },
+      { id: 'youngest', lastTouched: new Date(2024, 1, 1, 14, 30) },
+      { id: 'oldest', lastTouched: new Date(2024, 1, 1, 10, 30) },
+      { id: 'young', lastTouched: new Date(2024, 1, 1, 13, 30) },
+    ]
+
+    // When
+    const response = await request(app).get('/contacts/create/start')
+    const { location } = response.headers
+
+    // Then
+    expect(auditService.logPageView).toHaveBeenCalledWith(Page.CREATE_CONTACT_START_PAGE, {
+      who: user.username,
+      correlationId: expect.any(String),
+    })
+    expect(response.status).toEqual(302)
+    expect(location).toContain('/contacts/create/enter-name/')
+    const newId = location.substring(location.lastIndexOf('/') + 1)
+    expect(Object.keys(session.createContactJourneys).sort()).toStrictEqual(
+      [newId, 'old', 'middle-aged', 'young', 'youngest'].sort(),
+    )
   })
 })

--- a/server/routes/contacts/create/start/startCreateContactJourneyController.ts
+++ b/server/routes/contacts/create/start/startCreateContactJourneyController.ts
@@ -7,12 +7,20 @@ import CreateContactJourney = journeys.CreateContactJourney
 export default class StartCreateContactJourneyController implements PageHandler {
   public PAGE_NAME = Page.CREATE_CONTACT_START_PAGE
 
+  private MAX_JOURNEYS = 5
+
   GET = async (req: Request, res: Response): Promise<void> => {
-    const journey: CreateContactJourney = { id: uuidv4() }
+    const journey: CreateContactJourney = { id: uuidv4(), lastTouched: new Date() }
     if (!req.session.createContactJourneys) {
       req.session.createContactJourneys = {}
     }
     req.session.createContactJourneys[journey.id] = journey
+    if (Object.entries(req.session.createContactJourneys).length > this.MAX_JOURNEYS) {
+      Object.values(req.session.createContactJourneys)
+        .sort((a: CreateContactJourney, b: CreateContactJourney) => b.lastTouched.getTime() - a.lastTouched.getTime())
+        .slice(this.MAX_JOURNEYS)
+        .forEach(journeyToRemove => delete req.session.createContactJourneys[journeyToRemove.id])
+    }
     res.redirect(`/contacts/create/enter-name/${journey.id}`)
   }
 }


### PR DESCRIPTION
 Prevent too many journeys from entering the session. If there are more than 5, remove the journey that was interacted with the longest ago.