### PR TITLE
PRC-56 : Add assertions to create contact integration tests

### DIFF
--- a/integration_tests/e2e/createContacts.cy.ts
+++ b/integration_tests/e2e/createContacts.cy.ts
@@ -9,7 +9,7 @@ context('Create Contacts', () => {
     cy.task('stubSignIn', { roles: ['PRISON'] })
   })
 
-  it('Can create a contact without dob', () => {
+  it('Can create a contact with only required fields', () => {
     cy.signIn()
     cy.visit('/contacts/create/start')
     cy.task('stubCreateContact', { id: 132456 })
@@ -25,15 +25,28 @@ context('Create Contacts', () => {
       .clickContinue()
 
     Page.verifyOnPage(CreatedContactPage)
+    cy.verifyLastAPICall(
+      {
+        method: 'POST',
+        urlPath: '/contact',
+      },
+      {
+        lastName: 'Last',
+        firstName: 'First',
+        createdBy: 'USER1',
+      },
+    )
   })
 
-  it('Can create a contact with dob', () => {
+  it('Can create a contact with all fields', () => {
     cy.signIn()
     cy.visit('/contacts/create/start')
     cy.task('stubCreateContact', { id: 132456 })
     Page.verifyOnPage(EnterNamePage) //
+      .selectTitle('Mr')
       .enterLastName('Last')
       .enterFirstName('First')
+      .enterMiddleName('Middle')
       .clickContinue()
 
     const enterDobPage = new EnterContactDateOfBirthPage('Last, First')
@@ -46,6 +59,20 @@ context('Create Contacts', () => {
       .clickContinue()
 
     Page.verifyOnPage(CreatedContactPage)
+    cy.verifyLastAPICall(
+      {
+        method: 'POST',
+        urlPath: '/contact',
+      },
+      {
+        title: 'MR',
+        lastName: 'Last',
+        firstName: 'First',
+        middleName: 'Middle',
+        createdBy: 'USER1',
+        dateOfBirth: '1982-06-15T00:00:00.000Z',
+      },
+    )
   })
 
   it('First name is required', () => {
@@ -82,6 +109,20 @@ context('Create Contacts', () => {
     enterNamePage.hasFieldInError('lastName', "Contact's last name must be 35 characters or less")
     enterNamePage.hasFieldInError('firstName', "Contact's first name must be 35 characters or less")
     enterNamePage.hasFieldInError('middleName', "Contact's middle name must be 35 characters or less")
+  })
+
+  it('Cannot enter a blank first name or last name', () => {
+    cy.signIn()
+    cy.visit('/contacts/create/start')
+
+    const enterNamePage = Page.verifyOnPage(EnterNamePage)
+    enterNamePage //
+      .enterLastName('  ')
+      .enterFirstName('  ')
+      .clickContinue()
+
+    enterNamePage.hasFieldInError('lastName', "Enter the contact's last name")
+    enterNamePage.hasFieldInError('firstName', "Enter the contact's first name")
   })
 
   it('Must select whether dob is known', () => {

--- a/integration_tests/index.d.ts
+++ b/integration_tests/index.d.ts
@@ -5,5 +5,12 @@ declare namespace Cypress {
      * @example cy.signIn({ failOnStatusCode: boolean })
      */
     signIn(options?: { failOnStatusCode: boolean }): Chainable<AUTWindow>
+
+    /**
+     * Custom command to verify that the last API call matching the parameter is deeply equal to the expected value.
+     * @param matching a wiremock request to /requests/find. For options see: https://wiremock.org/docs/standalone/admin-api-reference/#tag/Requests/operation/removeRequestsByMetadata
+     * @param expected the request body to match
+     */
+    verifyLastAPICall(matching: string | object, expected: object): Chainable<*>
   }
 }

--- a/integration_tests/mockApis/wiremock.ts
+++ b/integration_tests/mockApis/wiremock.ts
@@ -1,4 +1,4 @@
-import superagent, { SuperAgentRequest, Response } from 'superagent'
+import superagent, { Response, SuperAgentRequest } from 'superagent'
 
 const url = 'http://localhost:9091/__admin'
 
@@ -6,6 +6,13 @@ const stubFor = (mapping: Record<string, unknown>): SuperAgentRequest =>
   superagent.post(`${url}/mappings`).send(mapping)
 
 const getMatchingRequests = body => superagent.post(`${url}/requests/find`).send(body)
+
+const getLastAPICallMatching = async (matching: string | object): Promise<unknown> => {
+  const wiremockApiResponse: Response = await superagent.post(`${url}/requests/find`).send(matching)
+  const responses = (wiremockApiResponse.body || '[]').requests
+  const last = responses[responses.length - 1]
+  return JSON.parse(last.body)
+}
 
 const resetStubs = (): Promise<Array<Response>> =>
   Promise.all([superagent.delete(`${url}/mappings`), superagent.delete(`${url}/requests`)])
@@ -52,4 +59,4 @@ const stubDelete = (urlPattern, jsonBody?) =>
     },
   })
 
-export { stubFor, getMatchingRequests, resetStubs, stubGet, stubPost, stubPut, stubDelete }
+export { stubFor, getMatchingRequests, resetStubs, stubGet, stubPost, stubPut, stubDelete, getLastAPICallMatching }

--- a/integration_tests/support/commands.ts
+++ b/integration_tests/support/commands.ts
@@ -1,4 +1,13 @@
+import { getLastAPICallMatching } from '../mockApis/wiremock'
+
 Cypress.Commands.add('signIn', (options = { failOnStatusCode: true }) => {
   cy.request('/')
   return cy.task('getSignInUrl').then((url: string) => cy.visit(url, options))
 })
+
+Cypress.Commands.add('verifyLastAPICall', (matching: string | object, expected: object) => {
+  return cy.wrap(getLastAPICallMatching(matching)).should('eql', expected)
+})
+
+// ensure .should('eql', thing) displays the full diff
+chai.config.truncateThreshold = 0

--- a/server/routes/contacts/create/enter-name/createContactEnterNameSchemas.ts
+++ b/server/routes/contacts/create/enter-name/createContactEnterNameSchemas.ts
@@ -11,7 +11,11 @@ const MIDDLE_NAME_TOO_LONG_ERROR_MSG = "Contact's middle name must be 35 charact
 
 export const createContactEnterNameSchemaFactory = () => async () => {
   return createSchema({
-    title: z.string().optional(),
+    title: z
+      .string()
+      .optional()
+      .transform(val => (val?.trim().length > 0 ? val.trim() : undefined))
+      .transform(val => val?.trim()),
     lastName: z
       .string({ message: LAST_NAME_REQUIRED_MESSAGE })
       .max(35, LAST_NAME_TOO_LONG_ERROR_MSG)
@@ -19,8 +23,13 @@ export const createContactEnterNameSchemaFactory = () => async () => {
     firstName: z
       .string({ message: FIRST_NAME_REQUIRED_MESSAGE })
       .max(35, FIRST_NAME_TOO_LONG_ERROR_MSG)
-      .refine(val => val?.trim().length > 0, { message: FIRST_NAME_REQUIRED_MESSAGE }),
-    middleName: z.string().max(35, MIDDLE_NAME_TOO_LONG_ERROR_MSG).optional(),
+      .refine(val => val?.trim().length > 0, { message: FIRST_NAME_REQUIRED_MESSAGE })
+      .transform(val => val?.trim()),
+    middleName: z
+      .string()
+      .max(35, MIDDLE_NAME_TOO_LONG_ERROR_MSG)
+      .optional()
+      .transform(val => (val?.trim().length > 0 ? val.trim() : undefined)),
   })
 }
 


### PR DESCRIPTION
Assert that the create contact API is called with the correct parameters in the integration tests. While doing this I discovered a bug in that we were sending a title and middle name with an empty string instead of null.

Also added some missing tests to check that you can't just enter whitespace for the name.