### PR TITLE
PRC-57: Support check answers update name flow

### DIFF
--- a/integration_tests/e2e/createContactsCheckAnswersChange.cy.ts
+++ b/integration_tests/e2e/createContactsCheckAnswersChange.cy.ts
@@ -1,0 +1,66 @@
+import Page from '../pages/page'
+import EnterNamePage from '../pages/enterNamePage'
+import CreatedContactPage from '../pages/createdContactPage'
+import EnterContactDateOfBirthPage from '../pages/enterContactDateOfBirthPage'
+import CreateContactCheckYourAnswersPage from '../pages/createContactCheckYourAnswersPage'
+
+context('Create contact and update from check answers', () => {
+  beforeEach(() => {
+    cy.task('reset')
+    cy.task('stubSignIn', { roles: ['PRISON'] })
+  })
+
+  it('Can change a contacts names when creating a new contact', () => {
+    cy.signIn()
+    cy.visit('/contacts/create/start')
+    cy.task('stubCreateContact', { id: 132456 })
+    Page.verifyOnPage(EnterNamePage) //
+      .selectTitle('MR')
+      .enterLastName('Last')
+      .enterMiddleName('Middle')
+      .enterFirstName('First')
+      .clickContinue()
+
+    const enterDobPage = new EnterContactDateOfBirthPage('Last, First')
+    enterDobPage.checkOnPage()
+    enterDobPage //
+      .selectIsDobKnown(true)
+      .enterDay('15')
+      .enterMonth('06')
+      .enterYear('1982')
+      .clickContinue()
+
+    Page.verifyOnPage(CreateContactCheckYourAnswersPage) //
+      .verifyShowsNameAs('Last, First')
+      .verifyShowsDateOfBirthAs('15 June 1982')
+      .clickChangeNameLink()
+
+    Page.verifyOnPage(EnterNamePage) //
+      .selectTitle('DR')
+      .enterLastName('Last Updated')
+      .enterMiddleName('Middle Updated')
+      .enterFirstName('First Updated')
+      .clickContinue()
+
+    Page.verifyOnPage(CreateContactCheckYourAnswersPage) //
+      .verifyShowsNameAs('Last Updated, First Updated')
+      .verifyShowsDateOfBirthAs('15 June 1982')
+      .clickCreatePrisonerContact()
+
+    Page.verifyOnPage(CreatedContactPage)
+    cy.verifyLastAPICall(
+      {
+        method: 'POST',
+        urlPath: '/contact',
+      },
+      {
+        title: 'DR',
+        lastName: 'Last Updated',
+        firstName: 'First Updated',
+        middleName: 'Middle Updated',
+        createdBy: 'USER1',
+        dateOfBirth: '1982-06-15T00:00:00.000Z',
+      },
+    )
+  })
+})

--- a/integration_tests/pages/createContactCheckYourAnswersPage.ts
+++ b/integration_tests/pages/createContactCheckYourAnswersPage.ts
@@ -9,6 +9,10 @@ export default class CreateContactCheckYourAnswersPage extends Page {
     this.createPrisonerContactButton().click()
   }
 
+  clickChangeNameLink() {
+    this.changeNameLink().click()
+  }
+
   verifyShowsNameAs(expected: string): CreateContactCheckYourAnswersPage {
     this.checkAnswersNameValue().should('contain.text', expected)
     return this
@@ -24,4 +28,6 @@ export default class CreateContactCheckYourAnswersPage extends Page {
   private checkAnswersNameValue = (): PageElement => cy.get('.check-answers-name-value')
 
   private checkAnswersDobValue = (): PageElement => cy.get('.check-answers-dob-value')
+
+  private changeNameLink = (): PageElement => cy.get('[data-qa=change-name-link]')
 }

--- a/integration_tests/pages/enterNamePage.ts
+++ b/integration_tests/pages/enterNamePage.ts
@@ -6,17 +6,17 @@ export default class EnterNamePage extends Page {
   }
 
   enterLastName(value: string): EnterNamePage {
-    this.lastNameTextBox().type(value)
+    this.lastNameTextBox().clear().type(value)
     return this
   }
 
   enterFirstName(value: string): EnterNamePage {
-    this.firstNameTextBox().type(value)
+    this.firstNameTextBox().clear().type(value)
     return this
   }
 
   enterMiddleName(value: string): EnterNamePage {
-    this.middleNameTextBox().type(value)
+    this.middleNameTextBox().clear().type(value)
     return this
   }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -63,6 +63,7 @@
         "@typescript-eslint/parser": "^8.3.0",
         "audit-ci": "^7.1.0",
         "aws-sdk-client-mock": "^4.0.1",
+        "cheerio": "^1.0.0-rc.12",
         "chokidar": "^3.6.0",
         "concurrently": "^8.2.2",
         "cypress": "^13.14.1",
@@ -4801,6 +4802,13 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="
     },
+    "node_modules/boolbase": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
+      "integrity": "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/bowser": {
       "version": "2.11.0",
       "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.11.0.tgz",
@@ -5099,6 +5107,50 @@
       "dev": true,
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/cheerio": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/cheerio/-/cheerio-1.0.0.tgz",
+      "integrity": "sha512-quS9HgjQpdaXOvsZz82Oz7uxtXiy6UIsIQcpBj7HRw2M63Skasm9qlDocAM7jNuaxdhpPU7c4kJN+gA5MCu4ww==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cheerio-select": "^2.1.0",
+        "dom-serializer": "^2.0.0",
+        "domhandler": "^5.0.3",
+        "domutils": "^3.1.0",
+        "encoding-sniffer": "^0.2.0",
+        "htmlparser2": "^9.1.0",
+        "parse5": "^7.1.2",
+        "parse5-htmlparser2-tree-adapter": "^7.0.0",
+        "parse5-parser-stream": "^7.1.2",
+        "undici": "^6.19.5",
+        "whatwg-mimetype": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=18.17"
+      },
+      "funding": {
+        "url": "https://github.com/cheeriojs/cheerio?sponsor=1"
+      }
+    },
+    "node_modules/cheerio-select": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/cheerio-select/-/cheerio-select-2.1.0.tgz",
+      "integrity": "sha512-9v9kG0LvzrlcungtnJtpGNxY+fzECQKhK4EGJX2vByejiMX84MFNQw4UxPJl3bFbTMw+Dfs37XaIkCwTZfLh4g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "boolbase": "^1.0.0",
+        "css-select": "^5.1.0",
+        "css-what": "^6.1.0",
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3",
+        "domutils": "^3.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/fb55"
       }
     },
     "node_modules/chokidar": {
@@ -5586,6 +5638,36 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/css-select": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/css-select/-/css-select-5.1.0.tgz",
+      "integrity": "sha512-nwoRF1rvRRnnCqqY7updORDsuqKzqYJ28+oSMaJMMgOauh3fvwHqMS7EZpIPqK8GL+g9mKxF1vP/ZjSeNjEVHg==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "boolbase": "^1.0.0",
+        "css-what": "^6.1.0",
+        "domhandler": "^5.0.2",
+        "domutils": "^3.0.1",
+        "nth-check": "^2.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/fb55"
+      }
+    },
+    "node_modules/css-what": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/css-what/-/css-what-6.1.0.tgz",
+      "integrity": "sha512-HTUrgRJ7r4dsZKU6GjmpfRK1O76h97Z8MfS1G0FozR+oF2kG6Vfe8JE6zwrkbxigziPHinCJ+gCPjA9EaBDtRw==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">= 6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/fb55"
+      }
+    },
     "node_modules/csurf": {
       "version": "1.11.0",
       "resolved": "https://registry.npmjs.org/csurf/-/csurf-1.11.0.tgz",
@@ -6028,6 +6110,65 @@
         "node": ">=6.0.0"
       }
     },
+    "node_modules/dom-serializer": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
+      "integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.2",
+        "entities": "^4.2.0"
+      },
+      "funding": {
+        "url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
+      }
+    },
+    "node_modules/domelementtype": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
+      "integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/domhandler": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
+      "integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "domelementtype": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 4"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domhandler?sponsor=1"
+      }
+    },
+    "node_modules/domutils": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.1.0.tgz",
+      "integrity": "sha512-H78uMmQtI2AhgDJjWeQmHwJJ2bLPD3GMmO7Zja/ZZh84wkm+4ut+IUnUdRa8uCGX88DiVx1j6FRe1XfxEgjEZA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "dom-serializer": "^2.0.0",
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domutils?sponsor=1"
+      }
+    },
     "node_modules/dotenv": {
       "version": "16.4.5",
       "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.4.5.tgz",
@@ -6144,6 +6285,33 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/encoding-sniffer": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/encoding-sniffer/-/encoding-sniffer-0.2.0.tgz",
+      "integrity": "sha512-ju7Wq1kg04I3HtiYIOrUrdfdDvkyO9s5XM8QAj/bN61Yo/Vb4vgJxy5vi4Yxk01gWHbrofpPtpxM8bKger9jhg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "iconv-lite": "^0.6.3",
+        "whatwg-encoding": "^3.1.1"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/encoding-sniffer?sponsor=1"
+      }
+    },
+    "node_modules/encoding-sniffer/node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/end-of-stream": {
       "version": "1.4.4",
       "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
@@ -6177,6 +6345,19 @@
       },
       "engines": {
         "node": ">=8.6"
+      }
+    },
+    "node_modules/entities": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
     "node_modules/environment": {
@@ -7989,6 +8170,26 @@
       "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
       "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
       "dev": true
+    },
+    "node_modules/htmlparser2": {
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-9.1.0.tgz",
+      "integrity": "sha512-5zfg6mHUoaer/97TxnGpxmbR7zJtPwIYFMZ/H5ucTlPZhKvtum05yiPK3Mgai3a0DyVxv7qYqoweaEd2nrYQzQ==",
+      "dev": true,
+      "funding": [
+        "https://github.com/fb55/htmlparser2?sponsor=1",
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3",
+        "domutils": "^3.1.0",
+        "entities": "^4.5.0"
+      }
     },
     "node_modules/http-errors": {
       "version": "2.0.0",
@@ -11067,6 +11268,19 @@
         "node": ">=8"
       }
     },
+    "node_modules/nth-check": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-2.1.1.tgz",
+      "integrity": "sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "boolbase": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/nth-check?sponsor=1"
+      }
+    },
     "node_modules/nunjucks": {
       "version": "3.2.4",
       "resolved": "https://registry.npmjs.org/nunjucks/-/nunjucks-3.2.4.tgz",
@@ -11356,6 +11570,46 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/parse5": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.1.2.tgz",
+      "integrity": "sha512-Czj1WaSVpaoj0wbhMzLmWD69anp2WH7FXMB9n1Sy8/ZFF9jolSQVMu1Ij5WIyGmcBmhk7EOndpO4mIpihVqAXw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^4.4.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/parse5-htmlparser2-tree-adapter": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/parse5-htmlparser2-tree-adapter/-/parse5-htmlparser2-tree-adapter-7.0.0.tgz",
+      "integrity": "sha512-B77tOZrqqfUfnVcOrUvfdLbz4pu4RopLD/4vmu3HUPswwTA8OH0EMW9BlWR2B0RCoiZRAHEUu7IxeP1Pd1UU+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "domhandler": "^5.0.2",
+        "parse5": "^7.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/parse5-parser-stream": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/parse5-parser-stream/-/parse5-parser-stream-7.1.2.tgz",
+      "integrity": "sha512-JyeQc9iwFLn5TbvvqACIF/VXG6abODeB3Fwmv/TGdLk2LfbWkaySGY72at4+Ty7EkPZj854u4CrICqNk2qIbow==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "parse5": "^7.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
       }
     },
     "node_modules/parseurl": {
@@ -13831,6 +14085,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/undici": {
+      "version": "6.19.8",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.19.8.tgz",
+      "integrity": "sha512-U8uCCl2x9TK3WANvmBavymRzxbfFYG+tAu+fgx3zxQy3qdagQqBLwJVrdyO1TBfUXvfKveMKJZhpvUYoOjM+4g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.17"
+      }
+    },
     "node_modules/undici-types": {
       "version": "6.19.8",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.19.8.tgz",
@@ -13998,6 +14262,42 @@
       "dev": true,
       "dependencies": {
         "makeerror": "1.0.12"
+      }
+    },
+    "node_modules/whatwg-encoding": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-3.1.1.tgz",
+      "integrity": "sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "iconv-lite": "0.6.3"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/whatwg-encoding/node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz",
+      "integrity": "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/which": {

--- a/package.json
+++ b/package.json
@@ -143,6 +143,7 @@
     "@typescript-eslint/parser": "^8.3.0",
     "audit-ci": "^7.1.0",
     "aws-sdk-client-mock": "^4.0.1",
+    "cheerio": "^1.0.0-rc.12",
     "chokidar": "^3.6.0",
     "concurrently": "^8.2.2",
     "cypress": "^13.14.1",

--- a/server/@types/journeys/index.d.ts
+++ b/server/@types/journeys/index.d.ts
@@ -2,6 +2,7 @@ declare namespace journeys {
   export interface CreateContactJourney {
     id: string
     lastTouched: Date
+    isCheckingAnswers: boolean
     names?: ContactNames
     dateOfBirth?: DateOfBirth
   }

--- a/server/routes/contacts/create/check-answers/createContactCheckAnswersController.test.ts
+++ b/server/routes/contacts/create/check-answers/createContactCheckAnswersController.test.ts
@@ -19,6 +19,7 @@ const journeyId: string = uuidv4()
 const journey: CreateContactJourney = {
   id: journeyId,
   lastTouched: new Date(),
+  isCheckingAnswers: false,
   names: {
     lastName: 'last',
     firstName: 'first',
@@ -65,6 +66,7 @@ describe('GET /contacts/create/check-answers', () => {
         who: user.username,
         correlationId: expect.any(String),
       })
+      expect(journey.isCheckingAnswers).toStrictEqual(true)
     })
     it('should return to start if no journey in session', async () => {
       await request(app)

--- a/server/routes/contacts/create/check-answers/createContactCheckAnswersController.ts
+++ b/server/routes/contacts/create/check-answers/createContactCheckAnswersController.ts
@@ -11,6 +11,7 @@ export default class CreateContactCheckAnswersController implements PageHandler 
   GET = async (req: Request<{ journeyId: string }, unknown, unknown>, res: Response): Promise<void> => {
     const { journeyId } = req.params
     const journey = req.session.createContactJourneys[journeyId]
+    journey.isCheckingAnswers = true
     res.render('pages/contacts/create/checkAnswers', { journey })
   }
 

--- a/server/routes/contacts/create/createContactMiddleware.test.ts
+++ b/server/routes/contacts/create/createContactMiddleware.test.ts
@@ -20,7 +20,11 @@ describe('createContactMiddleware', () => {
       const next = jest.fn()
       const lastTouchedBeforeCall = new Date(2020, 1, 1)
       req.session.createContactJourneys = {}
-      req.session.createContactJourneys[journeyId] = { id: journeyId, lastTouched: lastTouchedBeforeCall }
+      req.session.createContactJourneys[journeyId] = {
+        id: journeyId,
+        lastTouched: lastTouchedBeforeCall,
+        isCheckingAnswers: false,
+      }
       ensureInCreateContactJourney()(req, res, next)
       expect(next).toHaveBeenCalledTimes(1)
       expect(req.session.createContactJourneys[journeyId].lastTouched.getTime()).toBeGreaterThan(

--- a/server/routes/contacts/create/enter-dob/createContactEnterDobController.test.ts
+++ b/server/routes/contacts/create/enter-dob/createContactEnterDobController.test.ts
@@ -16,6 +16,7 @@ const journeyId: string = uuidv4()
 const baseJourney: CreateContactJourney = {
   id: journeyId,
   lastTouched: new Date(),
+  isCheckingAnswers: false,
   names: {
     lastName: 'last',
     firstName: 'first',

--- a/server/routes/contacts/create/enter-name/createContactEnterNameController.test.ts
+++ b/server/routes/contacts/create/enter-name/createContactEnterNameController.test.ts
@@ -2,8 +2,10 @@ import type { Express } from 'express'
 import request from 'supertest'
 import { SessionData } from 'express-session'
 import { v4 as uuidv4 } from 'uuid'
-import { appWithAllRoutes, user } from '../../../testutils/appSetup'
+import * as cheerio from 'cheerio'
+import { appWithAllRoutes, flashProvider, user } from '../../../testutils/appSetup'
 import AuditService, { Page } from '../../../../services/auditService'
+import CreateContactJourney = journeys.CreateContactJourney
 
 jest.mock('../../../../services/auditService')
 
@@ -12,8 +14,14 @@ const auditService = new AuditService(null) as jest.Mocked<AuditService>
 let app: Express
 let session: Partial<SessionData>
 const journeyId: string = uuidv4()
+let existingJourney: CreateContactJourney
 
 beforeEach(() => {
+  existingJourney = {
+    id: journeyId,
+    lastTouched: new Date(),
+    isCheckingAnswers: false,
+  }
   app = appWithAllRoutes({
     services: {
       auditService,
@@ -22,10 +30,7 @@ beforeEach(() => {
     sessionReceiver: (receivedSession: Partial<SessionData>) => {
       session = receivedSession
       session.createContactJourneys = {}
-      session.createContactJourneys[journeyId] = {
-        id: journeyId,
-        lastTouched: new Date(),
-      }
+      session.createContactJourneys[journeyId] = existingJourney
     },
   })
 })
@@ -50,6 +55,58 @@ describe('GET /contacts/create/enter-name', () => {
       who: user.username,
       correlationId: expect.any(String),
     })
+  })
+  it('should render previously entered details if validation errors', async () => {
+    // Given
+    const form = { firstName: 'first', lastName: 'last', middleName: 'middle', title: 'MR' }
+    auditService.logPageView.mockResolvedValue(null)
+    flashProvider.mockImplementation(key => (key === 'formResponses' ? [JSON.stringify(form)] : []))
+
+    // When
+    const response = await request(app).get(`/contacts/create/enter-name/${journeyId}`)
+
+    // Then
+    expect(response.status).toEqual(200)
+    const $ = cheerio.load(response.text)
+    expect($('#firstName').val()).toStrictEqual('first')
+    expect($('#middleName').val()).toStrictEqual('middle')
+    expect($('#lastName').val()).toStrictEqual('last')
+    expect($('#title').val()).toStrictEqual('MR')
+  })
+
+  it('should render previously entered details if no validation errors but there are session values', async () => {
+    // Given
+    auditService.logPageView.mockResolvedValue(null)
+    existingJourney.names = { firstName: 'first', lastName: 'last', middleName: 'middle', title: 'MR' }
+
+    // When
+    const response = await request(app).get(`/contacts/create/enter-name/${journeyId}`)
+
+    // Then
+    expect(response.status).toEqual(200)
+    const $ = cheerio.load(response.text)
+    expect($('#firstName').val()).toStrictEqual('first')
+    expect($('#middleName').val()).toStrictEqual('middle')
+    expect($('#lastName').val()).toStrictEqual('last')
+    expect($('#title').val()).toStrictEqual('MR')
+  })
+  it('should render submitted options on validation error even if there is a version in the session', async () => {
+    // Given
+    auditService.logPageView.mockResolvedValue(null)
+    existingJourney.names = { firstName: 'first', lastName: 'last', middleName: 'middle', title: 'MR' }
+    const form = { firstName: 'first updated', lastName: 'last updated', middleName: 'middle updated', title: 'DR' }
+    flashProvider.mockImplementation(key => (key === 'formResponses' ? [JSON.stringify(form)] : []))
+
+    // When
+    const response = await request(app).get(`/contacts/create/enter-name/${journeyId}`)
+
+    // Then
+    expect(response.status).toEqual(200)
+    const $ = cheerio.load(response.text)
+    expect($('#firstName').val()).toStrictEqual('first updated')
+    expect($('#middleName').val()).toStrictEqual('middle updated')
+    expect($('#lastName').val()).toStrictEqual('last updated')
+    expect($('#title').val()).toStrictEqual('DR')
   })
   it('should return to start if no journey in session', async () => {
     await request(app)
@@ -76,7 +133,34 @@ describe('POST /contacts/create/enter-name/:journeyId', () => {
     })
   })
 
-  it('should return to enter page if there are validation errors', async () => {
+  it('should pass to check answers page if there are no validation errors and journey is in check state', async () => {
+    // Given
+    existingJourney.names = {
+      lastName: 'last',
+      firstName: 'first',
+      middleName: 'middle',
+      title: 'MR',
+    }
+    existingJourney.isCheckingAnswers = true
+
+    // When
+    await request(app)
+      .post(`/contacts/create/enter-name/${journeyId}`)
+      .type('form')
+      .send({ firstName: 'first updated', lastName: 'last updated', middleName: 'middle updated', title: 'DR' })
+      .expect(302)
+      .expect('Location', `/contacts/create/check-answers/${journeyId}`)
+
+    // Then
+    expect(session.createContactJourneys[journeyId].names).toStrictEqual({
+      lastName: 'last updated',
+      firstName: 'first updated',
+      middleName: 'middle updated',
+      title: 'DR',
+    })
+  })
+
+  it('should return to enter page with details kept if there are validation errors', async () => {
     await request(app)
       .post(`/contacts/create/enter-name/${journeyId}`)
       .type('form')

--- a/server/routes/contacts/create/enter-name/createContactEnterNameController.ts
+++ b/server/routes/contacts/create/enter-name/createContactEnterNameController.ts
@@ -6,10 +6,37 @@ import { CreateContactEnterNameSchemaType } from './createContactEnterNameSchema
 export default class EnterNameController implements PageHandler {
   public PAGE_NAME = Page.CREATE_CONTACT_NAME_PAGE
 
+  private TITLES = [
+    { value: '', text: '' },
+    { value: 'DAME', text: 'Dame' },
+    { value: 'FR', text: 'Father' },
+    { value: 'LORD', text: 'Lord' },
+    { value: 'MS', text: 'Ms' },
+    { value: 'RABBI', text: 'Rabbi' },
+    { value: 'REV', text: 'Reverend' },
+    { value: 'SIR', text: 'Sir' },
+    { value: 'SR', text: 'Sister' },
+    { value: 'MR', text: 'Mr' },
+    { value: 'BR', text: 'Brother' },
+    { value: 'DR', text: 'Dr' },
+    { value: 'LADY', text: 'Lady' },
+    { value: 'MISS', text: 'Miss' },
+    { value: 'MRS', text: 'Mrs' },
+    { value: 'IMAM', text: 'Imam' },
+  ]
+
   GET = async (req: Request, res: Response): Promise<void> => {
     const { journeyId } = req.params
     const journey = req.session.createContactJourneys[journeyId]
-    res.render('pages/contacts/create/enterName', { journey })
+
+    const viewModel = {
+      journey,
+      titleOptions: this.getSelectedTitleOptions(res.locals?.formResponses?.title ?? journey?.names?.title),
+      lastName: res.locals?.formResponses?.lastName ?? journey?.names?.lastName,
+      firstName: res.locals?.formResponses?.firstName ?? journey?.names?.firstName,
+      middleName: res.locals?.formResponses?.middleName ?? journey?.names?.middleName,
+    }
+    res.render('pages/contacts/create/enterName', viewModel)
   }
 
   POST = async (
@@ -26,6 +53,16 @@ export default class EnterNameController implements PageHandler {
     const { title, lastName, firstName, middleName } = req.body
     const journey = req.session.createContactJourneys[journeyId]
     journey.names = { title, lastName, firstName, middleName }
-    res.redirect(`/contacts/create/enter-dob/${journeyId}`)
+    if (journey.isCheckingAnswers) {
+      res.redirect(`/contacts/create/check-answers/${journeyId}`)
+    } else {
+      res.redirect(`/contacts/create/enter-dob/${journeyId}`)
+    }
+  }
+
+  private getSelectedTitleOptions(selectedTitle?: string): Array<{ value: string; text: string; selected: boolean }> {
+    return this.TITLES.map((title: { value: string; text: string }) => {
+      return { ...title, selected: title.value === selectedTitle }
+    })
   }
 }

--- a/server/routes/contacts/create/start/startCreateContactJourneyController.test.ts
+++ b/server/routes/contacts/create/start/startCreateContactJourneyController.test.ts
@@ -78,6 +78,7 @@ describe('GET /contacts/create/start', () => {
       {
         id: uuidv4(),
         lastTouched: new Date(),
+        isCheckingAnswers: false,
         names: {
           lastName: 'foo',
           firstName: 'bar',
@@ -106,11 +107,11 @@ describe('GET /contacts/create/start', () => {
     // Given
     auditService.logPageView.mockResolvedValue(null)
     preExistingJourneysToAddToSession = [
-      { id: 'old', lastTouched: new Date(2024, 1, 1, 11, 30) },
-      { id: 'middle-aged', lastTouched: new Date(2024, 1, 1, 12, 30) },
-      { id: 'youngest', lastTouched: new Date(2024, 1, 1, 14, 30) },
-      { id: 'oldest', lastTouched: new Date(2024, 1, 1, 10, 30) },
-      { id: 'young', lastTouched: new Date(2024, 1, 1, 13, 30) },
+      { id: 'old', lastTouched: new Date(2024, 1, 1, 11, 30), isCheckingAnswers: false },
+      { id: 'middle-aged', lastTouched: new Date(2024, 1, 1, 12, 30), isCheckingAnswers: false },
+      { id: 'youngest', lastTouched: new Date(2024, 1, 1, 14, 30), isCheckingAnswers: false },
+      { id: 'oldest', lastTouched: new Date(2024, 1, 1, 10, 30), isCheckingAnswers: false },
+      { id: 'young', lastTouched: new Date(2024, 1, 1, 13, 30), isCheckingAnswers: false },
     ]
 
     // When

--- a/server/routes/contacts/create/start/startCreateContactJourneyController.ts
+++ b/server/routes/contacts/create/start/startCreateContactJourneyController.ts
@@ -10,7 +10,7 @@ export default class StartCreateContactJourneyController implements PageHandler 
   private MAX_JOURNEYS = 5
 
   GET = async (req: Request, res: Response): Promise<void> => {
-    const journey: CreateContactJourney = { id: uuidv4(), lastTouched: new Date() }
+    const journey: CreateContactJourney = { id: uuidv4(), lastTouched: new Date(), isCheckingAnswers: false }
     if (!req.session.createContactJourneys) {
       req.session.createContactJourneys = {}
     }

--- a/server/routes/contacts/manage/prisoner-search/prisonerSearchController.test.ts
+++ b/server/routes/contacts/manage/prisoner-search/prisonerSearchController.test.ts
@@ -69,7 +69,7 @@ describe('POST /contacts/manage/prisoner-search/:journeyId', () => {
       .expect(302)
       .expect('Location', `/contacts/manage/prisoner-search-results/${journeyId}`)
 
-    expect(flashProvider).not.toHaveBeenCalled()
+    expect(flashProvider).not.toHaveBeenCalledWith('validationErrors', expect.any(String))
     expect(session.manageContactsJourneys[journeyId].search.searchTerm).toEqual('A1111AA')
   })
 

--- a/server/routes/testutils/appSetup.ts
+++ b/server/routes/testutils/appSetup.ts
@@ -40,6 +40,7 @@ function appSetup(
   const app = express()
 
   app.set('view engine', 'njk')
+  flashProvider.mockImplementation(_ => [])
 
   nunjucksSetup(app)
   app.use(setUpWebSession())
@@ -69,10 +70,10 @@ function appSetup(
   }
   app.use(express.json())
   app.use(express.urlencoded({ extended: true }))
+  app.use(populateValidationErrors())
   app.use(routes(services))
   app.use((req, res, next) => next(new NotFound()))
   app.use(errorHandler(production))
-  app.use(populateValidationErrors())
 
   app.get(
     '*',

--- a/server/services/contactsService.test.ts
+++ b/server/services/contactsService.test.ts
@@ -30,6 +30,7 @@ describe('contactsService', () => {
       const journey: CreateContactJourney = {
         id: '1',
         lastTouched: new Date(),
+        isCheckingAnswers: false,
         names: {
           title: 'Mr',
           lastName: 'last',
@@ -66,6 +67,7 @@ describe('contactsService', () => {
       const journey: CreateContactJourney = {
         id: '1',
         lastTouched: new Date(),
+        isCheckingAnswers: false,
         names: {
           lastName: 'last',
           firstName: 'first',
@@ -97,6 +99,7 @@ describe('contactsService', () => {
           {
             id: '1',
             lastTouched: new Date(),
+            isCheckingAnswers: false,
             names: { firstName: 'first', lastName: 'last' },
             dateOfBirth: { isKnown: false },
           },

--- a/server/views/pages/contacts/create/checkAnswers.njk
+++ b/server/views/pages/contacts/create/checkAnswers.njk
@@ -53,7 +53,7 @@
                                         href: "/contacts/create/enter-name/"  + journey.id,
                                         text: "Change",
                                         visuallyHiddenText: "name",
-                                        attributes: {"data-qa": "change-enter-name-link"},
+                                        attributes: {"data-qa": "change-name-link"},
                                         classes: "govuk-link--no-visited-state"
                                     }
                                 ]

--- a/server/views/pages/contacts/create/enterName.njk
+++ b/server/views/pages/contacts/create/enterName.njk
@@ -39,24 +39,7 @@
                     label: {
                         text: "Title"
                     },
-                    items: [
-                        { "value": "", "text": "" , selected: true},
-                        { "value": "DAME", "text": "Dame" },
-                        { "value": "FR", "text": "Father" },
-                        { "value": "LORD", "text": "Lord" },
-                        { "value": "MS", "text": "Ms" },
-                        { "value": "RABBI", "text": "Rabbi" },
-                        { "value": "REV", "text": "Reverend" },
-                        { "value": "SIR", "text": "Sir" },
-                        { "value": "SR", "text": "Sister" },
-                        { "value": "MR", "text": "Mr" },
-                        { "value": "BR", "text": "Brother" },
-                        { "value": "DR", "text": "Dr" },
-                        { "value": "LADY", "text": "Lady" },
-                        { "value": "MISS", "text": "Miss" },
-                        { "value": "MRS", "text": "Mrs" },
-                        { "value": "IMAM", "text": "Imam" }
-                    ]
+                    items: titleOptions
                 }) }}
 
                 {{ govukInput({
@@ -65,7 +48,7 @@
                     label: { text: "First name" },
                     classes: 'govuk-!-width-one-third',
                     errorMessage: validationErrors | findError('firstName'),
-                    value: formResponses.firstName
+                    value: firstName
                 }) }}
 
                 {{ govukInput({
@@ -74,7 +57,7 @@
                     label: { text: "Middle names" },
                     classes: 'govuk-!-width-one-third',
                     errorMessage: validationErrors | findError('middleName'),
-                    value: formResponses.middleName
+                    value: middleName
                 }) }}
 
                 {{ govukInput({
@@ -83,7 +66,7 @@
                     label: { text: "Last name" },
                     classes: 'govuk-!-width-one-third',
                     errorMessage: validationErrors | findError('lastName'),
-                    value: formResponses.lastName
+                    value: lastName
                 }) }}
 
                 <div class="govuk-button-group">


### PR DESCRIPTION
Introduced flag to set once we are checking answers.  This is then used to redirect back to check answers straight from the enter name page. Also made it so the page is properly populated with either session data or form data if there was a validation error.