### PR TITLE
PRC-57: Wrap all controllers with asyncMiddleware

### DIFF
--- a/server/routes/contacts/create/createContactRoutes.ts
+++ b/server/routes/contacts/create/createContactRoutes.ts
@@ -11,25 +11,26 @@ import StartCreateContactJourneyController from './start/startCreateContactJourn
 import ensureInCreateContactJourney from './createContactMiddleware'
 import { ContactsService } from '../../../services'
 import CreateContactCheckAnswersController from './check-answers/createContactCheckAnswersController'
+import asyncMiddleware from '../../../middleware/asyncMiddleware'
 
 const CreateContactRoutes = (auditService: AuditService, contactsService: ContactsService) => {
   const router = Router({ mergeParams: true })
 
   const startController = new StartCreateContactJourneyController()
-  router.get('/start', logPageViewMiddleware(auditService, startController), startController.GET)
+  router.get('/start', logPageViewMiddleware(auditService, startController), asyncMiddleware(startController.GET))
 
   const enterNameController = new EnterNameController()
   router.get(
     '/enter-name/:journeyId',
     ensureInCreateContactJourney(),
     logPageViewMiddleware(auditService, enterNameController),
-    enterNameController.GET,
+    asyncMiddleware(enterNameController.GET),
   )
   router.post(
     '/enter-name/:journeyId',
     ensureInCreateContactJourney(),
     validate(createContactEnterNameSchemaFactory()),
-    enterNameController.POST,
+    asyncMiddleware(enterNameController.POST),
   )
 
   const enterDobController = new CreateContactEnterDobController()
@@ -37,13 +38,13 @@ const CreateContactRoutes = (auditService: AuditService, contactsService: Contac
     '/enter-dob/:journeyId',
     ensureInCreateContactJourney(),
     logPageViewMiddleware(auditService, enterDobController),
-    enterDobController.GET,
+    asyncMiddleware(enterDobController.GET),
   )
   router.post(
     '/enter-dob/:journeyId',
     ensureInCreateContactJourney(),
     validate(createContactEnterDobSchema()),
-    enterDobController.POST,
+    asyncMiddleware(enterDobController.POST),
   )
 
   const checkAnswersController = new CreateContactCheckAnswersController(contactsService)
@@ -51,12 +52,12 @@ const CreateContactRoutes = (auditService: AuditService, contactsService: Contac
     '/check-answers/:journeyId',
     ensureInCreateContactJourney(),
     logPageViewMiddleware(auditService, checkAnswersController),
-    checkAnswersController.GET,
+    asyncMiddleware(checkAnswersController.GET),
   )
-  router.post('/check-answers/:journeyId', ensureInCreateContactJourney(), checkAnswersController.POST)
+  router.post('/check-answers/:journeyId', ensureInCreateContactJourney(), asyncMiddleware(checkAnswersController.POST))
 
   const successController = new SuccessController()
-  router.get('/success', logPageViewMiddleware(auditService, successController), successController.GET)
+  router.get('/success', logPageViewMiddleware(auditService, successController), asyncMiddleware(successController.GET))
 
   return router
 }

--- a/server/routes/contacts/manage/manageContactsRoutes.ts
+++ b/server/routes/contacts/manage/manageContactsRoutes.ts
@@ -9,6 +9,7 @@ import PrisonerSearchResultsController from './prisoner-search/prisonerSearchRes
 import { prisonerSearchSchemaFactory } from './prisoner-search/prisonerSearchSchema'
 import ListContactsController from './list/listContactsController'
 import { ContactsService, PrisonerSearchService } from '../../../services'
+import asyncMiddleware from '../../../middleware/asyncMiddleware'
 
 const ManageContactsRoutes = (
   auditService: AuditService,
@@ -19,7 +20,7 @@ const ManageContactsRoutes = (
 
   // Part 1: Start manage contacts
   const startController = new StartManageContactsJourneyController()
-  router.get('/start', logPageViewMiddleware(auditService, startController), startController.GET)
+  router.get('/start', logPageViewMiddleware(auditService, startController), asyncMiddleware(startController.GET))
 
   // Part 2: Prisoner search
   const prisonerSearchController = new PrisonerSearchController()
@@ -27,13 +28,13 @@ const ManageContactsRoutes = (
     '/prisoner-search/:journeyId',
     ensureInManageContactsJourney(),
     logPageViewMiddleware(auditService, prisonerSearchController),
-    prisonerSearchController.GET,
+    asyncMiddleware(prisonerSearchController.GET),
   )
   router.post(
     '/prisoner-search/:journeyId',
     ensureInManageContactsJourney(),
     validate(prisonerSearchSchemaFactory()),
-    prisonerSearchController.POST,
+    asyncMiddleware(prisonerSearchController.POST),
   )
 
   // Part 3: Prisoner search results
@@ -42,7 +43,7 @@ const ManageContactsRoutes = (
     '/prisoner-search-results/:journeyId',
     ensureInManageContactsJourney(),
     logPageViewMiddleware(auditService, prisonerSearchResultsController),
-    prisonerSearchResultsController.GET,
+    asyncMiddleware(prisonerSearchResultsController.GET),
   )
 
   // Part 4: List contacts for a prisoner
@@ -51,7 +52,7 @@ const ManageContactsRoutes = (
     '/list/:journeyId',
     ensureInManageContactsJourney(),
     logPageViewMiddleware(auditService, listContactsController),
-    listContactsController.GET,
+    asyncMiddleware(listContactsController.GET),
   )
 
   // Part 5: View one contact

--- a/server/routes/home/routes.ts
+++ b/server/routes/home/routes.ts
@@ -2,12 +2,13 @@ import { Router } from 'express'
 import HomeController from './controller'
 import logPageViewMiddleware from '../../middleware/logPageViewMiddleware'
 import AuditService from '../../services/auditService'
+import asyncMiddleware from '../../middleware/asyncMiddleware'
 
 const HomeRoutes = (auditService: AuditService): Router => {
   const router = Router({ mergeParams: true })
   const controller = new HomeController()
 
-  router.get('/', logPageViewMiddleware(auditService, controller), controller.GET)
+  router.get('/', logPageViewMiddleware(auditService, controller), asyncMiddleware(controller.GET))
   return router
 }
 

--- a/server/routes/index.ts
+++ b/server/routes/index.ts
@@ -3,6 +3,7 @@ import type { Services } from '../services'
 import ContactsRoutes from './contacts/contactRoutes'
 import HomeRoutes from './home/routes'
 import PrisonerImageRoutes from './prisonerImage/prisonerImageRoutes'
+import asyncMiddleware from '../middleware/asyncMiddleware'
 
 export default function routes({
   auditService,
@@ -16,7 +17,7 @@ export default function routes({
   router.use('/', HomeRoutes(auditService))
 
   // Special route - which gives the mini-profile nunjucks macro access to prisoner images
-  router.get('/prisoner-image/:prisonerNumber', new PrisonerImageRoutes(prisonerImageService).GET)
+  router.get('/prisoner-image/:prisonerNumber', asyncMiddleware(new PrisonerImageRoutes(prisonerImageService).GET))
 
   return router
 }


### PR DESCRIPTION
All controllers that return a promise (which is all of them currently) should be wrapped in asyncMiddleware. This is because if they return an unresolved error in a promise it causes node to crash... This means that any unhandled 400 or 500 from a dependency would result in a crash.