### PR TITLE
PRC-57: Support edit DOB from check answers

### DIFF
--- a/integration_tests/e2e/createContacts.cy.ts
+++ b/integration_tests/e2e/createContacts.cy.ts
@@ -22,7 +22,7 @@ context('Create Contacts', () => {
     const enterDobPage = new EnterContactDateOfBirthPage('Last, First')
     enterDobPage.checkOnPage()
     enterDobPage //
-      .selectIsDobKnown(false)
+      .selectIsKnown('No')
       .clickContinue()
 
     Page.verifyOnPage(CreateContactCheckYourAnswersPage) //
@@ -58,7 +58,7 @@ context('Create Contacts', () => {
     const enterDobPage = new EnterContactDateOfBirthPage('Last, First')
     enterDobPage.checkOnPage()
     enterDobPage //
-      .selectIsDobKnown(true)
+      .selectIsKnown('Yes')
       .enterDay('15')
       .enterMonth('06')
       .enterYear('1982')
@@ -149,7 +149,7 @@ context('Create Contacts', () => {
     enterDobPage //
       .clickContinue()
 
-    enterDobPage.hasFieldInError('isDobKnown', 'Select whether the date of birth is known')
+    enterDobPage.hasFieldInError('isKnown', 'Select whether the date of birth is known')
   })
 
   it('Must enter dob if it is known', () => {
@@ -163,7 +163,7 @@ context('Create Contacts', () => {
     const enterDobPage = new EnterContactDateOfBirthPage('Last, First')
     enterDobPage.checkOnPage()
     enterDobPage //
-      .selectIsDobKnown(true)
+      .selectIsKnown('Yes')
       .clickContinue()
 
     enterDobPage.errorSummaryItems.spread((...$lis) => {
@@ -185,7 +185,7 @@ context('Create Contacts', () => {
     const enterDobPage = new EnterContactDateOfBirthPage('Last, First')
     enterDobPage.checkOnPage()
     enterDobPage //
-      .selectIsDobKnown(true)
+      .selectIsKnown('Yes')
       .enterDay('aa')
       .enterMonth('bb')
       .enterYear('cc')

--- a/integration_tests/e2e/createContactsCheckAnswersChange.cy.ts
+++ b/integration_tests/e2e/createContactsCheckAnswersChange.cy.ts
@@ -8,12 +8,12 @@ context('Create contact and update from check answers', () => {
   beforeEach(() => {
     cy.task('reset')
     cy.task('stubSignIn', { roles: ['PRISON'] })
-  })
-
-  it('Can change a contacts names when creating a new contact', () => {
     cy.signIn()
     cy.visit('/contacts/create/start')
     cy.task('stubCreateContact', { id: 132456 })
+  })
+
+  it('Can change a contacts names when creating a new contact', () => {
     Page.verifyOnPage(EnterNamePage) //
       .selectTitle('MR')
       .enterLastName('Last')
@@ -24,7 +24,7 @@ context('Create contact and update from check answers', () => {
     const enterDobPage = new EnterContactDateOfBirthPage('Last, First')
     enterDobPage.checkOnPage()
     enterDobPage //
-      .selectIsDobKnown(true)
+      .selectIsKnown('Yes')
       .enterDay('15')
       .enterMonth('06')
       .enterYear('1982')
@@ -58,6 +58,144 @@ context('Create contact and update from check answers', () => {
         lastName: 'Last Updated',
         firstName: 'First Updated',
         middleName: 'Middle Updated',
+        createdBy: 'USER1',
+        dateOfBirth: '1982-06-15T00:00:00.000Z',
+      },
+    )
+  })
+
+  it('Can change a contacts dob from known to a different known dob', () => {
+    Page.verifyOnPage(EnterNamePage) //
+      .enterLastName('Last')
+      .enterFirstName('First')
+      .clickContinue()
+
+    const enterDobPage = new EnterContactDateOfBirthPage('Last, First')
+    enterDobPage.checkOnPage()
+    enterDobPage //
+      .selectIsKnown('Yes')
+      .enterDay('15')
+      .enterMonth('06')
+      .enterYear('1982')
+      .clickContinue()
+
+    Page.verifyOnPage(CreateContactCheckYourAnswersPage) //
+      .verifyShowsNameAs('Last, First')
+      .verifyShowsDateOfBirthAs('15 June 1982')
+      .clickChangeDateOfBirthLink()
+
+    const revisitedDobPage = new EnterContactDateOfBirthPage('Last, First')
+    revisitedDobPage.checkOnPage()
+    revisitedDobPage //
+      .enterDay('16')
+      .enterMonth('07')
+      .enterYear('1983')
+      .clickContinue()
+
+    Page.verifyOnPage(CreateContactCheckYourAnswersPage) //
+      .verifyShowsNameAs('Last, First')
+      .verifyShowsDateOfBirthAs('16 July 1983')
+      .clickCreatePrisonerContact()
+
+    Page.verifyOnPage(CreatedContactPage)
+    cy.verifyLastAPICall(
+      {
+        method: 'POST',
+        urlPath: '/contact',
+      },
+      {
+        lastName: 'Last',
+        firstName: 'First',
+        createdBy: 'USER1',
+        dateOfBirth: '1983-07-16T00:00:00.000Z',
+      },
+    )
+  })
+
+  it('Can change a contacts dob from known to unknown', () => {
+    Page.verifyOnPage(EnterNamePage) //
+      .enterLastName('Last')
+      .enterFirstName('First')
+      .clickContinue()
+
+    const enterDobPage = new EnterContactDateOfBirthPage('Last, First')
+    enterDobPage.checkOnPage()
+    enterDobPage //
+      .selectIsKnown('Yes')
+      .enterDay('15')
+      .enterMonth('06')
+      .enterYear('1982')
+      .clickContinue()
+
+    Page.verifyOnPage(CreateContactCheckYourAnswersPage) //
+      .verifyShowsNameAs('Last, First')
+      .verifyShowsDateOfBirthAs('15 June 1982')
+      .clickChangeDateOfBirthLink()
+
+    const revisitedDobPage = new EnterContactDateOfBirthPage('Last, First')
+    revisitedDobPage.checkOnPage()
+    revisitedDobPage //
+      .selectIsKnown('No')
+      .clickContinue()
+
+    Page.verifyOnPage(CreateContactCheckYourAnswersPage) //
+      .verifyShowsNameAs('Last, First')
+      .verifyShowsDateOfBirthAs('Not provided')
+      .clickCreatePrisonerContact()
+
+    Page.verifyOnPage(CreatedContactPage)
+    cy.verifyLastAPICall(
+      {
+        method: 'POST',
+        urlPath: '/contact',
+      },
+      {
+        lastName: 'Last',
+        firstName: 'First',
+        createdBy: 'USER1',
+      },
+    )
+  })
+  it('Can change a contacts dob from known to unknown', () => {
+    Page.verifyOnPage(EnterNamePage) //
+      .enterLastName('Last')
+      .enterFirstName('First')
+      .clickContinue()
+
+    const enterDobPage = new EnterContactDateOfBirthPage('Last, First')
+    enterDobPage.checkOnPage()
+    enterDobPage //
+      .selectIsKnown('No')
+      .clickContinue()
+
+    Page.verifyOnPage(CreateContactCheckYourAnswersPage) //
+      .verifyShowsNameAs('Last, First')
+      .verifyShowsDateOfBirthAs('Not provided')
+      .clickChangeDateOfBirthLink()
+
+    const revisitedDobPage = new EnterContactDateOfBirthPage('Last, First')
+    revisitedDobPage.checkOnPage()
+    revisitedDobPage //
+      .selectIsKnown('Yes')
+      .enterDay('15')
+      .enterMonth('06')
+      .enterYear('1982')
+      .clickContinue()
+
+    Page.verifyOnPage(CreateContactCheckYourAnswersPage) //
+      .verifyShowsNameAs('Last, First')
+      .verifyShowsDateOfBirthAs('15 June 1982')
+      .clickCreatePrisonerContact()
+
+    Page.verifyOnPage(CreatedContactPage)
+    cy.verifyLastAPICall(
+      {
+        method: 'POST',
+        urlPath: '/contact',
+      },
+      {
+        lastName: 'Last',
+        firstName: 'First',
         createdBy: 'USER1',
         dateOfBirth: '1982-06-15T00:00:00.000Z',
       },

--- a/integration_tests/pages/createContactCheckYourAnswersPage.ts
+++ b/integration_tests/pages/createContactCheckYourAnswersPage.ts
@@ -13,6 +13,10 @@ export default class CreateContactCheckYourAnswersPage extends Page {
     this.changeNameLink().click()
   }
 
+  clickChangeDateOfBirthLink() {
+    this.changeDateOfBirthLink().click()
+  }
+
   verifyShowsNameAs(expected: string): CreateContactCheckYourAnswersPage {
     this.checkAnswersNameValue().should('contain.text', expected)
     return this
@@ -30,4 +34,6 @@ export default class CreateContactCheckYourAnswersPage extends Page {
   private checkAnswersDobValue = (): PageElement => cy.get('.check-answers-dob-value')
 
   private changeNameLink = (): PageElement => cy.get('[data-qa=change-name-link]')
+
+  private changeDateOfBirthLink = (): PageElement => cy.get('[data-qa=change-dob-link]')
 }

--- a/integration_tests/pages/enterContactDateOfBirthPage.ts
+++ b/integration_tests/pages/enterContactDateOfBirthPage.ts
@@ -5,23 +5,23 @@ export default class EnterContactDateOfBirthPage extends Page {
     super(`Do you know ${name}'s date of birth?`)
   }
 
-  selectIsDobKnown(value: boolean): EnterContactDateOfBirthPage {
+  selectIsKnown(value: 'Yes' | 'No'): EnterContactDateOfBirthPage {
     this.radio(value).click()
     return this
   }
 
   enterDay(day: string): EnterContactDateOfBirthPage {
-    this.dayTextBox().type(day)
+    this.dayTextBox().clear().type(day)
     return this
   }
 
   enterMonth(month: string): EnterContactDateOfBirthPage {
-    this.monthTextBox().type(month)
+    this.monthTextBox().clear().type(month)
     return this
   }
 
   enterYear(year: string): EnterContactDateOfBirthPage {
-    this.yearTextBox().type(year)
+    this.yearTextBox().clear().type(year)
     return this
   }
 
@@ -31,7 +31,7 @@ export default class EnterContactDateOfBirthPage extends Page {
 
   private continueButton = (): PageElement => cy.get('[data-qa=continue-button]')
 
-  private radio = (value: boolean): PageElement => cy.get(`.govuk-radios__input[value='${value}']`)
+  private radio = (value: 'Yes' | 'No'): PageElement => cy.get(`.govuk-radios__input[value='${value}']`)
 
   private dayTextBox = (): PageElement => cy.get('#day')
 

--- a/server/@types/journeys/index.d.ts
+++ b/server/@types/journeys/index.d.ts
@@ -15,8 +15,10 @@ declare namespace journeys {
   }
 
   export interface DateOfBirth {
-    isKnown: boolean
-    dateOfBirth?: Date
+    isKnown: 'Yes' | 'No'
+    day?: number
+    month?: number
+    year?: number
   }
 
   export interface ManageContactsJourney {

--- a/server/routes/contacts/create/check-answers/createContactCheckAnswersController.ts
+++ b/server/routes/contacts/create/check-answers/createContactCheckAnswersController.ts
@@ -12,7 +12,16 @@ export default class CreateContactCheckAnswersController implements PageHandler 
     const { journeyId } = req.params
     const journey = req.session.createContactJourneys[journeyId]
     journey.isCheckingAnswers = true
-    res.render('pages/contacts/create/checkAnswers', { journey })
+    let dateOfBirth
+    if (journey.dateOfBirth.isKnown === 'Yes') {
+      dateOfBirth = new Date(`${journey.dateOfBirth.year}-${journey.dateOfBirth.month}-${journey.dateOfBirth.day}Z`)
+    }
+
+    const view = {
+      journey,
+      dateOfBirth,
+    }
+    res.render('pages/contacts/create/checkAnswers', view)
   }
 
   POST = async (req: Request<{ journeyId: string }, unknown, unknown>, res: Response): Promise<void> => {

--- a/server/routes/contacts/create/enter-dob/createContactEnterDobController.test.ts
+++ b/server/routes/contacts/create/enter-dob/createContactEnterDobController.test.ts
@@ -2,7 +2,8 @@ import type { Express } from 'express'
 import request from 'supertest'
 import { SessionData } from 'express-session'
 import { v4 as uuidv4 } from 'uuid'
-import { appWithAllRoutes, user } from '../../../testutils/appSetup'
+import * as cheerio from 'cheerio'
+import { appWithAllRoutes, flashProvider, user } from '../../../testutils/appSetup'
 import AuditService, { Page } from '../../../../services/auditService'
 import CreateContactJourney = journeys.CreateContactJourney
 
@@ -13,17 +14,18 @@ const auditService = new AuditService(null) as jest.Mocked<AuditService>
 let app: Express
 let session: Partial<SessionData>
 const journeyId: string = uuidv4()
-const baseJourney: CreateContactJourney = {
-  id: journeyId,
-  lastTouched: new Date(),
-  isCheckingAnswers: false,
-  names: {
-    lastName: 'last',
-    firstName: 'first',
-  },
-}
+let existingJourney: CreateContactJourney
 
 beforeEach(() => {
+  existingJourney = {
+    id: journeyId,
+    lastTouched: new Date(),
+    isCheckingAnswers: false,
+    names: {
+      lastName: 'last',
+      firstName: 'first',
+    },
+  }
   app = appWithAllRoutes({
     services: {
       auditService,
@@ -32,7 +34,7 @@ beforeEach(() => {
     sessionReceiver: (receivedSession: Partial<SessionData>) => {
       session = receivedSession
       session.createContactJourneys = {}
-      session.createContactJourneys[journeyId] = { ...baseJourney }
+      session.createContactJourneys[journeyId] = { ...existingJourney }
     },
   })
 })
@@ -58,6 +60,96 @@ describe('GET /contacts/create/enter-dob/:journeyId', () => {
       correlationId: expect.any(String),
     })
   })
+
+  it('should render previously entered details if validation errors', async () => {
+    // Given
+    const form = { isKnown: 'Yes', day: '01', month: '06', year: '1982' }
+    auditService.logPageView.mockResolvedValue(null)
+    flashProvider.mockImplementation(key => (key === 'formResponses' ? [JSON.stringify(form)] : []))
+
+    // When
+    const response = await request(app).get(`/contacts/create/enter-dob/${journeyId}`)
+
+    // Then
+    expect(response.status).toEqual(200)
+    const $ = cheerio.load(response.text)
+    expect($('#day').val()).toStrictEqual('01')
+    expect($('#month').val()).toStrictEqual('06')
+    expect($('#year').val()).toStrictEqual('1982')
+    expect($('input[type=radio]:checked').val()).toStrictEqual('Yes')
+  })
+
+  it('should render previously entered details if validation errors with unknown dob', async () => {
+    // Given
+    const form = { isKnown: 'No' }
+    auditService.logPageView.mockResolvedValue(null)
+    flashProvider.mockImplementation(key => (key === 'formResponses' ? [JSON.stringify(form)] : []))
+
+    // When
+    const response = await request(app).get(`/contacts/create/enter-dob/${journeyId}`)
+
+    // Then
+    expect(response.status).toEqual(200)
+    const $ = cheerio.load(response.text)
+    expect($('#day').val()).toBeUndefined()
+    expect($('#month').val()).toBeUndefined()
+    expect($('#year').val()).toBeUndefined()
+    expect($('input[type=radio]:checked').val()).toStrictEqual('No')
+  })
+
+  it('should render previously entered details if no validation errors but there are session values', async () => {
+    // Given
+    auditService.logPageView.mockResolvedValue(null)
+    existingJourney.dateOfBirth = { isKnown: 'Yes', day: 1, month: 6, year: 1982 }
+
+    // When
+    const response = await request(app).get(`/contacts/create/enter-dob/${journeyId}`)
+
+    // Then
+    expect(response.status).toEqual(200)
+    const $ = cheerio.load(response.text)
+    expect($('#day').val()).toStrictEqual('1')
+    expect($('#month').val()).toStrictEqual('6')
+    expect($('#year').val()).toStrictEqual('1982')
+    expect($('input[type=radio]:checked').val()).toStrictEqual('Yes')
+  })
+
+  it('should render previously entered details if no validation errors but there are session values with unknown dob', async () => {
+    // Given
+    auditService.logPageView.mockResolvedValue(null)
+    existingJourney.dateOfBirth = { isKnown: 'No' }
+
+    // When
+    const response = await request(app).get(`/contacts/create/enter-dob/${journeyId}`)
+
+    // Then
+    expect(response.status).toEqual(200)
+    const $ = cheerio.load(response.text)
+    expect($('#day').val()).toBeUndefined()
+    expect($('#month').val()).toBeUndefined()
+    expect($('#year').val()).toBeUndefined()
+    expect($('input[type=radio]:checked').val()).toStrictEqual('No')
+  })
+
+  it('should render submitted options on validation error even if there is a version in the session', async () => {
+    // Given
+    auditService.logPageView.mockResolvedValue(null)
+    existingJourney.dateOfBirth = { isKnown: 'Yes', day: 1, month: 6, year: 1982 }
+    const form = { isKnown: 'No' }
+    flashProvider.mockImplementation(key => (key === 'formResponses' ? [JSON.stringify(form)] : []))
+
+    // When
+    const response = await request(app).get(`/contacts/create/enter-dob/${journeyId}`)
+
+    // Then
+    expect(response.status).toEqual(200)
+    const $ = cheerio.load(response.text)
+    expect($('#day').val()).toStrictEqual('1')
+    expect($('#month').val()).toStrictEqual('6')
+    expect($('#year').val()).toStrictEqual('1982')
+    expect($('input[type=radio]:checked').val()).toStrictEqual('No')
+  })
+
   it('should return to start if no journey in session', async () => {
     await request(app)
       .get(`/contacts/create/enter-dob/${uuidv4()}`)
@@ -71,31 +163,33 @@ describe('POST /contacts/create/enter-name', () => {
     await request(app)
       .post(`/contacts/create/enter-dob/${journeyId}`)
       .type('form')
-      .send({ isDobKnown: 'false' })
+      .send({ isKnown: 'false' })
       .expect(302)
       .expect('Location', `/contacts/create/check-answers/${journeyId}`)
 
-    const expectedDob = { isKnown: false }
+    const expectedDob = { isKnown: 'No' }
     expect(session.createContactJourneys[journeyId].dateOfBirth).toStrictEqual(expectedDob)
   })
 
   it.each([
-    ['01', '06', '1982', new Date('1982-06-01T00:00:00.000Z')],
-    ['1', '6', '1982', new Date('1982-06-01T00:00:00.000Z')],
+    ['01', '06', '1982'],
+    ['1', '6', '1982'],
   ])(
-    'should pass to success page if there are no validation errors and we created the contact with a dob',
-    async (day, month, year, expected) => {
+    'should pass to check answers page if there are no validation errors with the date parsable',
+    async (day, month, year) => {
       await request(app)
         .post(`/contacts/create/enter-dob/${journeyId}`)
         .type('form')
-        .send({ isDobKnown: 'true', day, month, year })
+        .send({ isKnown: 'Yes', day, month, year })
         .expect(302)
         .expect('Location', `/contacts/create/check-answers/${journeyId}`)
 
       // Then
       const expectedDob = {
-        isKnown: true,
-        dateOfBirth: expected,
+        isKnown: 'Yes',
+        day: 1,
+        month: 6,
+        year: 1982,
       }
       expect(session.createContactJourneys[journeyId].dateOfBirth).toStrictEqual(expectedDob)
     },
@@ -109,6 +203,7 @@ describe('POST /contacts/create/enter-name', () => {
       .expect(302)
       .expect('Location', `/contacts/create/enter-dob/${journeyId}`)
   })
+
   it('should return to start if no journey in session', async () => {
     await request(app)
       .post(`/contacts/create/enter-dob/${uuidv4()}`)

--- a/server/routes/contacts/create/enter-dob/createContactEnterDobController.ts
+++ b/server/routes/contacts/create/enter-dob/createContactEnterDobController.ts
@@ -9,7 +9,14 @@ export default class CreateContactEnterDobController implements PageHandler {
   GET = async (req: Request, res: Response): Promise<void> => {
     const { journeyId } = req.params
     const journey = req.session.createContactJourneys[journeyId]
-    res.render('pages/contacts/create/enterDob', { journey })
+    const view = {
+      journey,
+      isKnown: res.locals?.formResponses?.isKnown ?? journey?.dateOfBirth?.isKnown,
+      day: res.locals?.formResponses?.day ?? journey?.dateOfBirth?.day,
+      month: res.locals?.formResponses?.month ?? journey?.dateOfBirth?.month,
+      year: res.locals?.formResponses?.year ?? journey?.dateOfBirth?.year,
+    }
+    res.render('pages/contacts/create/enterDob', view)
   }
 
   POST = async (
@@ -19,14 +26,16 @@ export default class CreateContactEnterDobController implements PageHandler {
     const { journeyId } = req.params
     const journey = req.session.createContactJourneys[journeyId]
     const { body } = req
-    if (body.isDobKnown) {
+    if (body.isKnown === 'Yes') {
       journey.dateOfBirth = {
-        isKnown: body.isDobKnown,
-        dateOfBirth: body.dateOfBirth,
+        isKnown: 'Yes',
+        day: body.day,
+        month: body.month,
+        year: body.year,
       }
     } else {
       journey.dateOfBirth = {
-        isKnown: body.isDobKnown,
+        isKnown: 'No',
       }
     }
     res.redirect(`/contacts/create/check-answers/${journeyId}`)

--- a/server/routes/contacts/create/enter-dob/createContactEnterDobSchemas.test.ts
+++ b/server/routes/contacts/create/enter-dob/createContactEnterDobSchemas.test.ts
@@ -3,13 +3,13 @@ import { createContactEnterDobSchema } from './createContactEnterDobSchemas'
 
 describe('createContactEnterDobSchema', () => {
   type Form = {
-    isDobKnown?: string
+    isKnown?: string
     day?: string
     month?: string
     year?: string
   }
   describe('should validate the enter dob form', () => {
-    it('should require isDobKnown', async () => {
+    it('should require isKnown', async () => {
       // Given
       const form = {}
 
@@ -19,37 +19,38 @@ describe('createContactEnterDobSchema', () => {
       // Then
       expect(result.success).toStrictEqual(false)
       const deduplicatedFieldErrors = deduplicateFieldErrors(result)
-      expect(deduplicatedFieldErrors).toStrictEqual({ isDobKnown: ['Select whether the date of birth is known'] })
+      expect(deduplicatedFieldErrors).toStrictEqual({ isKnown: ['Select whether the date of birth is known'] })
     })
     it.each([
-      ['true', true],
-      ['false', false],
-    ])('should map true or false to boolean for isDobKnown (%s, %s)', async (isDobKnown: string, expected: boolean) => {
+      ['Yes', 'Yes'],
+      ['No', 'No'],
+    ])('should map Yes or No for isKnown (%s, %s)', async (isKnown: string, expected: string) => {
       // Given
-      const form = { isDobKnown, day: '1', month: '1', year: '1900' }
+      const form = { isKnown, day: '1', month: '1', year: '1900' }
 
       // When
       const result = await doValidate(form)
 
       // Then
       expect(result.success).toStrictEqual(true)
-      expect(result.data.isDobKnown).toStrictEqual(expected)
+      expect(result.data.isKnown).toStrictEqual(expected)
     })
+
     it('if dob is not known then do not require day, month and year', async () => {
       // Given
-      const form = { isDobKnown: 'false' }
+      const form = { isKnown: 'No' }
 
       // When
       const result = await doValidate(form)
 
       // Then
       expect(result.success).toStrictEqual(true)
-      expect(result.data).toStrictEqual({ isDobKnown: false })
+      expect(result.data).toStrictEqual({ isKnown: 'No' })
     })
 
     it('if dob is known then require day, month and year', async () => {
       // Given
-      const form = { isDobKnown: 'true' }
+      const form = { isKnown: 'Yes' }
 
       // When
       const result = await doValidate(form)
@@ -65,7 +66,7 @@ describe('createContactEnterDobSchema', () => {
     })
     it('if dob is known then require day, month and year not be empty', async () => {
       // Given
-      const form = { isDobKnown: 'true', day: '', month: '', year: '' }
+      const form = { isKnown: 'Yes', day: '', month: '', year: '' }
 
       // When
       const result = await doValidate(form)
@@ -79,9 +80,10 @@ describe('createContactEnterDobSchema', () => {
         year: ['Enter a valid year. Must be at least 1900'],
       })
     })
+
     it('if dob is known then require day, month and year be numbers', async () => {
       // Given
-      const form = { isDobKnown: 'true', day: 'd', month: 'm', year: 'y' }
+      const form = { isKnown: 'Yes', day: 'd', month: 'm', year: 'y' }
 
       // When
       const result = await doValidate(form)
@@ -95,6 +97,7 @@ describe('createContactEnterDobSchema', () => {
         year: ['Enter a valid year. Must be at least 1900'],
       })
     })
+
     it.each([
       ['0', false],
       ['-1', false],
@@ -103,7 +106,7 @@ describe('createContactEnterDobSchema', () => {
       ['31', true],
     ])('if dob is known then day must be in range of 1-31 (%s, %s)', async (day: string, isValid: boolean) => {
       // Given
-      const form = { isDobKnown: 'true', day, month: '1', year: '1999' }
+      const form = { isKnown: 'Yes', day, month: '1', year: '1999' }
 
       // When
       const result = await doValidate(form)
@@ -117,6 +120,7 @@ describe('createContactEnterDobSchema', () => {
         })
       }
     })
+
     it.each([
       ['0', false],
       ['-1', false],
@@ -125,7 +129,7 @@ describe('createContactEnterDobSchema', () => {
       ['12', true],
     ])('if dob is known then month must be in range of 1-12 (%s, %s)', async (month: string, isValid: boolean) => {
       // Given
-      const form = { isDobKnown: 'true', day: '1', month, year: '1999' }
+      const form = { isKnown: 'Yes', day: '1', month, year: '1999' }
 
       // When
       const result = await doValidate(form)
@@ -139,6 +143,7 @@ describe('createContactEnterDobSchema', () => {
         })
       }
     })
+
     it.each([
       ['0', false],
       ['-1', false],
@@ -146,7 +151,7 @@ describe('createContactEnterDobSchema', () => {
       ['1900', true],
     ])('if dob is known then year must be at least 1900 (%s, %s)', async (year: string, isValid: boolean) => {
       // Given
-      const form = { isDobKnown: 'true', day: '1', month: '1', year }
+      const form = { isKnown: 'Yes', day: '1', month: '1', year }
 
       // When
       const result = await doValidate(form)
@@ -160,9 +165,10 @@ describe('createContactEnterDobSchema', () => {
         })
       }
     })
+
     it('dob must not be in the future', async () => {
       // Given
-      const form = { isDobKnown: 'true', day: '1', month: '1', year: '2045' }
+      const form = { isKnown: 'Yes', day: '1', month: '1', year: '2045' }
 
       // When
       const result = await doValidate(form)
@@ -171,15 +177,15 @@ describe('createContactEnterDobSchema', () => {
       expect(result.success).toStrictEqual(false)
       const deduplicatedFieldErrors = deduplicateFieldErrors(result)
       expect(deduplicatedFieldErrors).toStrictEqual({
-        isDobKnown: ['The date of birth must not be in the future'],
+        isKnown: ['The date of birth must not be in the future'],
       })
     })
     it.each([
-      ['01', '06', '1982', new Date('1982-06-01T00:00:00.000Z')],
-      ['1', '6', '1982', new Date('1982-06-01T00:00:00.000Z')],
-    ])('dob should parse to a date correctly', async (day: string, month: string, year: string, expected: Date) => {
+      ['01', '06', '1982'],
+      ['1', '6', '1982'],
+    ])('dob should parse to a date correctly', async (day: string, month: string, year: string) => {
       // Given
-      const form = { isDobKnown: 'true', day, month, year }
+      const form = { isKnown: 'Yes', day, month, year }
 
       // When
       const result = await doValidate(form)
@@ -187,13 +193,15 @@ describe('createContactEnterDobSchema', () => {
       // Then
       expect(result.success).toStrictEqual(true)
       expect(result.data).toStrictEqual({
-        isDobKnown: true,
-        dateOfBirth: expected,
+        isKnown: 'Yes',
+        day: 1,
+        month: 6,
+        year: 1982,
       })
     })
     it('should not map dob if not known as we can select yes and enter day, month and year and then change to no so they may be populated in the form', async () => {
       // Given
-      const form = { isDobKnown: 'false', day: '1', month: '1', year: '1900' }
+      const form = { isKnown: 'No', day: '1', month: '1', year: '1900' }
 
       // When
       const result = await doValidate(form)
@@ -201,12 +209,13 @@ describe('createContactEnterDobSchema', () => {
       // Then
       expect(result.success).toStrictEqual(true)
       expect(result.data).toStrictEqual({
-        isDobKnown: false,
+        isKnown: 'No',
       })
     })
+
     it('should handle empty/invalid dob fields if dob is not known', async () => {
       // Given
-      const form = { isDobKnown: 'false', day: '', month: '', year: '' }
+      const form = { isKnown: 'No', day: '', month: '', year: '' }
 
       // When
       const result = await doValidate(form)
@@ -214,9 +223,10 @@ describe('createContactEnterDobSchema', () => {
       // Then
       expect(result.success).toStrictEqual(true)
       expect(result.data).toStrictEqual({
-        isDobKnown: false,
+        isKnown: 'No',
       })
     })
+
     const doValidate = async (form: Form) => {
       const schema = await createContactEnterDobSchema()()
       return schema.safeParse(form)

--- a/server/services/contactsService.test.ts
+++ b/server/services/contactsService.test.ts
@@ -38,8 +38,10 @@ describe('contactsService', () => {
           middleName: 'middle',
         },
         dateOfBirth: {
-          isKnown: true,
-          dateOfBirth: new Date('1982-06-01T00:00:00.000Z'),
+          isKnown: 'Yes',
+          day: 1,
+          month: 6,
+          year: 1982,
         },
       }
       const expectedRequest: CreateContactRequest = {
@@ -73,7 +75,7 @@ describe('contactsService', () => {
           firstName: 'first',
         },
         dateOfBirth: {
-          isKnown: false,
+          isKnown: 'No',
         },
       }
       const expectedRequest: CreateContactRequest = {
@@ -101,7 +103,7 @@ describe('contactsService', () => {
             lastTouched: new Date(),
             isCheckingAnswers: false,
             names: { firstName: 'first', lastName: 'last' },
-            dateOfBirth: { isKnown: false },
+            dateOfBirth: { isKnown: 'No' },
           },
           user,
         ),

--- a/server/services/contactsService.ts
+++ b/server/services/contactsService.ts
@@ -8,12 +8,16 @@ export default class ContactsService {
   constructor(private readonly contactsApiClient: ContactsApiClient) {}
 
   async createContact(journey: CreateContactJourney, user: Express.User): Promise<Contact> {
+    let dateOfBirth: Date
+    if (journey.dateOfBirth.isKnown === 'Yes') {
+      dateOfBirth = new Date(`${journey.dateOfBirth.year}-${journey.dateOfBirth.month}-${journey.dateOfBirth.day}Z`)
+    }
     const request: CreateContactRequest = {
       title: journey.names.title,
       lastName: journey.names.lastName,
       firstName: journey.names.firstName,
       middleName: journey.names.middleName,
-      dateOfBirth: journey.dateOfBirth.dateOfBirth,
+      dateOfBirth,
       createdBy: user.username,
     }
     return this.contactsApiClient.createContact(request, user)

--- a/server/views/pages/contacts/create/checkAnswers.njk
+++ b/server/views/pages/contacts/create/checkAnswers.njk
@@ -31,7 +31,7 @@
         <div class="govuk-grid-column-three-quarters">
             <form method='POST'>
                 <input type="hidden" name="_csrf" value="{{ csrfToken }}" />
-                {%set  formattedDateOfBirth %}{% if journey.dateOfBirth.isKnown %}{{ journey.dateOfBirth.dateOfBirth | formatDate }}{% else %}Not provided{% endif %}{% endset %}
+                {%set  formattedDateOfBirth %}{% if journey.dateOfBirth.isKnown === 'Yes' %}{{ dateOfBirth | formatDate }}{% else %}Not provided{% endif %}{% endset %}
                 {{ govukSummaryList({
                     card: {
                         title: {

--- a/server/views/pages/contacts/create/enterDob.njk
+++ b/server/views/pages/contacts/create/enterDob.njk
@@ -50,44 +50,44 @@
                                 label: 'Day',
                                 name: "day",
                                 classes: 'govuk-input--width-2',
-                                value: formResponses.day
+                                value: day
                             },
                             {
                                 id: 'month',
                                 label: 'Month',
                                 name: "month",
                                 classes: 'govuk-input--width-2',
-                                value: formResponses.month
+                                value: month
                             },
                             {
                                 id: 'year',
                                 label: 'Year',
                                 name: "year",
                                 classes: 'govuk-input--width-4',
-                                value: formResponses.year
+                                value: year
                             }
                         ]
                     }) }}
 
                 {% endset %}
                 {{ govukRadios({
-                    name: "isDobKnown",
+                    name: "isKnown",
                     items: [
                         {
-                            value: true,
+                            value: 'Yes',
                             text: "Yes",
-                            checked: formResponses.isDobKnown === 'true',
+                            checked: isKnown === 'Yes',
                             conditional: {
                                 html: dobHtml
                             }
                         },
                         {
-                            value: false,
+                            value: 'No',
                             text: "No",
-                            checked: formResponses.isDobKnown === 'false'
+                            checked: isKnown === 'No'
                         }
                     ],
-                    errorMessage: validationErrors | findError('isDobKnown')
+                    errorMessage: validationErrors | findError('isKnown')
                 }) }}
 
                 <div class="govuk-button-group">


### PR DESCRIPTION
Discovered several issues with the old data model. For one `Date` is converted back to string when it's persisted in the session. No idea how this worked so well up until now but if you need to parse it back it's a string. Instead, keep the originally entered day, month and year fields to construct a `Date` as needed.

Also, javascript was doing javascript things with the values for the isDobKnown field being true and false. Converted them to be `'Yes' | 'No'` type instead which matches the actual answers.