### PR TITLE
PRC-57: Change lastTouched to be a date string in session

### DIFF
--- a/server/@types/journeys/index.d.ts
+++ b/server/@types/journeys/index.d.ts
@@ -1,7 +1,7 @@
 declare namespace journeys {
   export interface CreateContactJourney {
     id: string
-    lastTouched: Date
+    lastTouched: string
     isCheckingAnswers: boolean
     names?: ContactNames
     dateOfBirth?: DateOfBirth
@@ -23,7 +23,7 @@ declare namespace journeys {
 
   export interface ManageContactsJourney {
     id: string
-    lastTouched: Date
+    lastTouched: string
     search?: {
       searchTerm?: string
     }

--- a/server/routes/contacts/create/check-answers/createContactCheckAnswersController.test.ts
+++ b/server/routes/contacts/create/check-answers/createContactCheckAnswersController.test.ts
@@ -21,7 +21,7 @@ let journey: CreateContactJourney
 beforeEach(() => {
   journey = {
     id: journeyId,
-    lastTouched: new Date(),
+    lastTouched: new Date().toISOString(),
     isCheckingAnswers: false,
     names: {
       lastName: 'last',

--- a/server/routes/contacts/create/createContactMiddleware.test.ts
+++ b/server/routes/contacts/create/createContactMiddleware.test.ts
@@ -22,12 +22,12 @@ describe('createContactMiddleware', () => {
       req.session.createContactJourneys = {}
       req.session.createContactJourneys[journeyId] = {
         id: journeyId,
-        lastTouched: lastTouchedBeforeCall,
+        lastTouched: lastTouchedBeforeCall.toISOString(),
         isCheckingAnswers: false,
       }
       ensureInCreateContactJourney()(req, res, next)
       expect(next).toHaveBeenCalledTimes(1)
-      expect(req.session.createContactJourneys[journeyId].lastTouched.getTime()).toBeGreaterThan(
+      expect(new Date(req.session.createContactJourneys[journeyId].lastTouched).getTime()).toBeGreaterThan(
         lastTouchedBeforeCall.getTime(),
       )
     })

--- a/server/routes/contacts/create/createContactMiddleware.ts
+++ b/server/routes/contacts/create/createContactMiddleware.ts
@@ -9,7 +9,7 @@ const ensureInCreateContactJourney = (): RequestHandler => {
     if (!req.session.createContactJourneys[journeyId]) {
       return res.redirect('/contacts/create/start')
     }
-    req.session.createContactJourneys[journeyId].lastTouched = new Date()
+    req.session.createContactJourneys[journeyId].lastTouched = new Date().toISOString()
 
     return next()
   }

--- a/server/routes/contacts/create/enter-dob/createContactEnterDobController.test.ts
+++ b/server/routes/contacts/create/enter-dob/createContactEnterDobController.test.ts
@@ -19,7 +19,7 @@ let existingJourney: CreateContactJourney
 beforeEach(() => {
   existingJourney = {
     id: journeyId,
-    lastTouched: new Date(),
+    lastTouched: new Date().toISOString(),
     isCheckingAnswers: false,
     names: {
       lastName: 'last',

--- a/server/routes/contacts/create/enter-name/createContactEnterNameController.test.ts
+++ b/server/routes/contacts/create/enter-name/createContactEnterNameController.test.ts
@@ -19,7 +19,7 @@ let existingJourney: CreateContactJourney
 beforeEach(() => {
   existingJourney = {
     id: journeyId,
-    lastTouched: new Date(),
+    lastTouched: new Date().toISOString(),
     isCheckingAnswers: false,
   }
   app = appWithAllRoutes({

--- a/server/routes/contacts/create/start/startCreateContactJourneyController.test.ts
+++ b/server/routes/contacts/create/start/startCreateContactJourneyController.test.ts
@@ -77,7 +77,7 @@ describe('GET /contacts/create/start', () => {
     preExistingJourneysToAddToSession = [
       {
         id: uuidv4(),
-        lastTouched: new Date(),
+        lastTouched: new Date().toISOString(),
         isCheckingAnswers: false,
         names: {
           lastName: 'foo',
@@ -107,11 +107,11 @@ describe('GET /contacts/create/start', () => {
     // Given
     auditService.logPageView.mockResolvedValue(null)
     preExistingJourneysToAddToSession = [
-      { id: 'old', lastTouched: new Date(2024, 1, 1, 11, 30), isCheckingAnswers: false },
-      { id: 'middle-aged', lastTouched: new Date(2024, 1, 1, 12, 30), isCheckingAnswers: false },
-      { id: 'youngest', lastTouched: new Date(2024, 1, 1, 14, 30), isCheckingAnswers: false },
-      { id: 'oldest', lastTouched: new Date(2024, 1, 1, 10, 30), isCheckingAnswers: false },
-      { id: 'young', lastTouched: new Date(2024, 1, 1, 13, 30), isCheckingAnswers: false },
+      { id: 'old', lastTouched: new Date(2024, 1, 1, 11, 30).toISOString(), isCheckingAnswers: false },
+      { id: 'middle-aged', lastTouched: new Date(2024, 1, 1, 12, 30).toISOString(), isCheckingAnswers: false },
+      { id: 'youngest', lastTouched: new Date(2024, 1, 1, 14, 30).toISOString(), isCheckingAnswers: false },
+      { id: 'oldest', lastTouched: new Date(2024, 1, 1, 10, 30).toISOString(), isCheckingAnswers: false },
+      { id: 'young', lastTouched: new Date(2024, 1, 1, 13, 30).toISOString(), isCheckingAnswers: false },
     ]
 
     // When

--- a/server/routes/contacts/create/start/startCreateContactJourneyController.ts
+++ b/server/routes/contacts/create/start/startCreateContactJourneyController.ts
@@ -10,14 +10,21 @@ export default class StartCreateContactJourneyController implements PageHandler 
   private MAX_JOURNEYS = 5
 
   GET = async (req: Request, res: Response): Promise<void> => {
-    const journey: CreateContactJourney = { id: uuidv4(), lastTouched: new Date(), isCheckingAnswers: false }
+    const journey: CreateContactJourney = {
+      id: uuidv4(),
+      lastTouched: new Date().toISOString(),
+      isCheckingAnswers: false,
+    }
     if (!req.session.createContactJourneys) {
       req.session.createContactJourneys = {}
     }
     req.session.createContactJourneys[journey.id] = journey
     if (Object.entries(req.session.createContactJourneys).length > this.MAX_JOURNEYS) {
       Object.values(req.session.createContactJourneys)
-        .sort((a: CreateContactJourney, b: CreateContactJourney) => b.lastTouched.getTime() - a.lastTouched.getTime())
+        .sort(
+          (a: CreateContactJourney, b: CreateContactJourney) =>
+            new Date(b.lastTouched).getTime() - new Date(a.lastTouched).getTime(),
+        )
         .slice(this.MAX_JOURNEYS)
         .forEach(journeyToRemove => delete req.session.createContactJourneys[journeyToRemove.id])
     }

--- a/server/routes/contacts/manage/list/listContactsController.test.ts
+++ b/server/routes/contacts/manage/list/listContactsController.test.ts
@@ -32,7 +32,7 @@ beforeEach(() => {
       session.manageContactsJourneys = {}
       session.manageContactsJourneys[journeyId] = {
         id: journeyId,
-        lastTouched: new Date(),
+        lastTouched: new Date().toISOString(),
         search: {
           searchTerm: 'A4162DZ',
         },

--- a/server/routes/contacts/manage/manageContactsMiddleware.test.ts
+++ b/server/routes/contacts/manage/manageContactsMiddleware.test.ts
@@ -24,12 +24,15 @@ describe('manageContactsMiddleware', () => {
     it('should proceed if the journey is in the session and update the last touched date', () => {
       const lastTouchedBeforeCall = new Date(2020, 1, 1)
       req.session.manageContactsJourneys = {}
-      req.session.manageContactsJourneys[journeyId] = { id: journeyId, lastTouched: lastTouchedBeforeCall }
+      req.session.manageContactsJourneys[journeyId] = {
+        id: journeyId,
+        lastTouched: lastTouchedBeforeCall.toISOString(),
+      }
 
       ensureInManageContactsJourney()(req, res, next)
 
       expect(next).toHaveBeenCalledTimes(1)
-      expect(req.session.manageContactsJourneys[journeyId].lastTouched.getTime()).toBeGreaterThan(
+      expect(new Date(req.session.manageContactsJourneys[journeyId].lastTouched).getTime()).toBeGreaterThan(
         lastTouchedBeforeCall.getTime(),
       )
     })

--- a/server/routes/contacts/manage/manageContactsMiddleware.ts
+++ b/server/routes/contacts/manage/manageContactsMiddleware.ts
@@ -12,7 +12,7 @@ const ensureInManageContactsJourney = (): RequestHandler => {
       return res.redirect('/contacts/manage/start')
     }
 
-    req.session.manageContactsJourneys[journeyId].lastTouched = new Date()
+    req.session.manageContactsJourneys[journeyId].lastTouched = new Date().toISOString()
     return next()
   }
 }

--- a/server/routes/contacts/manage/prisoner-search/prisonerSearchController.test.ts
+++ b/server/routes/contacts/manage/prisoner-search/prisonerSearchController.test.ts
@@ -25,7 +25,7 @@ beforeEach(() => {
       session.manageContactsJourneys = {}
       session.manageContactsJourneys[journeyId] = {
         id: journeyId,
-        lastTouched: new Date(),
+        lastTouched: new Date().toISOString(),
       }
     },
   })

--- a/server/routes/contacts/manage/prisoner-search/prisonerSearchResultsController.test.ts
+++ b/server/routes/contacts/manage/prisoner-search/prisonerSearchResultsController.test.ts
@@ -31,7 +31,7 @@ beforeEach(() => {
       session.manageContactsJourneys = {}
       session.manageContactsJourneys[journeyId] = {
         id: journeyId,
-        lastTouched: new Date(),
+        lastTouched: new Date().toISOString(),
         search: {
           searchTerm: 'test',
         },

--- a/server/routes/contacts/manage/start/startManageContactsJourneyController.test.ts
+++ b/server/routes/contacts/manage/start/startManageContactsJourneyController.test.ts
@@ -55,7 +55,7 @@ describe('GET /contacts/manage/start', () => {
     preExistingJourneysToAddToSession = [
       {
         id: uuidv4(),
-        lastTouched: new Date(),
+        lastTouched: new Date().toISOString(),
         search: {
           searchTerm: 'hello',
         },
@@ -86,7 +86,7 @@ describe('GET /contacts/manage/start', () => {
     preExistingJourneysToAddToSession = [
       {
         id: uuidv4(),
-        lastTouched: new Date(),
+        lastTouched: new Date().toISOString(),
         search: {
           searchTerm: 'hello',
         },
@@ -107,11 +107,11 @@ describe('GET /contacts/manage/start', () => {
   it('should remove the oldest journey if there will be more than 5 journeys', async () => {
     auditService.logPageView.mockResolvedValue(null)
     preExistingJourneysToAddToSession = [
-      { id: 'old', lastTouched: new Date(2024, 1, 1, 11, 30) },
-      { id: 'middle-aged', lastTouched: new Date(2024, 1, 1, 12, 30) },
-      { id: 'youngest', lastTouched: new Date(2024, 1, 1, 14, 30) },
-      { id: 'oldest', lastTouched: new Date(2024, 1, 1, 10, 30) },
-      { id: 'young', lastTouched: new Date(2024, 1, 1, 13, 30) },
+      { id: 'old', lastTouched: new Date(2024, 1, 1, 11, 30).toISOString() },
+      { id: 'middle-aged', lastTouched: new Date(2024, 1, 1, 12, 30).toISOString() },
+      { id: 'youngest', lastTouched: new Date(2024, 1, 1, 14, 30).toISOString() },
+      { id: 'oldest', lastTouched: new Date(2024, 1, 1, 10, 30).toISOString() },
+      { id: 'young', lastTouched: new Date(2024, 1, 1, 13, 30).toISOString() },
     ]
 
     const response = await request(app).get('/contacts/manage/start')

--- a/server/routes/contacts/manage/start/startManageContactsJourneyController.ts
+++ b/server/routes/contacts/manage/start/startManageContactsJourneyController.ts
@@ -11,7 +11,7 @@ export default class StartManageContactsJourneyController implements PageHandler
 
   GET = async (req: Request, res: Response): Promise<void> => {
     // Create a new journey object for managing contacts
-    const journey: ManageContactsJourney = { id: uuidv4(), lastTouched: new Date() }
+    const journey: ManageContactsJourney = { id: uuidv4(), lastTouched: new Date().toISOString() }
 
     // Create the object for journeys if not present in the session
     if (!req.session.manageContactsJourneys) {
@@ -24,7 +24,10 @@ export default class StartManageContactsJourneyController implements PageHandler
     // Replace the oldest journey if more than MAX_JOURNEYS exist
     if (Object.entries(req.session.manageContactsJourneys).length > this.MAX_JOURNEYS) {
       Object.values(req.session.manageContactsJourneys)
-        .sort((a: ManageContactsJourney, b: ManageContactsJourney) => b.lastTouched.getTime() - a.lastTouched.getTime())
+        .sort(
+          (a: ManageContactsJourney, b: ManageContactsJourney) =>
+            new Date(b.lastTouched).getTime() - new Date(a.lastTouched).getTime(),
+        )
         .slice(this.MAX_JOURNEYS)
         .forEach(journeyToRemove => delete req.session.manageContactsJourneys[journeyToRemove.id])
     }

--- a/server/services/contactsService.test.ts
+++ b/server/services/contactsService.test.ts
@@ -29,7 +29,7 @@ describe('contactsService', () => {
       apiClient.createContact.mockResolvedValue(expectedCreated)
       const journey: CreateContactJourney = {
         id: '1',
-        lastTouched: new Date(),
+        lastTouched: new Date().toISOString(),
         isCheckingAnswers: false,
         names: {
           title: 'Mr',
@@ -68,7 +68,7 @@ describe('contactsService', () => {
       apiClient.createContact.mockResolvedValue(expectedCreated)
       const journey: CreateContactJourney = {
         id: '1',
-        lastTouched: new Date(),
+        lastTouched: new Date().toISOString(),
         isCheckingAnswers: false,
         names: {
           lastName: 'last',
@@ -100,7 +100,7 @@ describe('contactsService', () => {
         service.createContact(
           {
             id: '1',
-            lastTouched: new Date(),
+            lastTouched: new Date().toISOString(),
             isCheckingAnswers: false,
             names: { firstName: 'first', lastName: 'last' },
             dateOfBirth: { isKnown: 'No' },


### PR DESCRIPTION
Dates aren't properly serialised in the session when it's persisted to redis so this can lead to issues when comparing the latest journeys. Converted to a string which is an ISO date instead and then create a Date where required.