### PR TITLE
PRC-55: link manage contacts and create new contact journeys

### DIFF
--- a/integration_tests/e2e/createContactsCheckAnswersChange.cy.ts
+++ b/integration_tests/e2e/createContactsCheckAnswersChange.cy.ts
@@ -9,6 +9,7 @@ context('Create contact and update from check answers', () => {
   beforeEach(() => {
     cy.task('reset')
     cy.task('stubSignIn', { roles: ['PRISON'] })
+    cy.task('stubComponentsMeta')
     cy.signIn()
     cy.visit('/prisoner/A1234BC/contacts/create/start')
     cy.task('stubCreateContact', { id: 132456 })
@@ -61,6 +62,12 @@ context('Create contact and update from check answers', () => {
         middleName: 'Middle Updated',
         createdBy: 'USER1',
         dateOfBirth: '1982-06-15T00:00:00.000Z',
+        relationship: {
+          prisonerNumber: 'A1234BC',
+          relationshipCode: 'FRI',
+          isNextOfKin: false,
+          isEmergencyContact: false,
+        },
       },
     )
   })
@@ -109,6 +116,12 @@ context('Create contact and update from check answers', () => {
         firstName: 'First',
         createdBy: 'USER1',
         dateOfBirth: '1983-07-16T00:00:00.000Z',
+        relationship: {
+          prisonerNumber: 'A1234BC',
+          relationshipCode: 'FRI',
+          isNextOfKin: false,
+          isEmergencyContact: false,
+        },
       },
     )
   })
@@ -161,6 +174,12 @@ context('Create contact and update from check answers', () => {
         firstName: 'First',
         isOverEighteen: 'DO_NOT_KNOW',
         createdBy: 'USER1',
+        relationship: {
+          prisonerNumber: 'A1234BC',
+          relationshipCode: 'FRI',
+          isNextOfKin: false,
+          isEmergencyContact: false,
+        },
       },
     )
   })
@@ -213,6 +232,12 @@ context('Create contact and update from check answers', () => {
         firstName: 'First',
         createdBy: 'USER1',
         dateOfBirth: '1982-06-15T00:00:00.000Z',
+        relationship: {
+          prisonerNumber: 'A1234BC',
+          relationshipCode: 'FRI',
+          isNextOfKin: false,
+          isEmergencyContact: false,
+        },
       },
     )
   })
@@ -263,6 +288,12 @@ context('Create contact and update from check answers', () => {
         firstName: 'First',
         isOverEighteen: 'YES',
         createdBy: 'USER1',
+        relationship: {
+          prisonerNumber: 'A1234BC',
+          relationshipCode: 'FRI',
+          isNextOfKin: false,
+          isEmergencyContact: false,
+        },
       },
     )
   })

--- a/integration_tests/pages/listContacts.ts
+++ b/integration_tests/pages/listContacts.ts
@@ -10,4 +10,10 @@ export default class ListContactsPage extends Page {
   manageContactsCard = (): PageElement => cy.get('[data-qa=manage-contacts-card]')
 
   manageContactRestrictionsCard = (): PageElement => cy.get('[data-qa=manage-restrictions-card]')
+
+  clickCreateNewContactButton() {
+    this.createNewContactButton().click()
+  }
+
+  private createNewContactButton = (): PageElement => cy.get('[data-qa=create-new-contact-button]')
 }

--- a/server/@types/contactsApi/index.d.ts
+++ b/server/@types/contactsApi/index.d.ts
@@ -58,6 +58,266 @@ export interface paths {
     patch?: never
     trace?: never
   }
+  '/language-reference': {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    /**
+     * Get language reference
+     * @description Gets all language references
+     */
+    get: operations['getAllCountries']
+    put?: never
+    post?: never
+    delete?: never
+    options?: never
+    head?: never
+    patch?: never
+    trace?: never
+  }
+  '/language-reference/{id}': {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    /**
+     * Get language reference
+     * @description Gets a language reference by their id
+     */
+    get: operations['getLanguageById']
+    put?: never
+    post?: never
+    delete?: never
+    options?: never
+    head?: never
+    patch?: never
+    trace?: never
+  }
+  '/language-reference/nomis-code/{code}': {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    /**
+     * Get language reference
+     * @description Gets a language reference by their nomis code
+     */
+    get: operations['getLanguageByNomisCode']
+    put?: never
+    post?: never
+    delete?: never
+    options?: never
+    head?: never
+    patch?: never
+    trace?: never
+  }
+  '/language-reference/iso-alpha3/{code}': {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    /**
+     * Get language reference
+     * @description Gets a language reference by their by ISO Alpha 3 code
+     */
+    get: operations['getLanguageByIsoAlpha3']
+    put?: never
+    post?: never
+    delete?: never
+    options?: never
+    head?: never
+    patch?: never
+    trace?: never
+  }
+  '/language-reference/iso-alpha2/{code}': {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    /**
+     * Get language reference
+     * @description Gets a language reference by their ISO Alpha 2 code
+     */
+    get: operations['getLanguageByIsoAlpha2']
+    put?: never
+    post?: never
+    delete?: never
+    options?: never
+    head?: never
+    patch?: never
+    trace?: never
+  }
+  '/county-reference': {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    /**
+     * Get county reference
+     * @description Gets all county references
+     */
+    get: operations['getAllCountries_1']
+    put?: never
+    post?: never
+    delete?: never
+    options?: never
+    head?: never
+    patch?: never
+    trace?: never
+  }
+  '/county-reference/{id}': {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    /**
+     * Get county reference
+     * @description Gets a county reference by their id
+     */
+    get: operations['getCountyById']
+    put?: never
+    post?: never
+    delete?: never
+    options?: never
+    head?: never
+    patch?: never
+    trace?: never
+  }
+  '/county-reference/nomis-code/{code}': {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    /**
+     * Get county reference
+     * @description Gets a county reference by their nomis code
+     */
+    get: operations['getCountyByNomisCode']
+    put?: never
+    post?: never
+    delete?: never
+    options?: never
+    head?: never
+    patch?: never
+    trace?: never
+  }
+  '/country-reference': {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    /**
+     * Get country reference
+     * @description Gets all country references
+     */
+    get: operations['getAllCountries_2']
+    put?: never
+    post?: never
+    delete?: never
+    options?: never
+    head?: never
+    patch?: never
+    trace?: never
+  }
+  '/country-reference/{id}': {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    /**
+     * Get country reference
+     * @description Gets a country reference by their id
+     */
+    get: operations['getCountryById']
+    put?: never
+    post?: never
+    delete?: never
+    options?: never
+    head?: never
+    patch?: never
+    trace?: never
+  }
+  '/country-reference/nomis-code/{code}': {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    /**
+     * Get country reference
+     * @description Gets a country reference by their nomis code
+     */
+    get: operations['getCountryByNomisCode']
+    put?: never
+    post?: never
+    delete?: never
+    options?: never
+    head?: never
+    patch?: never
+    trace?: never
+  }
+  '/country-reference/iso-alpha3/{code}': {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    /**
+     * Get country reference
+     * @description Gets a country reference by their by ISO Alpha 3 code
+     */
+    get: operations['getCountryByIsoAlpha3']
+    put?: never
+    post?: never
+    delete?: never
+    options?: never
+    head?: never
+    patch?: never
+    trace?: never
+  }
+  '/country-reference/iso-alpha2/{code}': {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    /**
+     * Get country reference
+     * @description Gets a country reference by their ISO Alpha 2 code
+     */
+    get: operations['getCountryByIsoAlpha2']
+    put?: never
+    post?: never
+    delete?: never
+    options?: never
+    head?: never
+    patch?: never
+    trace?: never
+  }
   '/contact/{contactId}': {
     parameters: {
       query?: never
@@ -78,10 +338,98 @@ export interface paths {
     patch?: never
     trace?: never
   }
+  '/city-reference': {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    /**
+     * Get city reference
+     * @description Gets all city references
+     */
+    get: operations['getAllCountries_3']
+    put?: never
+    post?: never
+    delete?: never
+    options?: never
+    head?: never
+    patch?: never
+    trace?: never
+  }
+  '/city-reference/{id}': {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    /**
+     * Get city reference
+     * @description Gets a city reference by their id
+     */
+    get: operations['getCityById']
+    put?: never
+    post?: never
+    delete?: never
+    options?: never
+    head?: never
+    patch?: never
+    trace?: never
+  }
+  '/city-reference/nomis-code/{code}': {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    /**
+     * Get city reference
+     * @description Gets a city reference by their nomis code
+     */
+    get: operations['getCityByNomisCode']
+    put?: never
+    post?: never
+    delete?: never
+    options?: never
+    head?: never
+    patch?: never
+    trace?: never
+  }
 }
 export type webhooks = Record<string, never>
 export interface components {
   schemas: {
+    /** @description A description of the relationship if the contact should be linked to a prisoner */
+    ContactRelationshipRequest: {
+      /**
+       * @description Prisoner number (NOMS ID)
+       * @example A1234BC
+       */
+      prisonerNumber: string
+      /**
+       * @description The relationship code between the prisoner and the contact
+       * @example FRI
+       */
+      relationshipCode: string
+      /**
+       * @description Whether they are the next of kin for the prisoner
+       * @example true
+       */
+      isNextOfKin: boolean
+      /**
+       * @description Whether they are the emergency contact for the prisoner
+       * @example true
+       */
+      isEmergencyContact: boolean
+      /**
+       * @description Comments about the contacts relationship with the prisoner
+       * @example Some additional information
+       */
+      comments?: string | null
+    } | null
     /** @description Request to create a new contact */
     CreateContactRequest: {
       /**
@@ -116,11 +464,20 @@ export interface components {
        * @enum {string|null}
        */
       isOverEighteen?: 'YES' | 'NO' | 'DO_NOT_KNOW' | null
+      relationship?: components['schemas']['ContactRelationshipRequest']
       /**
        * @description The id of the user creating the contact
        * @example JD000001
        */
       createdBy: string
+    }
+    ErrorResponse: {
+      /** Format: int32 */
+      status: number
+      errorCode?: string
+      userMessage?: string
+      developerMessage?: string
+      moreInfo?: string
     }
     /** @description The details of a contact as an individual */
     Contact: {
@@ -173,14 +530,6 @@ export interface components {
        * @example 2024-01-01T00:00:00Z
        */
       createdTime: string
-    }
-    ErrorResponse: {
-      /** Format: int32 */
-      status: number
-      errorCode?: string
-      userMessage?: string
-      developerMessage?: string
-      moreInfo?: string
     }
     /** @description Describes the details of a prisoner's contact */
     PrisonerContactSummary: {
@@ -304,6 +653,142 @@ export interface components {
        */
       comments?: string | null
     }
+    /** @description Language reference entity */
+    Language: {
+      /**
+       * Format: int64
+       * @description Unique identifier of the language
+       * @example 1
+       */
+      languageId: number | null
+      /**
+       * @description Nomis code of the language
+       * @example GBR
+       */
+      nomisCode: string
+      /**
+       * @description Nomis description of the language
+       * @example United Kingdom
+       */
+      nomisDescription: string
+      /**
+       * @description ISO Alpha-2 code of the language
+       * @example GB
+       */
+      isoAlpha2: string
+      /**
+       * @description ISO Alpha-3 code of the language
+       * @example GBR
+       */
+      isoAlpha3: string
+      /**
+       * @description ISO language description
+       * @example United Kingdom of Great Britain and Northern Ireland
+       */
+      isoLanguageDesc: string
+      /**
+       * Format: int32
+       * @description Display sequence for the language
+       * @example 1
+       */
+      displaySequence: number
+    }
+    /** @description County reference entity */
+    County: {
+      /**
+       * Format: int64
+       * @description Unique identifier of the county
+       * @example 1
+       */
+      countyId: number | null
+      /**
+       * @description Nomis code of the county
+       * @example GBR
+       */
+      nomisCode: string
+      /**
+       * @description Nomis description of the county
+       * @example United Kingdom
+       */
+      nomisDescription: string
+      /**
+       * Format: int32
+       * @description Display sequence for the county
+       * @example 1
+       */
+      displaySequence: number
+    }
+    /** @description Country reference entity */
+    Country: {
+      /**
+       * Format: int64
+       * @description Unique identifier of the country
+       * @example 1
+       */
+      countryId: number | null
+      /**
+       * @description Nomis code of the country
+       * @example GBR
+       */
+      nomisCode: string
+      /**
+       * @description Nomis description of the country
+       * @example United Kingdom
+       */
+      nomisDescription: string
+      /**
+       * Format: int32
+       * @description ISO numeric code of the country
+       * @example 826
+       */
+      isoNumeric: number
+      /**
+       * @description ISO Alpha-2 code of the country
+       * @example GB
+       */
+      isoAlpha2: string
+      /**
+       * @description ISO Alpha-3 code of the country
+       * @example GBR
+       */
+      isoAlpha3: string
+      /**
+       * @description ISO country description
+       * @example United Kingdom of Great Britain and Northern Ireland
+       */
+      isoCountryDesc: string
+      /**
+       * Format: int32
+       * @description Display sequence for the country
+       * @example 1
+       */
+      displaySequence: number
+    }
+    /** @description City reference entity */
+    City: {
+      /**
+       * Format: int64
+       * @description Unique identifier of the city
+       * @example 1
+       */
+      cityId: number | null
+      /**
+       * @description Nomis code of the city
+       * @example GBR
+       */
+      nomisCode: string
+      /**
+       * @description Nomis description of the city
+       * @example United Kingdom
+       */
+      nomisDescription: string
+      /**
+       * Format: int32
+       * @description Display sequence for the city
+       * @example 1
+       */
+      displaySequence: number
+    }
   }
   responses: never
   parameters: never
@@ -360,6 +845,15 @@ export interface operations {
       }
       /** @description Forbidden, requires an appropriate role */
       403: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['ErrorResponse']
+        }
+      }
+      /** @description Could not find the prisoner that this contact has a relationship to */
+      404: {
         headers: {
           [name: string]: unknown
         }
@@ -469,6 +963,610 @@ export interface operations {
       }
     }
   }
+  getAllCountries: {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    requestBody?: never
+    responses: {
+      /** @description Found the language reference */
+      200: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['Language']
+        }
+      }
+      /** @description Unauthorised, requires a valid Oauth2 token */
+      401: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['ErrorResponse']
+        }
+      }
+      /** @description Forbidden, requires an appropriate role */
+      403: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['ErrorResponse']
+        }
+      }
+    }
+  }
+  getLanguageById: {
+    parameters: {
+      query?: never
+      header?: never
+      path: {
+        id: number
+      }
+      cookie?: never
+    }
+    requestBody?: never
+    responses: {
+      /** @description Found the language reference */
+      200: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['Language']
+        }
+      }
+      /** @description Unauthorised, requires a valid Oauth2 token */
+      401: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['ErrorResponse']
+        }
+      }
+      /** @description Forbidden, requires an appropriate role */
+      403: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['ErrorResponse']
+        }
+      }
+      /** @description No language reference with that id could be found */
+      404: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['Language']
+        }
+      }
+    }
+  }
+  getLanguageByNomisCode: {
+    parameters: {
+      query?: never
+      header?: never
+      path: {
+        code: string
+      }
+      cookie?: never
+    }
+    requestBody?: never
+    responses: {
+      /** @description Found the language reference */
+      200: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['Language']
+        }
+      }
+      /** @description Unauthorised, requires a valid Oauth2 token */
+      401: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['ErrorResponse']
+        }
+      }
+      /** @description Forbidden, requires an appropriate role */
+      403: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['ErrorResponse']
+        }
+      }
+      /** @description No language reference with that nomis code could be found */
+      404: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['Language']
+        }
+      }
+    }
+  }
+  getLanguageByIsoAlpha3: {
+    parameters: {
+      query?: never
+      header?: never
+      path: {
+        code: string
+      }
+      cookie?: never
+    }
+    requestBody?: never
+    responses: {
+      /** @description Found the language reference */
+      200: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['Language']
+        }
+      }
+      /** @description Unauthorised, requires a valid Oauth2 token */
+      401: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['ErrorResponse']
+        }
+      }
+      /** @description Forbidden, requires an appropriate role */
+      403: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['ErrorResponse']
+        }
+      }
+      /** @description No language reference with that ISO Alpha 3 code could be found */
+      404: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['Language']
+        }
+      }
+    }
+  }
+  getLanguageByIsoAlpha2: {
+    parameters: {
+      query?: never
+      header?: never
+      path: {
+        code: string
+      }
+      cookie?: never
+    }
+    requestBody?: never
+    responses: {
+      /** @description Found the language reference */
+      200: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['Language']
+        }
+      }
+      /** @description Unauthorised, requires a valid Oauth2 token */
+      401: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['ErrorResponse']
+        }
+      }
+      /** @description Forbidden, requires an appropriate role */
+      403: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['ErrorResponse']
+        }
+      }
+      /** @description No language reference with that ISO Alpha 2 code could be found */
+      404: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['Language']
+        }
+      }
+    }
+  }
+  getAllCountries_1: {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    requestBody?: never
+    responses: {
+      /** @description Found the county reference */
+      200: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['County']
+        }
+      }
+      /** @description Unauthorised, requires a valid Oauth2 token */
+      401: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['ErrorResponse']
+        }
+      }
+      /** @description Forbidden, requires an appropriate role */
+      403: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['ErrorResponse']
+        }
+      }
+    }
+  }
+  getCountyById: {
+    parameters: {
+      query?: never
+      header?: never
+      path: {
+        id: number
+      }
+      cookie?: never
+    }
+    requestBody?: never
+    responses: {
+      /** @description Found the county reference */
+      200: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['County']
+        }
+      }
+      /** @description Unauthorised, requires a valid Oauth2 token */
+      401: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['ErrorResponse']
+        }
+      }
+      /** @description Forbidden, requires an appropriate role */
+      403: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['ErrorResponse']
+        }
+      }
+      /** @description No county reference with that id could be found */
+      404: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['County']
+        }
+      }
+    }
+  }
+  getCountyByNomisCode: {
+    parameters: {
+      query?: never
+      header?: never
+      path: {
+        code: string
+      }
+      cookie?: never
+    }
+    requestBody?: never
+    responses: {
+      /** @description Found the county reference */
+      200: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['County']
+        }
+      }
+      /** @description Unauthorised, requires a valid Oauth2 token */
+      401: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['ErrorResponse']
+        }
+      }
+      /** @description Forbidden, requires an appropriate role */
+      403: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['ErrorResponse']
+        }
+      }
+      /** @description No county reference with that nomis code could be found */
+      404: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['County']
+        }
+      }
+    }
+  }
+  getAllCountries_2: {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    requestBody?: never
+    responses: {
+      /** @description Found the country reference */
+      200: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['Country']
+        }
+      }
+      /** @description Unauthorised, requires a valid Oauth2 token */
+      401: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['ErrorResponse']
+        }
+      }
+      /** @description Forbidden, requires an appropriate role */
+      403: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['ErrorResponse']
+        }
+      }
+    }
+  }
+  getCountryById: {
+    parameters: {
+      query?: never
+      header?: never
+      path: {
+        id: number
+      }
+      cookie?: never
+    }
+    requestBody?: never
+    responses: {
+      /** @description Found the country reference */
+      200: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['Country']
+        }
+      }
+      /** @description Unauthorised, requires a valid Oauth2 token */
+      401: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['ErrorResponse']
+        }
+      }
+      /** @description Forbidden, requires an appropriate role */
+      403: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['ErrorResponse']
+        }
+      }
+      /** @description No country reference with that id could be found */
+      404: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['Country']
+        }
+      }
+    }
+  }
+  getCountryByNomisCode: {
+    parameters: {
+      query?: never
+      header?: never
+      path: {
+        code: string
+      }
+      cookie?: never
+    }
+    requestBody?: never
+    responses: {
+      /** @description Found the country reference */
+      200: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['Country']
+        }
+      }
+      /** @description Unauthorised, requires a valid Oauth2 token */
+      401: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['ErrorResponse']
+        }
+      }
+      /** @description Forbidden, requires an appropriate role */
+      403: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['ErrorResponse']
+        }
+      }
+      /** @description No country reference with that nomis code could be found */
+      404: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['Country']
+        }
+      }
+    }
+  }
+  getCountryByIsoAlpha3: {
+    parameters: {
+      query?: never
+      header?: never
+      path: {
+        code: string
+      }
+      cookie?: never
+    }
+    requestBody?: never
+    responses: {
+      /** @description Found the country reference */
+      200: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['Country']
+        }
+      }
+      /** @description Unauthorised, requires a valid Oauth2 token */
+      401: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['ErrorResponse']
+        }
+      }
+      /** @description Forbidden, requires an appropriate role */
+      403: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['ErrorResponse']
+        }
+      }
+      /** @description No country reference with that ISO Alpha 3 code could be found */
+      404: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['Country']
+        }
+      }
+    }
+  }
+  getCountryByIsoAlpha2: {
+    parameters: {
+      query?: never
+      header?: never
+      path: {
+        code: string
+      }
+      cookie?: never
+    }
+    requestBody?: never
+    responses: {
+      /** @description Found the country reference */
+      200: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['Country']
+        }
+      }
+      /** @description Unauthorised, requires a valid Oauth2 token */
+      401: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['ErrorResponse']
+        }
+      }
+      /** @description Forbidden, requires an appropriate role */
+      403: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['ErrorResponse']
+        }
+      }
+      /** @description No country reference with that ISO Alpha 2 code could be found */
+      404: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['Country']
+        }
+      }
+    }
+  }
   getContact: {
     parameters: {
       query?: never
@@ -518,6 +1616,142 @@ export interface operations {
         }
         content: {
           'application/json': Record<string, never>
+        }
+      }
+    }
+  }
+  getAllCountries_3: {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    requestBody?: never
+    responses: {
+      /** @description Found the city reference */
+      200: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['City']
+        }
+      }
+      /** @description Unauthorised, requires a valid Oauth2 token */
+      401: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['ErrorResponse']
+        }
+      }
+      /** @description Forbidden, requires an appropriate role */
+      403: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['ErrorResponse']
+        }
+      }
+    }
+  }
+  getCityById: {
+    parameters: {
+      query?: never
+      header?: never
+      path: {
+        id: number
+      }
+      cookie?: never
+    }
+    requestBody?: never
+    responses: {
+      /** @description Found the city reference */
+      200: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['City']
+        }
+      }
+      /** @description Unauthorised, requires a valid Oauth2 token */
+      401: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['ErrorResponse']
+        }
+      }
+      /** @description Forbidden, requires an appropriate role */
+      403: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['ErrorResponse']
+        }
+      }
+      /** @description No city reference with that id could be found */
+      404: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['City']
+        }
+      }
+    }
+  }
+  getCityByNomisCode: {
+    parameters: {
+      query?: never
+      header?: never
+      path: {
+        code: string
+      }
+      cookie?: never
+    }
+    requestBody?: never
+    responses: {
+      /** @description Found the city reference */
+      200: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['City']
+        }
+      }
+      /** @description Unauthorised, requires a valid Oauth2 token */
+      401: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['ErrorResponse']
+        }
+      }
+      /** @description Forbidden, requires an appropriate role */
+      403: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['ErrorResponse']
+        }
+      }
+      /** @description No city reference with that nomis code could be found */
+      404: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['City']
         }
       }
     }

--- a/server/@types/journeys/index.d.ts
+++ b/server/@types/journeys/index.d.ts
@@ -4,6 +4,7 @@ declare namespace journeys {
     lastTouched: string
     prisonerNumber: string
     isCheckingAnswers: boolean
+    returnPoint: ReturnPoint
     names?: ContactNames
     dateOfBirth?: DateOfBirth
   }
@@ -40,8 +41,13 @@ declare namespace journeys {
     contactId?: number
   }
 
+  export interface ReturnPoint {
+    type: ReturnPointType
+    url: string
+  }
+
+  type ReturnPointType = 'MANAGE_PRISONER_CONTACTS' | 'HOME'
   type YesOrNo = 'YES' | 'NO'
   type YesNoOrDoNotKnow = 'YES' | 'NO' | 'DO_NOT_KNOW'
-
   type PrisonerJourneyParams = { prisonerNumber: string; journeyId: string }
 }

--- a/server/routes/contacts/create/check-answers/createContactCheckAnswersController.ts
+++ b/server/routes/contacts/create/check-answers/createContactCheckAnswersController.ts
@@ -32,6 +32,11 @@ export default class CreateContactCheckAnswersController implements PageHandler 
     await this.contactService
       .createContact(journey, user)
       .then(() => delete req.session.createContactJourneys[journeyId])
-    res.redirect(`/prisoner/${prisonerNumber}/contacts/create/success`)
+
+    if (journey.returnPoint.type === 'MANAGE_PRISONER_CONTACTS') {
+      res.redirect(journey.returnPoint.url)
+    } else {
+      res.redirect(`/prisoner/${prisonerNumber}/contacts/create/success`)
+    }
   }
 }

--- a/server/routes/contacts/create/createContactMiddleware.test.ts
+++ b/server/routes/contacts/create/createContactMiddleware.test.ts
@@ -26,6 +26,7 @@ describe('createContactMiddleware', () => {
         lastTouched: lastTouchedBeforeCall.toISOString(),
         prisonerNumber,
         isCheckingAnswers: false,
+        returnPoint: { type: 'HOME', url: '/foo-bar' },
       }
       ensureInCreateContactJourney()(req, res, next)
       expect(next).toHaveBeenCalledTimes(1)

--- a/server/routes/contacts/create/enter-dob/createContactEnterDobController.test.ts
+++ b/server/routes/contacts/create/enter-dob/createContactEnterDobController.test.ts
@@ -23,6 +23,7 @@ beforeEach(() => {
     lastTouched: new Date().toISOString(),
     prisonerNumber,
     isCheckingAnswers: false,
+    returnPoint: { type: 'MANAGE_PRISONER_CONTACTS', url: '/foo-bar' },
     names: {
       lastName: 'last',
       firstName: 'first',
@@ -55,8 +56,22 @@ describe('GET /prisoner/:prisonerNumber/contacts/create/enter-dob/:journeyId', (
 
     // Then
     expect(response.status).toEqual(200)
-    expect(response.text).toContain('Contacts')
-    expect(response.text).toContain('Hmpps Contacts Ui')
+
+    const $ = cheerio.load(response.text)
+    expect($('[data-qa=main-heading]').first().text().trim()).toStrictEqual("Do you know last, first's date of birth?")
+    expect($('[data-qa=cancel-button]').first().attr('href')).toStrictEqual('/foo-bar')
+    expect($('[data-qa=contact-list-breadcrumb-link]').first().attr('href')).toStrictEqual('/foo-bar')
+  })
+
+  it('should call the audit service for the page view', async () => {
+    // Given
+    auditService.logPageView.mockResolvedValue(null)
+
+    // When
+    const response = await request(app).get(`/prisoner/${prisonerNumber}/contacts/create/enter-dob/${journeyId}`)
+
+    // Then
+    expect(response.status).toEqual(200)
     expect(auditService.logPageView).toHaveBeenCalledWith(Page.CREATE_CONTACT_DOB_PAGE, {
       who: user.username,
       correlationId: expect.any(String),

--- a/server/routes/contacts/create/start/startCreateContactJourneyController.ts
+++ b/server/routes/contacts/create/start/startCreateContactJourneyController.ts
@@ -3,18 +3,43 @@ import { v4 as uuidv4 } from 'uuid'
 import { Page } from '../../../../services/auditService'
 import { PageHandler } from '../../../../interfaces/pageHandler'
 import CreateContactJourney = journeys.CreateContactJourney
+import ReturnPointType = journeys.ReturnPointType
+import ReturnPoint = journeys.ReturnPoint
 
 export default class StartCreateContactJourneyController implements PageHandler {
   public PAGE_NAME = Page.CREATE_CONTACT_START_PAGE
 
   private MAX_JOURNEYS = 5
 
-  GET = async (req: Request<{ prisonerNumber: string }, unknown, unknown>, res: Response): Promise<void> => {
+  GET = async (
+    req: Request<
+      { prisonerNumber: string },
+      unknown,
+      unknown,
+      {
+        returnJourneyType?: ReturnPointType
+        returnJourneyId?: string
+      }
+    >,
+    res: Response,
+  ): Promise<void> => {
+    const { returnJourneyType, returnJourneyId } = req.query
+    const { prisonerNumber } = req.params
+    let returnPoint: ReturnPoint
+    if (returnJourneyType === 'MANAGE_PRISONER_CONTACTS') {
+      returnPoint = {
+        type: 'MANAGE_PRISONER_CONTACTS',
+        url: `/prisoner/${prisonerNumber}/contacts/list/${returnJourneyId}`,
+      }
+    } else {
+      returnPoint = { type: 'HOME', url: '/' }
+    }
     const journey: CreateContactJourney = {
       id: uuidv4(),
       lastTouched: new Date().toISOString(),
       isCheckingAnswers: false,
-      prisonerNumber: req.params.prisonerNumber,
+      returnPoint,
+      prisonerNumber,
     }
     if (!req.session.createContactJourneys) {
       req.session.createContactJourneys = {}

--- a/server/services/contactsService.test.ts
+++ b/server/services/contactsService.test.ts
@@ -33,6 +33,7 @@ describe('contactsService', () => {
         lastTouched: new Date().toISOString(),
         prisonerNumber,
         isCheckingAnswers: false,
+        returnPoint: { type: 'HOME', url: '/foo-bar' },
         names: {
           title: 'Mr',
           lastName: 'last',
@@ -54,6 +55,12 @@ describe('contactsService', () => {
         dateOfBirth: new Date('1982-06-01T00:00:00.000Z'),
         isOverEighteen: undefined,
         createdBy: 'user1',
+        relationship: {
+          prisonerNumber,
+          relationshipCode: 'FRI',
+          isNextOfKin: false,
+          isEmergencyContact: false,
+        },
       }
 
       // When
@@ -75,6 +82,7 @@ describe('contactsService', () => {
         lastTouched: new Date().toISOString(),
         prisonerNumber,
         isCheckingAnswers: false,
+        returnPoint: { type: 'HOME', url: '/foo-bar' },
         names: {
           lastName: 'last',
           firstName: 'first',
@@ -91,6 +99,12 @@ describe('contactsService', () => {
         middleName: undefined,
         dateOfBirth: undefined,
         isOverEighteen: 'DO_NOT_KNOW',
+        relationship: {
+          prisonerNumber,
+          relationshipCode: 'FRI',
+          isNextOfKin: false,
+          isEmergencyContact: false,
+        },
         createdBy: 'user1',
       }
 
@@ -117,6 +131,7 @@ describe('contactsService', () => {
         lastTouched: new Date().toISOString(),
         prisonerNumber,
         isCheckingAnswers: false,
+        returnPoint: { type: 'HOME', url: '/foo-bar' },
         names: {
           lastName: 'last',
           firstName: 'first',
@@ -133,6 +148,12 @@ describe('contactsService', () => {
         middleName: undefined,
         dateOfBirth: undefined,
         isOverEighteen: expected,
+        relationship: {
+          prisonerNumber,
+          relationshipCode: 'FRI',
+          isNextOfKin: false,
+          isEmergencyContact: false,
+        },
         createdBy: 'user1',
       }
 
@@ -152,6 +173,7 @@ describe('contactsService', () => {
             lastTouched: new Date().toISOString(),
             prisonerNumber,
             isCheckingAnswers: false,
+            returnPoint: { type: 'HOME', url: '/foo-bar' },
             names: { firstName: 'first', lastName: 'last' },
             dateOfBirth: { isKnown: 'NO' },
           },

--- a/server/services/contactsService.ts
+++ b/server/services/contactsService.ts
@@ -34,6 +34,12 @@ export default class ContactsService {
       middleName: journey.names.middleName,
       dateOfBirth,
       isOverEighteen,
+      relationship: {
+        prisonerNumber: journey.prisonerNumber,
+        relationshipCode: 'FRI',
+        isNextOfKin: false,
+        isEmergencyContact: false,
+      },
       createdBy: user.username,
     }
     return this.contactsApiClient.createContact(request, user)

--- a/server/views/pages/contacts/create/checkAnswers.njk
+++ b/server/views/pages/contacts/create/checkAnswers.njk
@@ -8,25 +8,10 @@
 {% set mainClasses = "app-container govuk-body" %}
 
 {% block content %}
-<div class="govuk-grid-row govuk-!-static-margin-bottom-5">
-  <div class="govuk-grid-column-full">
-      {{ govukBreadcrumbs({
-      items: [
-          {
-            text: "Digital Prison Services",
-            href: DPS_HOME_PAGE_URL
-          },
-          {
-              text: "Contacts",
-              href: "/"
-          }
-      ]
-      }) }}
-  </div>
-</div>
+{% include './partials/createContactBreadcrumbs.njk' %}
 {% include '../../../partials/formErrorSummary.njk' %}
 <span class="govuk-caption-l">Manage Contacts</span>
-<h1 class="govuk-heading-l">{{ title }}</h1>
+<h1 class="govuk-heading-l" data-qa="main-heading">{{ title }}</h1>
  <div class="govuk-grid-row">
         <div class="govuk-grid-column-three-quarters">
             <form method='POST'>
@@ -114,7 +99,7 @@
                         classes: 'govuk-!-margin-top-6',
                         attributes: {"data-qa": "create-prisoner-contact-button"}
                     }) }}
-                    <a class="govuk-link govuk-link--no-visited-state govuk-!-font-size-19" href="/">Cancel</a>
+                    <a class="govuk-link govuk-link--no-visited-state govuk-!-font-size-19" href="{{ journey.returnPoint.url }}" data-qa="cancel-button">Cancel</a>
                 </div>
             </form>
 

--- a/server/views/pages/contacts/create/enterDob.njk
+++ b/server/views/pages/contacts/create/enterDob.njk
@@ -9,25 +9,10 @@
 {% set mainClasses = "app-container govuk-body" %}
 
 {% block content %}
-<div class="govuk-grid-row govuk-!-static-margin-bottom-5">
-  <div class="govuk-grid-column-full">
-      {{ govukBreadcrumbs({
-      items: [
-          {
-            text: "Digital Prison Services",
-            href: DPS_HOME_PAGE_URL
-          },
-          {
-              text: "Contacts",
-              href: "/"
-          }
-      ]
-      }) }}
-  </div>
-</div>
+{% include './partials/createContactBreadcrumbs.njk' %}
 {% include '../../../partials/formErrorSummary.njk' %}
 <span class="govuk-caption-l">Manage Contacts</span>
-<h1 class="govuk-heading-l">{{ title }}</h1>
+<h1 class="govuk-heading-l" data-qa="main-heading">{{ title }}</h1>
  <div class="govuk-grid-row">
         <div class="govuk-grid-column-three-quarters">
             <form method='POST'>
@@ -97,7 +82,7 @@
                         classes: 'govuk-!-margin-top-6',
                         attributes: {"data-qa": "continue-button"}
                     }) }}
-                    <a class="govuk-link govuk-link--no-visited-state govuk-!-font-size-19" href="/">Cancel</a>
+                    <a class="govuk-link govuk-link--no-visited-state govuk-!-font-size-19" href="{{ journey.returnPoint.url }}" data-qa="cancel-button">Cancel</a>
                 </div>
             </form>
 

--- a/server/views/pages/contacts/create/enterEstimatedDob.njk
+++ b/server/views/pages/contacts/create/enterEstimatedDob.njk
@@ -9,25 +9,10 @@
 {% set mainClasses = "app-container govuk-body" %}
 
 {% block content %}
-<div class="govuk-grid-row govuk-!-static-margin-bottom-5">
-  <div class="govuk-grid-column-full">
-      {{ govukBreadcrumbs({
-      items: [
-          {
-            text: "Digital Prison Services",
-            href: DPS_HOME_PAGE_URL
-          },
-          {
-              text: "Contacts",
-              href: "/"
-          }
-      ]
-      }) }}
-  </div>
-</div>
+{% include './partials/createContactBreadcrumbs.njk' %}
 {% include '../../../partials/formErrorSummary.njk' %}
 <span class="govuk-caption-l">Manage Contacts</span>
-<h1 class="govuk-heading-l">{{ title }}</h1>
+<h1 class="govuk-heading-l" data-qa="main-heading">{{ title }}</h1>
  <div class="govuk-grid-row">
         <div class="govuk-grid-column-three-quarters">
             <form method='POST'>
@@ -61,7 +46,7 @@
                         classes: 'govuk-!-margin-top-6',
                         attributes: {"data-qa": "continue-button"}
                     }) }}
-                    <a class="govuk-link govuk-link--no-visited-state govuk-!-font-size-19" href="/">Cancel</a>
+                    <a class="govuk-link govuk-link--no-visited-state govuk-!-font-size-19" href="{{ journey.returnPoint.url }}" data-qa="cancel-button">Cancel</a>
                 </div>
             </form>
 

--- a/server/views/pages/contacts/create/enterName.njk
+++ b/server/views/pages/contacts/create/enterName.njk
@@ -9,25 +9,11 @@
 {% set mainClasses = "app-container govuk-body" %}
 
 {% block content %}
-<div class="govuk-grid-row govuk-!-static-margin-bottom-5">
-  <div class="govuk-grid-column-full">
-      {{ govukBreadcrumbs({
-      items: [
-          {
-            text: "Digital Prison Services",
-            href: DPS_HOME_PAGE_URL
-          },
-          {
-              text: "Contacts",
-              href: "/"
-          }
-      ]
-      }) }}
-  </div>
-</div>
+
+{% include './partials/createContactBreadcrumbs.njk' %}
 {% include '../../../partials/formErrorSummary.njk' %}
 <span class="govuk-caption-l">Manage Contacts</span>
-<h1 class="govuk-heading-l">{{ title }}</h1>
+<h1 class="govuk-heading-l" data-qa="main-heading">{{ title }}</h1>
  <div class="govuk-grid-row">
         <div class="govuk-grid-column-three-quarters">
             <form method='POST'>
@@ -76,7 +62,7 @@
                         classes: 'govuk-!-margin-top-6',
                         attributes: {"data-qa": "continue-button"}
                     }) }}
-                    <a class="govuk-link govuk-link--no-visited-state govuk-!-font-size-19" href="/">Cancel</a>
+                    <a class="govuk-link govuk-link--no-visited-state govuk-!-font-size-19" href="{{ journey.returnPoint.url }}" data-qa="cancel-button">Cancel</a>
                 </div>
             </form>
 

--- a/server/views/pages/contacts/create/partials/createContactBreadcrumbs.njk
+++ b/server/views/pages/contacts/create/partials/createContactBreadcrumbs.njk
@@ -1,0 +1,26 @@
+<div class="govuk-grid-row govuk-!-static-margin-bottom-5">
+    <div class="govuk-grid-column-full">
+        {% set breadcrumbs = [
+            {
+                text: "Digital Prison Services",
+                href: DPS_HOME_PAGE_URL
+            },
+            {
+                text: "Contacts",
+                href: "/"
+            }
+        ] %}
+        {% if journey.returnPoint.type === 'MANAGE_PRISONER_CONTACTS' %}
+            {% set breadcrumbs = (breadcrumbs.push(
+                {
+                    text: "Prisoner Contacts",
+                    href: journey.returnPoint.url,
+                    attributes: {"data-qa": "contact-list-breadcrumb-link"}
+                }
+            ), breadcrumbs) %}
+        {%  endif %}
+        {{ govukBreadcrumbs({
+            items: breadcrumbs
+        }) }}
+    </div>
+</div>

--- a/server/views/pages/contacts/manage/listContacts.njk
+++ b/server/views/pages/contacts/manage/listContacts.njk
@@ -104,7 +104,8 @@
 
     {{ govukButton({
         text: "Create new prisoner contact",
-        href: "/prisoner/" + journey.prisoner.prisonerNumber + "/contacts/create/start"
+        href: "/prisoner/" + journey.prisoner.prisonerNumber + "/contacts/create/start?returnJourneyType=MANAGE_PRISONER_CONTACTS&returnJourneyId=" + journey.id,
+        attributes: {"data-qa": "create-new-contact-button"}
     }) }}
 
 <div class="govuk-tabs" data-module="govuk-tabs">


### PR DESCRIPTION
Added a return point to the "create contact" journey and updated the cancel buttons and breadcrumbs to use it.

Successfully creating a contact returns you to the prisoner contact list.

It is currently optional as a convenience for testing as you can currently only get to prisoner contact page by searching. The default is to cancel > home page and show the temporary success page.

Also sets the relationship with defaulted values for now so that the contact appears in the list.