### PR TITLE
PRC-109: Add mini profile to create flow

### DIFF
--- a/integration_tests/e2e/createContacts.cy.ts
+++ b/integration_tests/e2e/createContacts.cy.ts
@@ -16,6 +16,7 @@ context('Create Contacts', () => {
     cy.task('stubSignIn', { roles: ['PRISON'] })
     cy.task('stubTitlesReferenceData')
     cy.task('stubRelationshipReferenceData')
+    cy.task('stubPrisonerById', TestData.prisoner())
   })
 
   it('Can create a contact with only required fields with direct link', () => {
@@ -308,7 +309,6 @@ context('Create Contacts', () => {
   it('Can create a contact from prisoner contact page', () => {
     cy.signIn()
     const { prisonerNumber } = TestData.prisoner()
-    cy.task('stubComponentsMeta')
     cy.task('stubPrisoners', {
       results: {
         totalPages: 1,
@@ -318,7 +318,6 @@ context('Create Contacts', () => {
       prisonId: 'HEI',
       term: prisonerNumber,
     })
-    cy.task('stubPrisonerById', TestData.prisoner())
     cy.task('stubContactList', prisonerNumber)
     cy.task('stubCreateContact', { id: 132456 })
 

--- a/integration_tests/e2e/createContactsCheckAnswersChange.cy.ts
+++ b/integration_tests/e2e/createContactsCheckAnswersChange.cy.ts
@@ -5,6 +5,7 @@ import EnterContactDateOfBirthPage from '../pages/enterContactDateOfBirthPage'
 import CreateContactCheckYourAnswersPage from '../pages/createContactCheckYourAnswersPage'
 import EnterContactEstimatedDateOfBirthPage from '../pages/enterContactEstimatedDateOfBirthPage'
 import SelectRelationshipPage from '../pages/selectRelationshipPage'
+import TestData from '../../server/routes/testutils/testData'
 
 context('Create contact and update from check answers', () => {
   beforeEach(() => {
@@ -13,6 +14,7 @@ context('Create contact and update from check answers', () => {
     cy.task('stubComponentsMeta')
     cy.task('stubTitlesReferenceData')
     cy.task('stubRelationshipReferenceData')
+    cy.task('stubPrisonerById', TestData.prisoner())
     cy.signIn()
     cy.visit('/prisoner/A1234BC/contacts/create/start')
     cy.task('stubCreateContact', { id: 132456 })

--- a/server/@types/journeys/index.d.ts
+++ b/server/@types/journeys/index.d.ts
@@ -35,14 +35,7 @@ declare namespace journeys {
     search?: {
       searchTerm?: string
     }
-    prisoner?: {
-      firstName?: string
-      lastName?: string
-      prisonerNumber?: string
-      dateOfBirth?: string
-      prisonId?: string
-      prisonName?: string
-    }
+    prisoner?: PrisonerDetails
     searchContact?: {
       contact?: Partial<ContactNames>
       dateOfBirth?: Partial<DateOfBirth>
@@ -53,6 +46,15 @@ declare namespace journeys {
   export interface ReturnPoint {
     type: ReturnPointType
     url: string
+  }
+
+  export interface PrisonerDetails {
+    prisonerNumber: string
+    lastName: string
+    firstName: string
+    dateOfBirth: string
+    prisonName: string
+    cellLocation?: string
   }
 
   type ReturnPointType = 'MANAGE_PRISONER_CONTACTS' | 'HOME'

--- a/server/middleware/prisonerDetailsMiddleware.test.ts
+++ b/server/middleware/prisonerDetailsMiddleware.test.ts
@@ -1,0 +1,63 @@
+import 'reflect-metadata'
+import { Request, Response } from 'express'
+import prisonerDetailsMiddleware from './prisonerDetailsMiddleware'
+import PrisonerSearchService from '../services/prisonerSearchService'
+import TestData from '../routes/testutils/testData'
+import { user } from '../routes/testutils/appSetup'
+import PrisonerDetails = journeys.PrisonerDetails
+
+jest.mock('../services/prisonerSearchService')
+
+const prisonerSearchService = new PrisonerSearchService(null) as jest.Mocked<PrisonerSearchService>
+
+describe('prisonerDetailsMiddleware', () => {
+  const res = { locals: { user } } as unknown as Response
+  let req = {} as Request
+
+  afterEach(() => {
+    jest.resetAllMocks()
+  })
+
+  it('should add prisoner details and call next', async () => {
+    const next = jest.fn()
+    prisonerSearchService.getByPrisonerNumber.mockResolvedValue(TestData.prisoner())
+
+    req = {
+      params: {
+        prisonerNumber: 'A1234BC',
+      },
+      session: {},
+    } as Request<{ prisonerNumber: string }>
+
+    await prisonerDetailsMiddleware(prisonerSearchService)(req, res, next)
+
+    expect(next).toHaveBeenCalledTimes(1)
+    expect(prisonerSearchService.getByPrisonerNumber).toHaveBeenCalledWith('A1234BC', user)
+    const expectedPrisonerDetails: PrisonerDetails = {
+      prisonerNumber: 'A1234BC',
+      lastName: 'SMITH',
+      firstName: 'JOHN',
+      dateOfBirth: '1975-04-02',
+      prisonName: 'HMP Hewell',
+      cellLocation: '1-1-C-028',
+    }
+    expect(res.locals.prisonerDetails).toStrictEqual(expectedPrisonerDetails)
+  })
+
+  it('should deal with problems coming from the service without blowing up', async () => {
+    const next = jest.fn()
+    const error = new Error('Bang!')
+    prisonerSearchService.getByPrisonerNumber.mockRejectedValue(error)
+
+    req = {
+      params: {
+        prisonerNumber: 'A1234BC',
+      },
+      session: {},
+    } as Request<{ prisonerNumber: string }>
+
+    await prisonerDetailsMiddleware(prisonerSearchService)(req, res, next)
+
+    expect(prisonerSearchService.getByPrisonerNumber).toHaveBeenCalledWith('A1234BC', user)
+  })
+})

--- a/server/middleware/prisonerDetailsMiddleware.ts
+++ b/server/middleware/prisonerDetailsMiddleware.ts
@@ -1,0 +1,28 @@
+import { Request, RequestHandler } from 'express'
+import { PrisonerSearchService } from '../services'
+import { Prisoner } from '../data/prisonerOffenderSearchTypes'
+import asyncMiddleware from './asyncMiddleware'
+import PrisonerDetails = journeys.PrisonerDetails
+
+const prisonerDetailsMiddleware = (prisonerSearchService: PrisonerSearchService): RequestHandler => {
+  return asyncMiddleware(async (req: Request<{ prisonerNumber: string }>, res, next) => {
+    const { prisonerNumber } = req.params
+    const { user } = res.locals
+    const prisoner = await prisonerSearchService.getByPrisonerNumber(prisonerNumber, user)
+    res.locals.prisonerDetails = toPrisonerDetails(prisoner)
+    return next()
+  })
+
+  function toPrisonerDetails(prisoner: Prisoner): PrisonerDetails {
+    return {
+      prisonerNumber: prisoner.prisonerNumber,
+      lastName: prisoner.lastName,
+      firstName: prisoner.firstName,
+      dateOfBirth: prisoner.dateOfBirth,
+      prisonName: prisoner.prisonName,
+      cellLocation: prisoner.cellLocation,
+    }
+  }
+}
+
+export default prisonerDetailsMiddleware

--- a/server/routes/contacts/common/relationship/selectRelationshipController.test.ts
+++ b/server/routes/contacts/common/relationship/selectRelationshipController.test.ts
@@ -8,12 +8,16 @@ import AuditService, { Page } from '../../../../services/auditService'
 import ReferenceDataService from '../../../../services/referenceDataService'
 import { mockedReferenceData } from '../../../testutils/stubReferenceData'
 import CreateContactJourney = journeys.CreateContactJourney
+import PrisonerSearchService from '../../../../services/prisonerSearchService'
+import TestData from '../../../testutils/testData'
 
 jest.mock('../../../../services/auditService')
 jest.mock('../../../../services/referenceDataService')
+jest.mock('../../../../services/prisonerSearchService')
 
 const auditService = new AuditService(null) as jest.Mocked<AuditService>
 const referenceDataService = new ReferenceDataService(null) as jest.Mocked<ReferenceDataService>
+const prisonerSearchService = new PrisonerSearchService(null) as jest.Mocked<PrisonerSearchService>
 
 let app: Express
 let session: Partial<SessionData>
@@ -34,6 +38,7 @@ beforeEach(() => {
     services: {
       auditService,
       referenceDataService,
+      prisonerSearchService,
     },
     userSupplier: () => user,
     sessionReceiver: (receivedSession: Partial<SessionData>) => {
@@ -43,6 +48,7 @@ beforeEach(() => {
     },
   })
   referenceDataService.getReferenceData.mockImplementation(mockedReferenceData)
+  prisonerSearchService.getByPrisonerNumber.mockResolvedValue(TestData.prisoner({ prisonerNumber }))
 })
 
 afterEach(() => {

--- a/server/routes/contacts/create/check-answers/createContactCheckAnswersController.test.ts
+++ b/server/routes/contacts/create/check-answers/createContactCheckAnswersController.test.ts
@@ -8,14 +8,18 @@ import AuditService, { Page } from '../../../../services/auditService'
 import ContactsService from '../../../../services/contactsService'
 import CreateContactJourney = journeys.CreateContactJourney
 import ReferenceDataService from '../../../../services/referenceDataService'
+import TestData from '../../../testutils/testData'
+import PrisonerSearchService from '../../../../services/prisonerSearchService'
 
 jest.mock('../../../../services/auditService')
 jest.mock('../../../../services/contactsService')
 jest.mock('../../../../services/referenceDataService')
+jest.mock('../../../../services/prisonerSearchService')
 
 const auditService = new AuditService(null) as jest.Mocked<AuditService>
 const contactsService = new ContactsService(null) as jest.Mocked<ContactsService>
 const referenceDataService = new ReferenceDataService(null) as jest.Mocked<ReferenceDataService>
+const prisonerSearchService = new PrisonerSearchService(null) as jest.Mocked<PrisonerSearchService>
 
 let app: Express
 let session: Partial<SessionData>
@@ -49,6 +53,7 @@ beforeEach(() => {
       auditService,
       contactsService,
       referenceDataService,
+      prisonerSearchService,
     },
     userSupplier: () => user,
     sessionReceiver: (receivedSession: Partial<SessionData>) => {
@@ -58,6 +63,7 @@ beforeEach(() => {
     },
   })
   referenceDataService.getReferenceDescriptionForCode.mockResolvedValue('Mother')
+  prisonerSearchService.getByPrisonerNumber.mockResolvedValue(TestData.prisoner({ prisonerNumber }))
 })
 
 afterEach(() => {

--- a/server/routes/contacts/create/createContactRoutes.ts
+++ b/server/routes/contacts/create/createContactRoutes.ts
@@ -9,7 +9,7 @@ import CreateContactEnterDobController from './enter-dob/createContactEnterDobCo
 import { createContactEnterDobSchema } from './enter-dob/createContactEnterDobSchemas'
 import StartCreateContactJourneyController from './start/startCreateContactJourneyController'
 import ensureInCreateContactJourney from './createContactMiddleware'
-import { ContactsService } from '../../../services'
+import { ContactsService, PrisonerSearchService } from '../../../services'
 import CreateContactCheckAnswersController from './check-answers/createContactCheckAnswersController'
 import asyncMiddleware from '../../../middleware/asyncMiddleware'
 import CreateContactEnterEstimatedDobController from './enter-estimated-dob/createContactEnterEstimatedDobController'
@@ -17,11 +17,13 @@ import { createContactEnterEstimatedDobSchema } from './enter-estimated-dob/crea
 import ReferenceDataService from '../../../services/referenceDataService'
 import SelectRelationshipController from '../common/relationship/selectRelationshipController'
 import { selectRelationshipSchemaFactory } from '../common/relationship/selectRelationshipSchemas'
+import prisonerDetailsMiddleware from '../../../middleware/prisonerDetailsMiddleware'
 
 const CreateContactRoutes = (
   auditService: AuditService,
   contactsService: ContactsService,
   referenceDataService: ReferenceDataService,
+  prisonerSearchService: PrisonerSearchService,
 ) => {
   const router = Router({ mergeParams: true })
 
@@ -36,6 +38,7 @@ const CreateContactRoutes = (
   router.get(
     '/prisoner/:prisonerNumber/contacts/create/enter-name/:journeyId',
     ensureInCreateContactJourney(),
+    prisonerDetailsMiddleware(prisonerSearchService),
     logPageViewMiddleware(auditService, enterNameController),
     asyncMiddleware(enterNameController.GET),
   )
@@ -50,6 +53,7 @@ const CreateContactRoutes = (
   router.get(
     '/prisoner/:prisonerNumber/contacts/create/select-relationship/:journeyId',
     ensureInCreateContactJourney(),
+    prisonerDetailsMiddleware(prisonerSearchService),
     logPageViewMiddleware(auditService, selectRelationshipController),
     asyncMiddleware(selectRelationshipController.GET),
   )
@@ -64,6 +68,7 @@ const CreateContactRoutes = (
   router.get(
     '/prisoner/:prisonerNumber/contacts/create/enter-dob/:journeyId',
     ensureInCreateContactJourney(),
+    prisonerDetailsMiddleware(prisonerSearchService),
     logPageViewMiddleware(auditService, enterDobController),
     asyncMiddleware(enterDobController.GET),
   )
@@ -78,6 +83,7 @@ const CreateContactRoutes = (
   router.get(
     '/prisoner/:prisonerNumber/contacts/create/enter-estimated-dob/:journeyId',
     ensureInCreateContactJourney(),
+    prisonerDetailsMiddleware(prisonerSearchService),
     logPageViewMiddleware(auditService, enterEstimatedDobController),
     asyncMiddleware(enterEstimatedDobController.GET),
   )
@@ -92,6 +98,7 @@ const CreateContactRoutes = (
   router.get(
     '/prisoner/:prisonerNumber/contacts/create/check-answers/:journeyId',
     ensureInCreateContactJourney(),
+    prisonerDetailsMiddleware(prisonerSearchService),
     logPageViewMiddleware(auditService, checkAnswersController),
     asyncMiddleware(checkAnswersController.GET),
   )

--- a/server/routes/contacts/create/enter-dob/createContactEnterDobController.test.ts
+++ b/server/routes/contacts/create/enter-dob/createContactEnterDobController.test.ts
@@ -6,10 +6,14 @@ import * as cheerio from 'cheerio'
 import { appWithAllRoutes, flashProvider, user } from '../../../testutils/appSetup'
 import AuditService, { Page } from '../../../../services/auditService'
 import CreateContactJourney = journeys.CreateContactJourney
+import TestData from '../../../testutils/testData'
+import PrisonerSearchService from '../../../../services/prisonerSearchService'
 
 jest.mock('../../../../services/auditService')
+jest.mock('../../../../services/prisonerSearchService')
 
 const auditService = new AuditService(null) as jest.Mocked<AuditService>
+const prisonerSearchService = new PrisonerSearchService(null) as jest.Mocked<PrisonerSearchService>
 
 let app: Express
 let session: Partial<SessionData>
@@ -32,6 +36,7 @@ beforeEach(() => {
   app = appWithAllRoutes({
     services: {
       auditService,
+      prisonerSearchService,
     },
     userSupplier: () => user,
     sessionReceiver: (receivedSession: Partial<SessionData>) => {
@@ -40,6 +45,7 @@ beforeEach(() => {
       session.createContactJourneys[journeyId] = { ...existingJourney }
     },
   })
+  prisonerSearchService.getByPrisonerNumber.mockResolvedValue(TestData.prisoner({ prisonerNumber }))
 })
 
 afterEach(() => {

--- a/server/routes/contacts/create/enter-estimated-dob/createContactEnterEstimatedDobController.test.ts
+++ b/server/routes/contacts/create/enter-estimated-dob/createContactEnterEstimatedDobController.test.ts
@@ -6,10 +6,14 @@ import * as cheerio from 'cheerio'
 import { appWithAllRoutes, user } from '../../../testutils/appSetup'
 import AuditService, { Page } from '../../../../services/auditService'
 import CreateContactJourney = journeys.CreateContactJourney
+import PrisonerSearchService from '../../../../services/prisonerSearchService'
+import TestData from '../../../testutils/testData'
 
 jest.mock('../../../../services/auditService')
+jest.mock('../../../../services/prisonerSearchService')
 
 const auditService = new AuditService(null) as jest.Mocked<AuditService>
+const prisonerSearchService = new PrisonerSearchService(null) as jest.Mocked<PrisonerSearchService>
 
 let app: Express
 let session: Partial<SessionData>
@@ -32,6 +36,7 @@ beforeEach(() => {
   app = appWithAllRoutes({
     services: {
       auditService,
+      prisonerSearchService,
     },
     userSupplier: () => user,
     sessionReceiver: (receivedSession: Partial<SessionData>) => {
@@ -40,6 +45,7 @@ beforeEach(() => {
       session.createContactJourneys[journeyId] = { ...existingJourney }
     },
   })
+  prisonerSearchService.getByPrisonerNumber.mockResolvedValue(TestData.prisoner({ prisonerNumber }))
 })
 
 afterEach(() => {

--- a/server/routes/contacts/create/enter-name/createContactEnterNameController.test.ts
+++ b/server/routes/contacts/create/enter-name/createContactEnterNameController.test.ts
@@ -8,12 +8,16 @@ import AuditService, { Page } from '../../../../services/auditService'
 import ReferenceDataService from '../../../../services/referenceDataService'
 import CreateContactJourney = journeys.CreateContactJourney
 import { mockedReferenceData } from '../../../testutils/stubReferenceData'
+import PrisonerSearchService from '../../../../services/prisonerSearchService'
+import TestData from '../../../testutils/testData'
 
 jest.mock('../../../../services/auditService')
 jest.mock('../../../../services/referenceDataService')
+jest.mock('../../../../services/prisonerSearchService')
 
 const auditService = new AuditService(null) as jest.Mocked<AuditService>
 const referenceDataService = new ReferenceDataService(null) as jest.Mocked<ReferenceDataService>
+const prisonerSearchService = new PrisonerSearchService(null) as jest.Mocked<PrisonerSearchService>
 
 let app: Express
 let session: Partial<SessionData>
@@ -33,6 +37,7 @@ beforeEach(() => {
     services: {
       auditService,
       referenceDataService,
+      prisonerSearchService,
     },
     userSupplier: () => user,
     sessionReceiver: (receivedSession: Partial<SessionData>) => {
@@ -42,6 +47,7 @@ beforeEach(() => {
     },
   })
   referenceDataService.getReferenceData.mockImplementation(mockedReferenceData)
+  prisonerSearchService.getByPrisonerNumber.mockResolvedValue(TestData.prisoner({ prisonerNumber }))
 })
 
 afterEach(() => {

--- a/server/routes/contacts/manage/contact-search/contactSearchController.test.ts
+++ b/server/routes/contacts/manage/contact-search/contactSearchController.test.ts
@@ -31,7 +31,6 @@ beforeEach(() => {
       lastName: 'last',
       prisonerNumber: 'A1234BC',
       dateOfBirth: '1986-06-27',
-      prisonId: 'MDI',
       prisonName: 'Moorland (HMP & YOI)',
     },
   }

--- a/server/routes/contacts/manage/contact-search/contactSearchController.ts
+++ b/server/routes/contacts/manage/contact-search/contactSearchController.ts
@@ -10,11 +10,8 @@ export default class ContactSearchController implements PageHandler {
   public PAGE_NAME = Page.CONTACT_SEARCH_PAGE
 
   GET = async (req: Request, res: Response): Promise<void> => {
-    const { user } = res.locals
-    const { journeyId, prisonerNumber } = req.params
+    const { journeyId } = req.params
     const journey = req.session.manageContactsJourneys[journeyId]
-
-    const prisonerDetails = await this.prisonerSearchService.getByPrisonerNumber(prisonerNumber as string, user)
 
     const view = {
       journey,
@@ -26,7 +23,7 @@ export default class ContactSearchController implements PageHandler {
       year: res.locals?.formResponses?.year ?? journey?.searchContact?.dateOfBirth?.year,
     }
 
-    res.render('pages/contacts/manage/contactSearch', { view, prisonerDetails, journey })
+    res.render('pages/contacts/manage/contactSearch', { view, journey })
   }
 
   POST = async (req: Request<{ journeyId: string }, ContactSearchSchemaType>, res: Response): Promise<void> => {

--- a/server/routes/contacts/manage/list/listContactsController.test.ts
+++ b/server/routes/contacts/manage/list/listContactsController.test.ts
@@ -44,7 +44,6 @@ beforeEach(() => {
           firstName: 'Jon',
           lastName: 'Harper',
           dateOfBirth: '1 Aug 1974',
-          prisonId: 'MDI',
           prisonName: 'Moorland HMP',
         },
       }

--- a/server/routes/contacts/manage/list/listContactsController.ts
+++ b/server/routes/contacts/manage/list/listContactsController.ts
@@ -13,18 +13,15 @@ export default class ListContactsController implements PageHandler {
   public PAGE_NAME = Page.LIST_CONTACTS_PAGE
 
   GET = async (req: Request<PrisonerJourneyParams, unknown, unknown>, res: Response): Promise<void> => {
-    const { user } = res.locals
+    const { user, prisonerDetails } = res.locals
     const { journeyId, prisonerNumber } = req.params
     const journey = req.session.manageContactsJourneys[journeyId]
-
-    const prisonerDetails = await this.prisonerSearchService.getByPrisonerNumber(prisonerNumber as string, user)
 
     journey.prisoner = {
       firstName: prisonerDetails?.firstName,
       lastName: prisonerDetails?.lastName,
       prisonerNumber: prisonerDetails?.prisonerNumber,
       dateOfBirth: prisonerDetails?.dateOfBirth,
-      prisonId: prisonerDetails?.prisonId,
       prisonName: prisonerDetails?.prisonName,
     }
 
@@ -34,7 +31,6 @@ export default class ListContactsController implements PageHandler {
     res.render('pages/contacts/manage/listContacts', {
       activeContacts,
       inactiveContacts,
-      prisonerDetails,
       journey,
     })
   }

--- a/server/routes/contacts/manage/manageContactsRoutes.ts
+++ b/server/routes/contacts/manage/manageContactsRoutes.ts
@@ -12,6 +12,7 @@ import { ContactsService, PrisonerSearchService } from '../../../services'
 import asyncMiddleware from '../../../middleware/asyncMiddleware'
 import ContactSearchController from './contact-search/contactSearchController'
 import { contactSearchSchema } from './contact-search/contactSearchSchema'
+import prisonerDetailsMiddleware from '../../../middleware/prisonerDetailsMiddleware'
 
 const ManageContactsRoutes = (
   auditService: AuditService,
@@ -63,6 +64,7 @@ const ManageContactsRoutes = (
   router.get(
     '/prisoner/:prisonerNumber/contacts/list/:journeyId',
     ensureInManageContactsJourney(),
+    prisonerDetailsMiddleware(prisonerSearchService),
     logPageViewMiddleware(auditService, listContactsController),
     asyncMiddleware(listContactsController.GET),
   )
@@ -81,6 +83,7 @@ const ManageContactsRoutes = (
   router.get(
     '/prisoner/:prisonerNumber/contacts/search/:journeyId',
     ensureInManageContactsJourney(),
+    prisonerDetailsMiddleware(prisonerSearchService),
     logPageViewMiddleware(auditService, contactsSearchController),
     asyncMiddleware(contactsSearchController.GET),
   )

--- a/server/routes/index.ts
+++ b/server/routes/index.ts
@@ -15,7 +15,7 @@ export default function routes({
 }: Services): Router {
   const router = Router({ mergeParams: true })
 
-  router.use('', CreateContactRoutes(auditService, contactsService, referenceDataService))
+  router.use('', CreateContactRoutes(auditService, contactsService, referenceDataService, prisonerSearchService))
   router.use('/', ManageContactsRoutes(auditService, prisonerSearchService, contactsService))
   router.use('/', HomeRoutes(auditService))
 

--- a/server/views/pages/contacts/common/partials/createContactBreadcrumbs.njk
+++ b/server/views/pages/contacts/common/partials/createContactBreadcrumbs.njk
@@ -13,7 +13,7 @@
         {% if journey.returnPoint.type === 'MANAGE_PRISONER_CONTACTS' %}
             {% set breadcrumbs = (breadcrumbs.push(
                 {
-                    text: "Prisoner Contacts",
+                    text: (prisonerDetails.lastName + ", " + prisonerDetails.firstName) | convertToTitleCase,
                     href: journey.returnPoint.url,
                     attributes: {"data-qa": "contact-list-breadcrumb-link"}
                 }

--- a/server/views/pages/contacts/common/selectRelationship.njk
+++ b/server/views/pages/contacts/common/selectRelationship.njk
@@ -3,6 +3,7 @@
 {% from "govuk/components/input/macro.njk" import govukInput %}
 {% from "govuk/components/select/macro.njk" import govukSelect %}
 {% from "govuk/components/button/macro.njk" import govukButton %}
+{% from "../../../partials/miniProfile/macro.njk" import miniProfile %}
 
 {% set pageTitle = applicationName + " - Enter name" %}
 {% set title = "How is " + journey.names.lastName + ", " + journey.names.firstName + " related to the prisoner?" %}
@@ -11,6 +12,7 @@
 {% block content %}
 
 {% include './partials/createContactBreadcrumbs.njk' %}
+{{ miniProfile(prisonerDetails) }}
 {% include '../../../partials/formErrorSummary.njk' %}
 <span class="govuk-caption-l">Manage Contacts</span>
 <h1 class="govuk-heading-l" data-qa="main-heading">{{ title }}</h1>

--- a/server/views/pages/contacts/create/checkAnswers.njk
+++ b/server/views/pages/contacts/create/checkAnswers.njk
@@ -2,6 +2,7 @@
 {% from "govuk/components/breadcrumbs/macro.njk" import govukBreadcrumbs %}
 {% from "govuk/components/button/macro.njk" import govukButton %}
 {% from "govuk/components/summary-list/macro.njk" import govukSummaryList %}
+{% from "../../../partials/miniProfile/macro.njk" import miniProfile %}
 
 {% set pageTitle = applicationName + " - Enter date of birth" %}
 {% set title = "Check your answers" %}
@@ -9,6 +10,7 @@
 
 {% block content %}
 {% include '../common/partials/createContactBreadcrumbs.njk' %}
+{{ miniProfile(prisonerDetails) }}
 {% include '../../../partials/formErrorSummary.njk' %}
 <span class="govuk-caption-l">Manage Contacts</span>
 <h1 class="govuk-heading-l" data-qa="main-heading">{{ title }}</h1>

--- a/server/views/pages/contacts/create/enterDob.njk
+++ b/server/views/pages/contacts/create/enterDob.njk
@@ -3,6 +3,7 @@
 {% from "govuk/components/date-input/macro.njk" import govukDateInput %}
 {% from "govuk/components/button/macro.njk" import govukButton %}
 {% from "govuk/components/radios/macro.njk" import govukRadios %}
+{% from "../../../partials/miniProfile/macro.njk" import miniProfile %}
 
 {% set pageTitle = applicationName + " - Enter date of birth" %}
 {% set title = "Do you know " + journey.names.lastName + ", " + journey.names.firstName + "'s date of birth?" %}
@@ -10,6 +11,7 @@
 
 {% block content %}
 {% include '../common/partials/createContactBreadcrumbs.njk' %}
+{{ miniProfile(prisonerDetails) }}
 {% include '../../../partials/formErrorSummary.njk' %}
 <span class="govuk-caption-l">Manage Contacts</span>
 <h1 class="govuk-heading-l" data-qa="main-heading">{{ title }}</h1>

--- a/server/views/pages/contacts/create/enterEstimatedDob.njk
+++ b/server/views/pages/contacts/create/enterEstimatedDob.njk
@@ -1,8 +1,8 @@
 {% extends "../../../partials/layout.njk" %}
 {% from "govuk/components/breadcrumbs/macro.njk" import govukBreadcrumbs %}
-{% from "govuk/components/date-input/macro.njk" import govukDateInput %}
 {% from "govuk/components/button/macro.njk" import govukButton %}
 {% from "govuk/components/radios/macro.njk" import govukRadios %}
+{% from "../../../partials/miniProfile/macro.njk" import miniProfile %}
 
 {% set pageTitle = applicationName + " - Enter date of birth" %}
 {% set title = "Is " + journey.names.lastName + ", " + journey.names.firstName + " over 18 years old?" %}
@@ -10,6 +10,7 @@
 
 {% block content %}
 {% include '../common/partials/createContactBreadcrumbs.njk' %}
+{{ miniProfile(prisonerDetails) }}
 {% include '../../../partials/formErrorSummary.njk' %}
 <span class="govuk-caption-l">Manage Contacts</span>
 <h1 class="govuk-heading-l" data-qa="main-heading">{{ title }}</h1>

--- a/server/views/pages/contacts/create/enterName.njk
+++ b/server/views/pages/contacts/create/enterName.njk
@@ -3,7 +3,7 @@
 {% from "govuk/components/input/macro.njk" import govukInput %}
 {% from "govuk/components/select/macro.njk" import govukSelect %}
 {% from "govuk/components/button/macro.njk" import govukButton %}
-
+{% from "../../../partials/miniProfile/macro.njk" import miniProfile %}
 {% set pageTitle = applicationName + " - Enter name" %}
 {% set title = "What is the contacts name?" %}
 {% set mainClasses = "app-container govuk-body" %}
@@ -11,6 +11,7 @@
 {% block content %}
 
 {% include '../common/partials/createContactBreadcrumbs.njk' %}
+{{ miniProfile(prisonerDetails) }}
 {% include '../../../partials/formErrorSummary.njk' %}
 <span class="govuk-caption-l">Manage Contacts</span>
 <h1 class="govuk-heading-l" data-qa="main-heading">{{ title }}</h1>

--- a/server/views/pages/contacts/manage/contactSearch.njk
+++ b/server/views/pages/contacts/manage/contactSearch.njk
@@ -34,7 +34,7 @@
   </div>
 </div>
 
-{{ miniProfile(prisonerDetails, '/prisoner-image/' + prisonerDetails.prisonerNumber, digitalPrisonServicesUrl + '/prisoner/' + prisonerDetails.prisonerNumber) }}
+{{ miniProfile(prisonerDetails) }}
 
 {% include '../../../partials/formErrorSummary.njk' %}
 <span class="govuk-caption-l">Manage Contacts</span>

--- a/server/views/pages/contacts/manage/listContacts.njk
+++ b/server/views/pages/contacts/manage/listContacts.njk
@@ -31,8 +31,7 @@
     </div>
 </div>
 
-{# Test the mini profile macro #}
-{{ miniProfile(prisonerDetails, '/prisoner-image/' + prisonerDetails.prisonerNumber, digitalPrisonServicesUrl + '/prisoner/' + prisonerDetails.prisonerNumber) }}
+{{ miniProfile(prisonerDetails) }}
 
 {% macro createTable(contactsList) %}
     <table class="govuk-table">

--- a/server/views/partials/miniProfile/macro.njk
+++ b/server/views/partials/miniProfile/macro.njk
@@ -1,9 +1,7 @@
 {#
  Parameters:
-    person = prisoner details - object from prisoner search
-    personImgUrl = path to the local route to get the image data
-    personProfileUrl = URL to the prisoner's profile page
+    miniProfile = a components.PrisonerDetails entity. Can be populated by prisonerDetailsMiddleware() middleware.
 #}
-{% macro miniProfile(person, personImgUrl, personProfileUrl) %}
+{% macro miniProfile(prisonerDetails) %}
     {%- include "./template.njk" -%}
 {% endmacro %}

--- a/server/views/partials/miniProfile/template.njk
+++ b/server/views/partials/miniProfile/template.njk
@@ -1,27 +1,28 @@
 <div class="mini-profile govuk-!-margin-top-7" data-qa="mini-profile">
+    {% set formattedName =  (prisonerDetails.lastName + ", " + prisonerDetails.firstName) | convertToTitleCase %}
     <div class="mini-profile-inner">
         <div class="mini-profile-left">
-            <img class="mini-profile-person-img" src="{{ personImgUrl }}" alt="Image of {{ (person.lastName + ", " + person.firstName) | convertToTitleCase }}" loading="lazy" data-qa="mini-profile-person-img">
+            <img class="mini-profile-person-img" src="/prisoner-image/{{ prisonerDetails.prisonerNumber}}" alt="Image of {{ formattedName }}" loading="lazy" data-qa="mini-profile-person-img">
         </div>
         <div class="mini-profile-right">
             <ul class="mini-profile-info">
                 <li>
                     <p class="govuk-heading-s govuk-!-margin-bottom-1">
-                        <a id="mini-profile-link" class="govuk-link--no-visited-state" href="{{ personProfileUrl }}" target="_blank" data-qa="mini-profile-person-profile-link">{{ (person.lastName + ", " + person.firstName) | convertToTitleCase }}</a>
+                        <a id="mini-profile-link" class="govuk-link--no-visited-state" href="{{ digitalPrisonServicesUrl }}/prisoner/{{ prisonerDetails.prisonerNumber }}" target="_blank" data-qa="mini-profile-person-profile-link">{{ formattedName }}</a>
                     </p>
-                    <span class="govuk-body" data-qa="mini-profile-prisoner-number">{{ person.prisonerNumber }}</span>
+                    <span class="govuk-body" data-qa="mini-profile-prisoner-number">{{ prisonerDetails.prisonerNumber }}</span>
                 </li>
                 <li>
                      <span class="govuk-heading-s govuk-!-margin-bottom-0 govuk-!-padding-0">Date of birth</span>
-                     <span class="govuk-body" data-qa="mini-profile-dob">{{ person.dateOfBirth | formatDate }}</span>
+                     <span class="govuk-body" data-qa="mini-profile-dob">{{ prisonerDetails.dateOfBirth | formatDate }}</span>
                 </li>
                 <li>
                     <span class="govuk-heading-s govuk-!-margin-bottom-0 govuk-!-padding-0">Establishment</span>
-                    <span class="govuk-body" data-qa="mini-profile-prison-name">{{ person.prisonName }}</span>
+                    <span class="govuk-body" data-qa="mini-profile-prison-name">{{ prisonerDetails.prisonName }}</span>
                 </li>
                 <li>
                     <span class="govuk-heading-s govuk-!-margin-bottom-0 govuk-!-padding-0">Cell number</span>
-                    <span class="govuk-body" data-qa="mini-profile-cell-location">{{ person.cellLocation }}</span>
+                    <span class="govuk-body" data-qa="mini-profile-cell-location">{{ prisonerDetails.cellLocation }}</span>
                 </li>
             </ul>
         </div>


### PR DESCRIPTION
Move the loading of prisoner details to middleware to make it easier when it's only needed for mini profile.

Small changes to mini profile to make the import simpler.