### PR TITLE
PRC-53: Standardise formatting of name

### DIFF
--- a/integration_tests/e2e/createContacts.cy.ts
+++ b/integration_tests/e2e/createContacts.cy.ts
@@ -94,21 +94,21 @@ context('Create Contacts', () => {
       .enterMiddleName('Middle')
       .clickContinue()
 
-    Page.verifyOnPage(SelectRelationshipPage, 'Last, First') //
+    Page.verifyOnPage(SelectRelationshipPage, 'Last, First Middle') //
       .hasSelectedRelationshipHint('')
       .selectRelationship('MOT')
-      .hasSelectedRelationshipHint("Last, First is the prisoner's mother")
+      .hasSelectedRelationshipHint("Last, First Middle is the prisoner's mother")
       .clickContinue()
 
-    Page.verifyOnPage(SelectEmergencyContactPage, 'Last, First') //
+    Page.verifyOnPage(SelectEmergencyContactPage, 'Last, First Middle') //
       .selectIsEmergencyContact('YES')
       .clickContinue()
 
-    Page.verifyOnPage(SelectNextOfKinPage, 'Last, First') //
+    Page.verifyOnPage(SelectNextOfKinPage, 'Last, First Middle') //
       .selectIsNextOfKin('NO')
       .clickContinue()
 
-    Page.verifyOnPage(EnterContactDateOfBirthPage, 'Last, First') //
+    Page.verifyOnPage(EnterContactDateOfBirthPage, 'Last, First Middle') //
       .selectIsKnown('YES')
       .enterDay('15')
       .enterMonth('06')
@@ -116,7 +116,7 @@ context('Create Contacts', () => {
       .clickContinue()
 
     Page.verifyOnPage(CreateContactCheckYourAnswersPage) //
-      .verifyShowsNameAs('Last, First')
+      .verifyShowsNameAs('Last, First Middle')
       .verifyShowsDateOfBirthAs('15 June 1982')
       .verifyShowRelationshipAs('Mother')
       .verifyShowIsEmergencyContactAs('Yes')

--- a/integration_tests/e2e/createContactsCheckAnswersChangeOther.cy.ts
+++ b/integration_tests/e2e/createContactsCheckAnswersChangeOther.cy.ts
@@ -25,19 +25,19 @@ context('Create contact and update from check answers excluding DOB changes', ()
       .enterLastName('Last')
       .enterMiddleName('Middle')
       .enterFirstName('First')
-      .continueTo(SelectRelationshipPage, 'Last, First') //
+      .continueTo(SelectRelationshipPage, 'Last, First Middle')
       .selectRelationship('MOT')
-      .continueTo(SelectEmergencyContactPage, 'Last, First') //
+      .continueTo(SelectEmergencyContactPage, 'Last, First Middle')
       .selectIsEmergencyContact('NO')
-      .continueTo(SelectNextOfKinPage, 'Last, First') //
+      .continueTo(SelectNextOfKinPage, 'Last, First Middle')
       .selectIsNextOfKin('NO')
-      .continueTo(EnterContactDateOfBirthPage, 'Last, First') //
+      .continueTo(EnterContactDateOfBirthPage, 'Last, First Middle')
       .selectIsKnown('YES')
       .enterDay('15')
       .enterMonth('06')
       .enterYear('1982')
-      .continueTo(CreateContactCheckYourAnswersPage) //
-      .verifyShowsNameAs('Last, First')
+      .continueTo(CreateContactCheckYourAnswersPage)
+      .verifyShowsNameAs('Last, First Middle')
       .verifyShowsDateOfBirthAs('15 June 1982')
       .verifyShowRelationshipAs('Mother')
       .verifyShowIsEmergencyContactAs('No')
@@ -46,7 +46,7 @@ context('Create contact and update from check answers excluding DOB changes', ()
 
   it('Can change a contacts names when creating a new contact', () => {
     Page.verifyOnPage(CreateContactCheckYourAnswersPage) //
-      .verifyShowsNameAs('Last, First')
+      .verifyShowsNameAs('Last, First Middle')
       .clickChangeNameLink()
 
     Page.verifyOnPage(EnterNamePage) //
@@ -57,7 +57,7 @@ context('Create contact and update from check answers excluding DOB changes', ()
       .clickContinue()
 
     Page.verifyOnPage(CreateContactCheckYourAnswersPage) //
-      .verifyShowsNameAs('Last Updated, First Updated')
+      .verifyShowsNameAs('Last Updated, First Updated Middle Updated')
       .clickCreatePrisonerContact()
 
     Page.verifyOnPage(CreatedContactPage)
@@ -89,10 +89,10 @@ context('Create contact and update from check answers excluding DOB changes', ()
       .verifyShowRelationshipAs('Mother')
       .clickChangeRelationshipLink()
 
-    Page.verifyOnPage(SelectRelationshipPage, 'Last, First') //
-      .hasSelectedRelationshipHint("Last, First is the prisoner's mother")
+    Page.verifyOnPage(SelectRelationshipPage, 'Last, First Middle') //
+      .hasSelectedRelationshipHint("Last, First Middle is the prisoner's mother")
       .selectRelationship('FA')
-      .hasSelectedRelationshipHint("Last, First is the prisoner's father")
+      .hasSelectedRelationshipHint("Last, First Middle is the prisoner's father")
       .clickContinue()
 
     Page.verifyOnPage(CreateContactCheckYourAnswersPage) //
@@ -128,7 +128,7 @@ context('Create contact and update from check answers excluding DOB changes', ()
       .verifyShowIsEmergencyContactAs('No')
       .clickChangeEmergencyContactLink()
 
-    Page.verifyOnPage(SelectEmergencyContactPage, 'Last, First') //
+    Page.verifyOnPage(SelectEmergencyContactPage, 'Last, First Middle') //
       .selectIsEmergencyContact('YES')
       .clickContinue()
 
@@ -165,7 +165,7 @@ context('Create contact and update from check answers excluding DOB changes', ()
       .verifyShowIsNextOfKinAs('No')
       .clickChangeNextOfKinLink()
 
-    Page.verifyOnPage(SelectNextOfKinPage, 'Last, First') //
+    Page.verifyOnPage(SelectNextOfKinPage, 'Last, First Middle') //
       .selectIsNextOfKin('YES')
       .clickContinue()
 

--- a/server/routes/contacts/common/emergency-contact/emergencyContactController.test.ts
+++ b/server/routes/contacts/common/emergency-contact/emergencyContactController.test.ts
@@ -70,7 +70,7 @@ describe('GET /prisoner/:prisonerNumber/contacts/create/select-emergency-contact
 
     const $ = cheerio.load(response.text)
     expect($('[data-qa=main-heading]').first().text().trim()).toStrictEqual(
-      'Is last, first an emergency contact for the prisoner?',
+      'Is Last, First an emergency contact for the prisoner?',
     )
     expect($('[data-qa=cancel-button]').first().attr('href')).toStrictEqual('/foo-bar')
     expect($('[data-qa=contact-list-breadcrumb-link]').first().attr('href')).toStrictEqual('/foo-bar')

--- a/server/routes/contacts/common/next-of-kin/nextOfKinController.test.ts
+++ b/server/routes/contacts/common/next-of-kin/nextOfKinController.test.ts
@@ -71,7 +71,7 @@ describe('GET /prisoner/:prisonerNumber/contacts/create/select-next-of-kin/:jour
 
     const $ = cheerio.load(response.text)
     expect($('[data-qa=main-heading]').first().text().trim()).toStrictEqual(
-      'Is last, first next of kin for the prisoner?',
+      'Is Last, First next of kin for the prisoner?',
     )
     expect($('[data-qa=cancel-button]').first().attr('href')).toStrictEqual('/foo-bar')
     expect($('[data-qa=contact-list-breadcrumb-link]').first().attr('href')).toStrictEqual('/foo-bar')

--- a/server/routes/contacts/create/enter-dob/createContactEnterDobController.test.ts
+++ b/server/routes/contacts/create/enter-dob/createContactEnterDobController.test.ts
@@ -64,7 +64,7 @@ describe('GET /prisoner/:prisonerNumber/contacts/create/enter-dob/:journeyId', (
     expect(response.status).toEqual(200)
 
     const $ = cheerio.load(response.text)
-    expect($('[data-qa=main-heading]').first().text().trim()).toStrictEqual("Do you know last, first's date of birth?")
+    expect($('[data-qa=main-heading]').first().text().trim()).toStrictEqual("Do you know Last, First's date of birth?")
     expect($('[data-qa=cancel-button]').first().attr('href')).toStrictEqual('/foo-bar')
     expect($('[data-qa=contact-list-breadcrumb-link]').first().attr('href')).toStrictEqual('/foo-bar')
   })

--- a/server/routes/contacts/create/enter-estimated-dob/createContactEnterEstimatedDobController.test.ts
+++ b/server/routes/contacts/create/enter-estimated-dob/createContactEnterEstimatedDobController.test.ts
@@ -66,7 +66,7 @@ describe('GET /prisoner/:prisonerNumber/contacts/create/enter-estimated-dob/:jou
     expect(response.status).toEqual(200)
 
     const $ = cheerio.load(response.text)
-    expect($('[data-qa=main-heading]').first().text().trim()).toStrictEqual('Is last, first over 18 years old?')
+    expect($('[data-qa=main-heading]').first().text().trim()).toStrictEqual('Is Last, First over 18 years old?')
     expect($('[data-qa=cancel-button]').first().attr('href')).toStrictEqual('/foo-bar')
     expect($('[data-qa=contact-list-breadcrumb-link]').first().attr('href')).toStrictEqual('/foo-bar')
   })

--- a/server/utils/formatName.test.ts
+++ b/server/utils/formatName.test.ts
@@ -1,0 +1,44 @@
+import ContactNames = journeys.ContactNames
+import PrisonerDetails = journeys.PrisonerDetails
+import formatName from './formatName'
+import { Prisoner } from '../data/prisonerOffenderSearchTypes'
+
+describe('formatName', () => {
+  const is: <T>(value: T) => T = value => value
+
+  it.each([
+    [is<ContactNames>({ lastName: 'Last', firstName: 'First' }), 'Last, First'],
+    [is<ContactNames>({ lastName: 'Last', firstName: 'First', middleName: 'Middle' }), 'Last, First Middle'],
+    [is<ContactNames>({ lastName: 'last', firstName: 'first', middleName: 'middle' }), 'Last, First Middle'],
+    [is<ContactNames>({ lastName: 'LAST', firstName: 'FIRST', middleName: 'MIDDLE' }), 'Last, First Middle'],
+  ])('should format journey ContactNames', (names: ContactNames, expected: string) => {
+    expect(formatName(names)).toStrictEqual(expected)
+  })
+
+  it.each([
+    [is<Partial<PrisonerDetails>>({ lastName: 'Last', firstName: 'First' }), 'Last, First'],
+    [is<Partial<PrisonerDetails>>({ lastName: 'last', firstName: 'first' }), 'Last, First'],
+    [is<Partial<PrisonerDetails>>({ lastName: 'LAST', firstName: 'FIRST' }), 'Last, First'],
+  ])('should format journey PrisonerDetails', (names: PrisonerDetails, expected: string) => {
+    expect(formatName(names)).toStrictEqual(expected)
+  })
+
+  it.each([
+    [is<Partial<Prisoner>>({ lastName: 'Last', firstName: 'First' }), 'Last, First'],
+    [
+      is<Partial<Prisoner>>({ lastName: 'Last', firstName: 'First', middleNames: 'Middle Names' }),
+      'Last, First Middle Names',
+    ],
+    [is<Partial<Prisoner>>({ lastName: 'last', firstName: 'first' }), 'Last, First'],
+    [is<Partial<Prisoner>>({ lastName: 'LAST', firstName: 'FIRST' }), 'Last, First'],
+  ])('should format search Prisoner', (names: Prisoner, expected: string) => {
+    expect(formatName(names)).toStrictEqual(expected)
+  })
+
+  it.each([
+    [is<ContactNames>({ lastName: 'Last', firstName: 'First', middleName: 'Middle' }), 'Last, First'],
+    [is<Partial<Prisoner>>({ lastName: 'Last', firstName: 'First', middleNames: 'Middle Names' }), 'Last, First'],
+  ])('should exclude middle names if requested', (names: ContactNames | Prisoner, expected: string) => {
+    expect(formatName(names, { excludeMiddleNames: true })).toStrictEqual(expected)
+  })
+})

--- a/server/utils/formatName.ts
+++ b/server/utils/formatName.ts
@@ -1,0 +1,20 @@
+import { convertToTitleCase } from './utils'
+import PrisonerDetails = journeys.PrisonerDetails
+import ContactNames = journeys.ContactNames
+
+const formatName = (
+  val: { lastName: string; firstName: string; middleName?: string } | ContactNames | PrisonerDetails,
+  opts?: { excludeMiddleNames?: boolean },
+): string => {
+  let name = `${val.lastName}, ${val.firstName}`
+  if (!opts?.excludeMiddleNames) {
+    if ('middleName' in val && val.middleName) {
+      name += ` ${val.middleName}`
+    } else if ('middleNames' in val && val.middleNames) {
+      name += ` ${val.middleNames}`
+    }
+  }
+  return convertToTitleCase(name)
+}
+
+export default formatName

--- a/server/utils/nunjucksSetup.ts
+++ b/server/utils/nunjucksSetup.ts
@@ -9,6 +9,7 @@ import logger from '../../logger'
 import { buildErrorSummaryList, findError } from '../middleware/validationMiddleware'
 import addressToLines from './addressToLines'
 import formatYesNo from './formatYesNo'
+import formatName from './formatName'
 
 export default function nunjucksSetup(app: express.Express): void {
   app.set('view engine', 'njk')
@@ -64,4 +65,5 @@ export default function nunjucksSetup(app: express.Express): void {
   njkEnv.addFilter('getFormatDistanceToNow', getFormatDistanceToNow)
   njkEnv.addFilter('formatDate', formatDate)
   njkEnv.addFilter('formatYesNo', formatYesNo)
+  njkEnv.addFilter('formatName', formatName)
 }

--- a/server/views/pages/contacts/common/partials/createContactBreadcrumbs.njk
+++ b/server/views/pages/contacts/common/partials/createContactBreadcrumbs.njk
@@ -13,7 +13,7 @@
         {% if journey.returnPoint.type === 'MANAGE_PRISONER_CONTACTS' %}
             {% set breadcrumbs = (breadcrumbs.push(
                 {
-                    text: (prisonerDetails.lastName + ", " + prisonerDetails.firstName) | convertToTitleCase,
+                    text: prisonerDetails | formatName(excludeMiddleNames = true),
                     href: journey.returnPoint.url,
                     attributes: {"data-qa": "contact-list-breadcrumb-link"}
                 }

--- a/server/views/pages/contacts/common/selectEmergencyContact.njk
+++ b/server/views/pages/contacts/common/selectEmergencyContact.njk
@@ -6,7 +6,7 @@
 {% from "../../../partials/miniProfile/macro.njk" import miniProfile %}
 
 {% set pageTitle = applicationName + " - Select emergency contact" %}
-{% set title = "Is " + journey.names.lastName + ", " + journey.names.firstName + " an emergency contact for the prisoner?" %}
+{% set title = "Is " + journey.names | formatName + " an emergency contact for the prisoner?" %}
 {% set mainClasses = "app-container govuk-body" %}
 
 {% block content %}

--- a/server/views/pages/contacts/common/selectNextOfKin.njk
+++ b/server/views/pages/contacts/common/selectNextOfKin.njk
@@ -6,7 +6,7 @@
 {% from "../../../partials/miniProfile/macro.njk" import miniProfile %}
 
 {% set pageTitle = applicationName + " - Select next of kin" %}
-{% set title = "Is " + journey.names.lastName + ", " + journey.names.firstName + " next of kin for the prisoner?" %}
+{% set title = "Is " + journey.names | formatName + " next of kin for the prisoner?" %}
 {% set mainClasses = "app-container govuk-body" %}
 
 {% block content %}

--- a/server/views/pages/contacts/common/selectRelationship.njk
+++ b/server/views/pages/contacts/common/selectRelationship.njk
@@ -6,7 +6,7 @@
 {% from "../../../partials/miniProfile/macro.njk" import miniProfile %}
 
 {% set pageTitle = applicationName + " - Enter name" %}
-{% set title = "How is " + journey.names.lastName + ", " + journey.names.firstName + " related to the prisoner?" %}
+{% set title = "How is " + journey.names | formatName + " related to the prisoner?" %}
 {% set mainClasses = "app-container govuk-body" %}
 
 {% block content %}
@@ -30,7 +30,7 @@
                     items: relationshipOptions,
                     errorMessage: validationErrors | findError('relationship')
                 }) }}
-                <div id="selected-relationship-hint" data-contact="{{ journey.names.lastName }}, {{ journey.names.firstName }}"></div>
+                <div id="selected-relationship-hint" data-contact="{{ journey.names | formatName }}"></div>
                 <div class="govuk-button-group">
                     {{ govukButton({
                         html: "Continue",

--- a/server/views/pages/contacts/create/checkAnswers.njk
+++ b/server/views/pages/contacts/create/checkAnswers.njk
@@ -26,7 +26,7 @@
                             text: "Name"
                         },
                         value: {
-                            html: journey.names.lastName + ", " + journey.names.firstName,
+                            html: journey.names | formatName,
                             classes: 'check-answers-name-value'
                         },
                         actions: {

--- a/server/views/pages/contacts/create/enterDob.njk
+++ b/server/views/pages/contacts/create/enterDob.njk
@@ -6,7 +6,7 @@
 {% from "../../../partials/miniProfile/macro.njk" import miniProfile %}
 
 {% set pageTitle = applicationName + " - Enter date of birth" %}
-{% set title = "Do you know " + journey.names.lastName + ", " + journey.names.firstName + "'s date of birth?" %}
+{% set title = "Do you know " + journey.names | formatName + "'s date of birth?" %}
 {% set mainClasses = "app-container govuk-body" %}
 
 {% block content %}

--- a/server/views/pages/contacts/create/enterEstimatedDob.njk
+++ b/server/views/pages/contacts/create/enterEstimatedDob.njk
@@ -5,7 +5,7 @@
 {% from "../../../partials/miniProfile/macro.njk" import miniProfile %}
 
 {% set pageTitle = applicationName + " - Enter date of birth" %}
-{% set title = "Is " + journey.names.lastName + ", " + journey.names.firstName + " over 18 years old?" %}
+{% set title = "Is " + journey.names | formatName + " over 18 years old?" %}
 {% set mainClasses = "app-container govuk-body" %}
 
 {% block content %}

--- a/server/views/pages/contacts/manage/contactSearch.njk
+++ b/server/views/pages/contacts/manage/contactSearch.njk
@@ -26,7 +26,7 @@
               href: "/"
           },
           {
-            text: prisonerDetails.lastName | convertToTitleCase + ", " + prisonerDetails.firstName | convertToTitleCase,
+            text: prisonerDetails | formatName(excludeMiddleNames = true),
             href: prisonerResultsLink
         }
       ]

--- a/server/views/pages/contacts/manage/listContacts.njk
+++ b/server/views/pages/contacts/manage/listContacts.njk
@@ -97,7 +97,7 @@
 {% endmacro %}
 
 <span class="govuk-caption-l">Manage Contacts</span>
-<h1 class="govuk-heading-l">Contacts for {{ journey.prisoner.lastName | convertToTitleCase }}, {{ journey.prisoner.firstName | convertToTitleCase }}</h1>
+<h1 class="govuk-heading-l">Contacts for {{ journey.prisoner | formatName(excludeMiddleNames = true) }}</h1>
 
     {{ govukButton({
         text: "Add prisoner contact",

--- a/server/views/pages/contacts/manage/prisonerSearchResults.njk
+++ b/server/views/pages/contacts/manage/prisonerSearchResults.njk
@@ -85,7 +85,7 @@
             {% for result in results.content %}
                 {% set prisonerNameHtml %}
                    <a href="/prisoner/{{ result.prisonerNumber }}/contacts/list/{{journey.id}}" class="govuk-link govuk-link--no-visited-state bapv-result-row">
-                      {{ (result.lastName + ", " + result.firstName) | convertToTitleCase }}
+                      {{ result | formatName(excludeMiddleNames = true) }}
                    </a>
                 {% endset %}
 

--- a/server/views/partials/miniProfile/template.njk
+++ b/server/views/partials/miniProfile/template.njk
@@ -1,5 +1,5 @@
 <div class="mini-profile govuk-!-margin-top-7" data-qa="mini-profile">
-    {% set formattedName =  (prisonerDetails.lastName + ", " + prisonerDetails.firstName) | convertToTitleCase %}
+    {% set formattedName =  prisonerDetails | formatName(excludeMiddleNames = true) %}
     <div class="mini-profile-inner">
         <div class="mini-profile-left">
             <img class="mini-profile-person-img" src="/prisoner-image/{{ prisonerDetails.prisonerNumber}}" alt="Image of {{ formattedName }}" loading="lazy" data-qa="mini-profile-person-img">


### PR DESCRIPTION
Add a nunjucks filter for formatting objects with names to be used with prisoners and contacts. Prisoners currently do not show middle names while contacts do as per relevant tickets.

Capitalisation and middle names were missing from create journey so those have been fixed as a result.