### PR TITLE
PRC-45: Link up existing contact flow

### DIFF
--- a/integration_tests/e2e/addExistingContact.cy.ts
+++ b/integration_tests/e2e/addExistingContact.cy.ts
@@ -1,0 +1,100 @@
+import Page from '../pages/page'
+import CreateContactCheckYourAnswersPage from '../pages/createContactCheckYourAnswersPage'
+import TestData from '../../server/routes/testutils/testData'
+import ListContactsPage from '../pages/listContacts'
+import SelectRelationshipPage from '../pages/selectRelationshipPage'
+import SelectEmergencyContactPage from '../pages/selectEmergencyContactPage'
+import SelectNextOfKinPage from '../pages/selectNextOfKinPage'
+import RelationshipCommentsPage from '../pages/relationshipCommentsPage'
+import SearchContactPage from '../pages/searchContactPage'
+
+context('Create Contacts', () => {
+  const { prisonerNumber } = TestData.prisoner()
+  const contactId = 654321
+  const contact = TestData.contacts({ id: contactId, lastName: 'Contact', firstName: 'Existing', middleName: '' })
+
+  beforeEach(() => {
+    cy.task('reset')
+    cy.task('stubComponentsMeta')
+    cy.task('stubSignIn', { roles: ['PRISON'] })
+    cy.task('stubTitlesReferenceData')
+    cy.task('stubRelationshipReferenceData')
+    cy.task('stubPrisonerById', TestData.prisoner())
+    cy.task('stubContactList', prisonerNumber)
+    cy.task('stubGetContactById', contact)
+    cy.task('stubContactSearch', {
+      results: {
+        totalPages: 1,
+        totalElements: 1,
+        content: [contact],
+      },
+      lastName: 'FOO',
+      firstName: '',
+      middleName: '',
+      dateOfBirth: '',
+    })
+
+    cy.signIn()
+    cy.visit(`/prisoner/${prisonerNumber}/contacts/list`)
+
+    Page.verifyOnPage(ListContactsPage) //
+      .clickAddNewContactButton()
+
+    Page.verifyOnPage(SearchContactPage) //
+      .enterLastName('FOO')
+      .clickSearchButton()
+
+    Page.verifyOnPage(SearchContactPage) //
+      .verifyShowsTheContactIsNotListedAs('The contact is not listed')
+      .clickTheContactLink(contactId)
+  })
+
+  it('Can add an existing contact with only required fields', () => {
+    // TODO Confirm contact page goes here
+
+    Page.verifyOnPage(SelectRelationshipPage, 'Contact, Existing') //
+      .hasSelectedRelationshipHint('')
+      .selectRelationship('MOT')
+      .hasSelectedRelationshipHint("Contact, Existing is the prisoner's mother")
+      .clickContinue()
+
+    Page.verifyOnPage(SelectEmergencyContactPage, 'Contact, Existing') //
+      .selectIsEmergencyContact('NO')
+      .clickContinue()
+
+    Page.verifyOnPage(SelectNextOfKinPage, 'Contact, Existing') //
+      .selectIsNextOfKin('YES')
+      .clickContinue()
+
+    Page.verifyOnPage(RelationshipCommentsPage, 'Contact, Existing').clickContinue()
+
+    Page.verifyOnPage(CreateContactCheckYourAnswersPage) //
+      .verifyShowsNameAs('Contact, Existing')
+      // .verifyShowsDateOfBirthAs('Not provided')
+      // .verifyShowsEstimatedDateOfBirthAs("I don't know")
+      .verifyShowRelationshipAs('Mother')
+      .verifyShowIsEmergencyContactAs('No')
+      .verifyShowIsNextOfKinAs('Yes')
+    // TODO Confirm create relationship and check answers
+    // verifyNameNotChangeable
+    // verifyDOBNotChangeable
+    // .clickAddPrisonerContact()
+
+    // Page.verifyOnPage(ListContactsPage)
+    // cy.verifyLastAPICall(
+    //   {
+    //     method: 'POST',
+    //     urlPath: `/contact/${contactId}/relationship`,
+    //   },
+    //   {
+    //     relationship: {
+    //       prisonerNumber: 'A1234BC',
+    //       relationshipCode: 'MOT',
+    //       isNextOfKin: true,
+    //       isEmergencyContact: false,
+    //     },
+    //     createdBy: 'USER1',
+    //   },
+    // )
+  })
+})

--- a/integration_tests/mockApis/contactsApi.ts
+++ b/integration_tests/mockApis/contactsApi.ts
@@ -82,6 +82,20 @@ export default {
     })
   },
 
+  stubGetContactById: (contact: { id: number }): SuperAgentRequest => {
+    return stubFor({
+      request: {
+        method: 'GET',
+        urlPath: `/contact/${contact.id}`,
+      },
+      response: {
+        status: 200,
+        headers: { 'Content-Type': 'application/json;charset=UTF-8' },
+        jsonBody: contact,
+      },
+    })
+  },
+
   stubTitlesReferenceData: (): SuperAgentRequest => {
     return stubFor({
       request: {

--- a/integration_tests/pages/searchContactPage.ts
+++ b/integration_tests/pages/searchContactPage.ts
@@ -63,6 +63,10 @@ export default class SearchContactPage extends Page {
     this.theContactIsNotListedLink().click()
   }
 
+  clickTheContactLink(contactId: number) {
+    this.contactLink(contactId).click()
+  }
+
   private firstNameTextBox = (): PageElement => cy.get('#firstName')
 
   private middleNameTextBox = (): PageElement => cy.get('#middleName')
@@ -78,6 +82,8 @@ export default class SearchContactPage extends Page {
   private searchButton = (): PageElement => cy.get('[data-qa=search-button]')
 
   private theContactIsNotListedLink = (): PageElement => cy.get('[data-qa="contact-not-listed-link"]')
+
+  private contactLink = (contactId: number): PageElement => cy.get(`[data-qa="add-contact-${contactId}-link"]`)
 
   private checkContactSearchTableNameValue = (): PageElement =>
     cy.get('.govuk-table__body > :nth-child(1) > :nth-child(1)')

--- a/server/@types/contactsApiClient/index.d.ts
+++ b/server/@types/contactsApiClient/index.d.ts
@@ -7,4 +7,5 @@ declare namespace contactsApiClientTypes {
   export type ReferenceCode = components['schemas']['ReferenceCode']
   export type ContactSearchRequest = components['schemas']['ContactSearchRequest']
   export type Pageable = components['schema']['Pageable']
+  export type AddContactRelationshipRequest = components['schema']['AddContactRelationshipRequest']
 }

--- a/server/@types/journeys/index.d.ts
+++ b/server/@types/journeys/index.d.ts
@@ -14,6 +14,7 @@ declare namespace journeys {
     dateOfBirth?: DateOfBirth
     relationship?: PrisonerContactRelationship
     previousAnswers?: CreateContactJourneyPreviousAnswers
+    contactId?: number
   }
 
   export interface ContactNames {

--- a/server/data/contactsApiClient.test.ts
+++ b/server/data/contactsApiClient.test.ts
@@ -185,4 +185,51 @@ describe('contactsApiClient', () => {
       expect(output).toEqual(results)
     })
   })
+  describe('getContact', () => {
+    it('should create the request and return the response', async () => {
+      // Given
+      const expectedContact: Contact = {
+        id: 123456,
+        lastName: 'last',
+        firstName: 'middle',
+        middleName: 'first',
+        dateOfBirth: '1980-12-10T00:00:00.000Z',
+        createdBy: user.username,
+        createdTime: '2024-01-01',
+      }
+      fakeContactsApi
+        .get('/contact/123456')
+        .matchHeader('authorization', `Bearer systemToken`)
+        .reply(200, expectedContact)
+
+      // When
+      const createdContact = await contactsApiClient.getContact(123456, user)
+
+      // Then
+      expect(createdContact).toEqual(expectedContact)
+    })
+
+    it.each([401, 403])('should propagate errors', async (errorCode: number) => {
+      // Given
+      const expectedErrorBody = {
+        status: errorCode,
+        userMessage: 'Some error',
+        developerMessage: 'Some error',
+      }
+
+      fakeContactsApi
+        .get('/contact/123456')
+        .matchHeader('authorization', `Bearer systemToken`)
+        .reply(errorCode, expectedErrorBody)
+
+      // When
+      try {
+        await contactsApiClient.getContact(123456, user)
+      } catch (e) {
+        // Then
+        expect(e.status).toEqual(errorCode)
+        expect(e.data).toEqual(expectedErrorBody)
+      }
+    })
+  })
 })

--- a/server/data/contactsApiClient.ts
+++ b/server/data/contactsApiClient.ts
@@ -66,4 +66,8 @@ export default class ContactsApiClient extends RestClient {
       user,
     )
   }
+
+  async getContact(contactId: number, user: Express.User): Promise<Contact> {
+    return this.get<Contact>({ path: `/contact/${contactId}` }, user)
+  }
 }

--- a/server/routes/contacts/add/addContactFlowControl.test.ts
+++ b/server/routes/contacts/add/addContactFlowControl.test.ts
@@ -62,6 +62,7 @@ describe('addContactFlowControl', () => {
               type: 'PRISONER_CONTACTS',
               url: '/foo',
             },
+            mode: 'NEW',
             isCheckingAnswers: false,
             dateOfBirth,
           }
@@ -87,6 +88,7 @@ describe('addContactFlowControl', () => {
 
       it.each([
         [Page.CREATE_CONTACT_START_PAGE, undefined, `/prisoner/A1234BC/contacts/search/${journeyId}`],
+        [Page.ADD_CONTACT_MODE_PAGE, undefined, `/prisoner/A1234BC/contacts/create/enter-name/${journeyId}`],
         [
           Page.CREATE_CONTACT_NAME_PAGE,
           undefined,
@@ -129,6 +131,7 @@ describe('addContactFlowControl', () => {
             },
             isCheckingAnswers: false,
             dateOfBirth,
+            mode: 'NEW',
           }
 
           const nav = nextPageForAddContactJourney(page, journey)
@@ -145,7 +148,6 @@ describe('addContactFlowControl', () => {
         [Page.CREATE_CONTACT_DOB_PAGE],
         [Page.CREATE_CONTACT_ESTIMATED_DOB_PAGE],
         [Page.ENTER_RELATIONSHIP_COMMENTS],
-        [Page.CREATE_CONTACT_CHECK_ANSWERS_PAGE],
       ])('Should go back to checking answer page: from %s', (page: Page) => {
         const journey: AddContactJourney = {
           id: journeyId,
@@ -155,7 +157,11 @@ describe('addContactFlowControl', () => {
             type: 'PRISONER_CONTACTS',
             url: '/foo',
           },
+          dateOfBirth: {
+            isKnown: 'YES',
+          },
           isCheckingAnswers: true,
+          mode: 'NEW',
         }
         const expected = `/prisoner/A1234BC/contacts/create/check-answers/${journeyId}`
 
@@ -177,6 +183,7 @@ describe('addContactFlowControl', () => {
           dateOfBirth: {
             isKnown: 'NO',
           },
+          mode: 'NEW',
         }
         const expected = `/prisoner/A1234BC/contacts/create/enter-estimated-dob/${journeyId}`
 
@@ -184,8 +191,22 @@ describe('addContactFlowControl', () => {
 
         expect(nav).toStrictEqual(expected)
       })
+    })
+  })
 
-      it('Should go to enter-name if selecting mode NEW', () => {
+  describe('add existing contact', () => {
+    describe('getNavigationForAddContactJourney', () => {
+      const journeyId = uuidv4()
+      it.each([
+        [Page.SELECT_CONTACT_RELATIONSHIP, undefined],
+        [Page.SELECT_EMERGENCY_CONTACT, `/prisoner/A1234BC/contacts/create/select-relationship/${journeyId}`],
+        [Page.SELECT_NEXT_OF_KIN, `/prisoner/A1234BC/contacts/create/select-emergency-contact/${journeyId}`],
+        [Page.ENTER_RELATIONSHIP_COMMENTS, `/prisoner/A1234BC/contacts/create/select-next-of-kin/${journeyId}`],
+        [
+          Page.CREATE_CONTACT_CHECK_ANSWERS_PAGE,
+          `/prisoner/A1234BC/contacts/create/enter-relationship-comments/${journeyId}`,
+        ],
+      ])('Should go back to previous page: from %s to %s', (page: Page, expectedBackUrl?: string) => {
         const journey: AddContactJourney = {
           id: journeyId,
           lastTouched: new Date().toISOString(),
@@ -194,15 +215,116 @@ describe('addContactFlowControl', () => {
             type: 'PRISONER_CONTACTS',
             url: '/foo',
           },
+          mode: 'EXISTING',
           isCheckingAnswers: false,
-          mode: 'NEW',
         }
-        const expected = `/prisoner/A1234BC/contacts/create/enter-name/${journeyId}`
+        const expected: AddContactNavigation = {
+          backLink: expectedBackUrl,
+        }
 
-        const nav = nextPageForAddContactJourney(Page.ADD_CONTACT_MODE_PAGE, journey)
+        const nav = navigationForAddContactJourney(page, journey)
 
         expect(nav).toStrictEqual(expected)
       })
+    })
+
+    describe('getNextPageForAddContactJourney', () => {
+      const journeyId = uuidv4()
+      it.each([
+        [Page.CREATE_CONTACT_START_PAGE, `/prisoner/A1234BC/contacts/search/${journeyId}`],
+        [Page.ADD_CONTACT_MODE_PAGE, `/prisoner/A1234BC/contacts/create/select-relationship/${journeyId}`],
+        [Page.SELECT_CONTACT_RELATIONSHIP, `/prisoner/A1234BC/contacts/create/select-emergency-contact/${journeyId}`],
+        [Page.SELECT_EMERGENCY_CONTACT, `/prisoner/A1234BC/contacts/create/select-next-of-kin/${journeyId}`],
+        [Page.SELECT_NEXT_OF_KIN, `/prisoner/A1234BC/contacts/create/enter-relationship-comments/${journeyId}`],
+        [Page.ENTER_RELATIONSHIP_COMMENTS, `/prisoner/A1234BC/contacts/create/check-answers/${journeyId}`],
+      ])('Should go to next page if not checking answers: from %s to %s', (page: Page, expectedNextUrl?: string) => {
+        const journey: AddContactJourney = {
+          id: journeyId,
+          lastTouched: new Date().toISOString(),
+          prisonerNumber: 'A1234BC',
+          returnPoint: {
+            type: 'PRISONER_CONTACTS',
+            url: '/foo',
+          },
+          mode: 'EXISTING',
+          isCheckingAnswers: false,
+        }
+
+        const nav = nextPageForAddContactJourney(page, journey)
+
+        expect(nav).toStrictEqual(expectedNextUrl)
+      })
+
+      it.each([
+        [Page.SELECT_CONTACT_RELATIONSHIP],
+        [Page.SELECT_EMERGENCY_CONTACT],
+        [Page.SELECT_NEXT_OF_KIN],
+        [Page.ENTER_RELATIONSHIP_COMMENTS],
+      ])('Should go back to checking answer page: from %s', (page: Page) => {
+        const journey: AddContactJourney = {
+          id: journeyId,
+          lastTouched: new Date().toISOString(),
+          prisonerNumber: 'A1234BC',
+          returnPoint: {
+            type: 'PRISONER_CONTACTS',
+            url: '/foo',
+          },
+          mode: 'EXISTING',
+          isCheckingAnswers: true,
+        }
+        const expected = `/prisoner/A1234BC/contacts/create/check-answers/${journeyId}`
+
+        const nav = nextPageForAddContactJourney(page, journey)
+
+        expect(nav).toStrictEqual(expected)
+      })
+    })
+  })
+  describe('should work correctly before mode set', () => {
+    const journeyId = uuidv4()
+    it.each([[Page.CREATE_CONTACT_START_PAGE], [Page.CONTACT_SEARCH_PAGE]])(
+      'Should have no back for initial pages',
+      (page: Page) => {
+        const journey: AddContactJourney = {
+          id: journeyId,
+          lastTouched: new Date().toISOString(),
+          prisonerNumber: 'A1234BC',
+          returnPoint: {
+            type: 'PRISONER_CONTACTS',
+            url: '/foo',
+          },
+          mode: undefined,
+          isCheckingAnswers: false,
+        }
+        const expected: AddContactNavigation = {
+          backLink: undefined,
+        }
+
+        const nav = navigationForAddContactJourney(page, journey)
+
+        expect(nav).toStrictEqual(expected)
+      },
+    )
+
+    it.each([
+      [Page.CREATE_CONTACT_START_PAGE, `/prisoner/A1234BC/contacts/search/${journeyId}`],
+      [Page.CONTACT_SEARCH_PAGE, `/prisoner/A1234BC/contacts/search/${journeyId}`],
+    ])('Should go to next page if mode not set: from %s to %s', (page: Page, expectedNextUrl?: string) => {
+      const journey: AddContactJourney = {
+        id: journeyId,
+        lastTouched: new Date().toISOString(),
+        prisonerNumber: 'A1234BC',
+        returnPoint: {
+          type: 'PRISONER_CONTACTS',
+          url: '/foo',
+        },
+        mode: undefined,
+        isCheckingAnswers: false,
+      }
+
+      const nav = nextPageForAddContactJourney(page, journey)
+
+      expect(nav).toStrictEqual(expectedNextUrl)
     })
   })
 })

--- a/server/routes/contacts/add/addContactFlowControl.ts
+++ b/server/routes/contacts/add/addContactFlowControl.ts
@@ -5,79 +5,183 @@ interface AddContactNavigation {
   backLink?: string
 }
 
-function navigationForAddContactJourney(currentPage: Page, journey: journeys.AddContactJourney): AddContactNavigation {
-  if (currentPage === Page.CREATE_CONTACT_NAME_PAGE) {
-    return { backLink: undefined }
-  }
-  if (currentPage === Page.SELECT_CONTACT_RELATIONSHIP) {
-    return { backLink: `/prisoner/${journey.prisonerNumber}/contacts/create/enter-name/${journey.id}` }
-  }
-  if (currentPage === Page.SELECT_EMERGENCY_CONTACT) {
-    return { backLink: `/prisoner/${journey.prisonerNumber}/contacts/create/select-relationship/${journey.id}` }
-  }
-  if (currentPage === Page.SELECT_NEXT_OF_KIN) {
-    return { backLink: `/prisoner/${journey.prisonerNumber}/contacts/create/select-emergency-contact/${journey.id}` }
-  }
-  if (currentPage === Page.CREATE_CONTACT_DOB_PAGE) {
-    return { backLink: `/prisoner/${journey.prisonerNumber}/contacts/create/select-next-of-kin/${journey.id}` }
-  }
-  if (currentPage === Page.CREATE_CONTACT_ESTIMATED_DOB_PAGE) {
-    return { backLink: `/prisoner/${journey.prisonerNumber}/contacts/create/enter-dob/${journey.id}` }
-  }
-  if (currentPage === Page.ENTER_RELATIONSHIP_COMMENTS) {
-    if (journey?.dateOfBirth?.isKnown === 'YES') {
-      return { backLink: `/prisoner/${journey.prisonerNumber}/contacts/create/enter-dob/${journey.id}` }
-    }
-    if (journey?.dateOfBirth?.isKnown === 'NO') {
-      return { backLink: `/prisoner/${journey.prisonerNumber}/contacts/create/enter-estimated-dob/${journey.id}` }
-    }
-  }
-  if (currentPage === Page.CREATE_CONTACT_CHECK_ANSWERS_PAGE) {
-    return { backLink: `/prisoner/${journey.prisonerNumber}/contacts/create/enter-relationship-comments/${journey.id}` }
-  }
+type PreModePages = Page.CREATE_CONTACT_START_PAGE | Page.CONTACT_SEARCH_PAGE
+type CreateContactPages =
+  | Page.CREATE_CONTACT_START_PAGE
+  | Page.CONTACT_SEARCH_PAGE
+  | Page.ADD_CONTACT_MODE_PAGE
+  | Page.CREATE_CONTACT_NAME_PAGE
+  | Page.SELECT_CONTACT_RELATIONSHIP
+  | Page.SELECT_EMERGENCY_CONTACT
+  | Page.SELECT_NEXT_OF_KIN
+  | Page.CREATE_CONTACT_DOB_PAGE
+  | Page.CREATE_CONTACT_ESTIMATED_DOB_PAGE
+  | Page.ENTER_RELATIONSHIP_COMMENTS
+  | Page.CREATE_CONTACT_CHECK_ANSWERS_PAGE
+type ExistingContactPages =
+  | Page.CREATE_CONTACT_START_PAGE
+  | Page.CONTACT_SEARCH_PAGE
+  | Page.ADD_CONTACT_MODE_PAGE
+  | Page.SELECT_CONTACT_RELATIONSHIP
+  | Page.SELECT_EMERGENCY_CONTACT
+  | Page.SELECT_NEXT_OF_KIN
+  | Page.ENTER_RELATIONSHIP_COMMENTS
+  | Page.CREATE_CONTACT_CHECK_ANSWERS_PAGE
+type AllAddContactPages = PreModePages | CreateContactPages | ExistingContactPages
+type JourneyUrlProvider = (journey: journeys.AddContactJourney) => string | undefined
+type Spec = { previousUrl: JourneyUrlProvider; nextUrl: JourneyUrlProvider }
 
+const PAGE_URLS: Record<AllAddContactPages, { url: JourneyUrlProvider }> = {
+  [Page.CREATE_CONTACT_START_PAGE]: { url: journey => `/prisoner/${journey.prisonerNumber}/contacts/create/start` },
+  [Page.CONTACT_SEARCH_PAGE]: { url: journey => `/prisoner/${journey.prisonerNumber}/contacts/search/${journey.id}` },
+  [Page.ADD_CONTACT_MODE_PAGE]: {
+    url: journey => `/prisoner/${journey.prisonerNumber}/contacts/mode/${journey.mode}/${journey.id}`,
+  },
+  [Page.CREATE_CONTACT_NAME_PAGE]: {
+    url: journey => `/prisoner/${journey.prisonerNumber}/contacts/create/enter-name/${journey.id}`,
+  },
+  [Page.SELECT_CONTACT_RELATIONSHIP]: {
+    url: journey => `/prisoner/${journey.prisonerNumber}/contacts/create/select-relationship/${journey.id}`,
+  },
+  [Page.SELECT_EMERGENCY_CONTACT]: {
+    url: journey => `/prisoner/${journey.prisonerNumber}/contacts/create/select-emergency-contact/${journey.id}`,
+  },
+  [Page.SELECT_NEXT_OF_KIN]: {
+    url: journey => `/prisoner/${journey.prisonerNumber}/contacts/create/select-next-of-kin/${journey.id}`,
+  },
+  [Page.CREATE_CONTACT_DOB_PAGE]: {
+    url: journey => `/prisoner/${journey.prisonerNumber}/contacts/create/enter-dob/${journey.id}`,
+  },
+  [Page.CREATE_CONTACT_ESTIMATED_DOB_PAGE]: {
+    url: journey => `/prisoner/${journey.prisonerNumber}/contacts/create/enter-estimated-dob/${journey.id}`,
+  },
+  [Page.ENTER_RELATIONSHIP_COMMENTS]: {
+    url: journey => `/prisoner/${journey.prisonerNumber}/contacts/create/enter-relationship-comments/${journey.id}`,
+  },
+  [Page.CREATE_CONTACT_CHECK_ANSWERS_PAGE]: {
+    url: journey => `/prisoner/${journey.prisonerNumber}/contacts/create/check-answers/${journey.id}`,
+  },
+}
+
+const PRE_MODE_SPEC: Record<PreModePages, Spec> = {
+  [Page.CREATE_CONTACT_START_PAGE]: { previousUrl: _ => undefined, nextUrl: PAGE_URLS.CONTACT_SEARCH_PAGE.url },
+  [Page.CONTACT_SEARCH_PAGE]: { previousUrl: _ => undefined, nextUrl: PAGE_URLS.CONTACT_SEARCH_PAGE.url },
+}
+
+const CREATE_CONTACT_SPEC: Record<CreateContactPages, Spec> = {
+  [Page.CREATE_CONTACT_START_PAGE]: { previousUrl: _ => undefined, nextUrl: PAGE_URLS.CONTACT_SEARCH_PAGE.url },
+  [Page.CONTACT_SEARCH_PAGE]: { previousUrl: _ => undefined, nextUrl: PAGE_URLS.CONTACT_SEARCH_PAGE.url },
+  [Page.ADD_CONTACT_MODE_PAGE]: { previousUrl: _ => undefined, nextUrl: PAGE_URLS.CREATE_CONTACT_NAME_PAGE.url },
+  [Page.CREATE_CONTACT_NAME_PAGE]: {
+    previousUrl: _ => undefined,
+    nextUrl: checkAnswersOr(PAGE_URLS.SELECT_CONTACT_RELATIONSHIP.url),
+  },
+  [Page.SELECT_CONTACT_RELATIONSHIP]: {
+    previousUrl: PAGE_URLS.CREATE_CONTACT_NAME_PAGE.url,
+    nextUrl: checkAnswersOr(PAGE_URLS.SELECT_EMERGENCY_CONTACT.url),
+  },
+  [Page.SELECT_EMERGENCY_CONTACT]: {
+    previousUrl: PAGE_URLS.SELECT_CONTACT_RELATIONSHIP.url,
+    nextUrl: checkAnswersOr(PAGE_URLS.SELECT_NEXT_OF_KIN.url),
+  },
+  [Page.SELECT_NEXT_OF_KIN]: {
+    previousUrl: PAGE_URLS.SELECT_EMERGENCY_CONTACT.url,
+    nextUrl: checkAnswersOr(PAGE_URLS.CREATE_CONTACT_DOB_PAGE.url),
+  },
+  [Page.CREATE_CONTACT_DOB_PAGE]: {
+    previousUrl: PAGE_URLS.SELECT_NEXT_OF_KIN.url,
+    nextUrl: journey => {
+      if (journey.dateOfBirth?.isKnown === 'NO') {
+        return PAGE_URLS.CREATE_CONTACT_ESTIMATED_DOB_PAGE.url(journey)
+      }
+      if (journey.dateOfBirth?.isKnown === 'YES') {
+        if (journey.isCheckingAnswers) {
+          return PAGE_URLS.CREATE_CONTACT_CHECK_ANSWERS_PAGE.url(journey)
+        }
+        return PAGE_URLS.ENTER_RELATIONSHIP_COMMENTS.url(journey)
+      }
+      return PAGE_URLS.CREATE_CONTACT_DOB_PAGE.url(journey)
+    },
+  },
+  [Page.CREATE_CONTACT_ESTIMATED_DOB_PAGE]: {
+    previousUrl: PAGE_URLS.CREATE_CONTACT_DOB_PAGE.url,
+    nextUrl: checkAnswersOr(PAGE_URLS.ENTER_RELATIONSHIP_COMMENTS.url),
+  },
+  [Page.ENTER_RELATIONSHIP_COMMENTS]: {
+    previousUrl: journey => {
+      if (journey.dateOfBirth?.isKnown === 'NO') {
+        return PAGE_URLS.CREATE_CONTACT_ESTIMATED_DOB_PAGE.url(journey)
+      }
+      return PAGE_URLS.CREATE_CONTACT_DOB_PAGE.url(journey)
+    },
+    nextUrl: checkAnswersOr(PAGE_URLS.CREATE_CONTACT_CHECK_ANSWERS_PAGE.url),
+  },
+  [Page.CREATE_CONTACT_CHECK_ANSWERS_PAGE]: {
+    previousUrl: PAGE_URLS.ENTER_RELATIONSHIP_COMMENTS.url,
+    nextUrl: _ => undefined,
+  },
+}
+
+const EXISTING_CONTACT_SPEC: Record<ExistingContactPages, Spec> = {
+  [Page.CREATE_CONTACT_START_PAGE]: { previousUrl: _ => undefined, nextUrl: PAGE_URLS.CONTACT_SEARCH_PAGE.url },
+  [Page.CONTACT_SEARCH_PAGE]: { previousUrl: _ => undefined, nextUrl: PAGE_URLS.CONTACT_SEARCH_PAGE.url },
+  [Page.ADD_CONTACT_MODE_PAGE]: {
+    previousUrl: _ => undefined,
+    nextUrl: checkAnswersOr(PAGE_URLS.SELECT_CONTACT_RELATIONSHIP.url),
+  },
+  [Page.SELECT_CONTACT_RELATIONSHIP]: {
+    previousUrl: _ => undefined,
+    nextUrl: checkAnswersOr(PAGE_URLS.SELECT_EMERGENCY_CONTACT.url),
+  },
+  [Page.SELECT_EMERGENCY_CONTACT]: {
+    previousUrl: PAGE_URLS.SELECT_CONTACT_RELATIONSHIP.url,
+    nextUrl: checkAnswersOr(PAGE_URLS.SELECT_NEXT_OF_KIN.url),
+  },
+  [Page.SELECT_NEXT_OF_KIN]: {
+    previousUrl: PAGE_URLS.SELECT_EMERGENCY_CONTACT.url,
+    nextUrl: checkAnswersOr(PAGE_URLS.ENTER_RELATIONSHIP_COMMENTS.url),
+  },
+  [Page.ENTER_RELATIONSHIP_COMMENTS]: {
+    previousUrl: PAGE_URLS.SELECT_NEXT_OF_KIN.url,
+    nextUrl: checkAnswersOr(PAGE_URLS.CREATE_CONTACT_CHECK_ANSWERS_PAGE.url),
+  },
+  [Page.CREATE_CONTACT_CHECK_ANSWERS_PAGE]: {
+    previousUrl: PAGE_URLS.ENTER_RELATIONSHIP_COMMENTS.url,
+    nextUrl: _ => undefined,
+  },
+}
+
+function checkAnswersOr(other: JourneyUrlProvider): JourneyUrlProvider {
+  return journey =>
+    journey.isCheckingAnswers ? PAGE_URLS.CREATE_CONTACT_CHECK_ANSWERS_PAGE.url(journey) : other(journey)
+}
+
+function navigationForAddContactJourney(currentPage: Page, journey: journeys.AddContactJourney): AddContactNavigation {
+  const spec = findSpec(journey, currentPage)
+  if (spec) {
+    return { backLink: spec.previousUrl(journey) }
+  }
   throw new Error(`Couldn't determine navigation for page (${currentPage}) and journey (${JSON.stringify(journey)})`)
 }
 
 function nextPageForAddContactJourney(currentPage: Page, journey: AddContactJourney): string {
-  if (journey.isCheckingAnswers) {
-    if (currentPage === Page.CREATE_CONTACT_DOB_PAGE && journey.dateOfBirth?.isKnown === 'NO') {
-      return `/prisoner/${journey.prisonerNumber}/contacts/create/enter-estimated-dob/${journey.id}`
-    }
-    return `/prisoner/${journey.prisonerNumber}/contacts/create/check-answers/${journey.id}`
+  const spec = findSpec(journey, currentPage)
+  if (spec) {
+    return spec.nextUrl(journey)
   }
-  if (currentPage === Page.CREATE_CONTACT_START_PAGE || currentPage === Page.CONTACT_SEARCH_PAGE) {
-    return `/prisoner/${journey.prisonerNumber}/contacts/search/${journey.id}`
-  }
-  if (currentPage === Page.ADD_CONTACT_MODE_PAGE && journey.mode === 'NEW') {
-    return `/prisoner/${journey.prisonerNumber}/contacts/create/enter-name/${journey.id}`
-  }
-  if (currentPage === Page.CREATE_CONTACT_NAME_PAGE) {
-    return `/prisoner/${journey.prisonerNumber}/contacts/create/select-relationship/${journey.id}`
-  }
-  if (currentPage === Page.SELECT_CONTACT_RELATIONSHIP) {
-    return `/prisoner/${journey.prisonerNumber}/contacts/create/select-emergency-contact/${journey.id}`
-  }
-  if (currentPage === Page.SELECT_EMERGENCY_CONTACT) {
-    return `/prisoner/${journey.prisonerNumber}/contacts/create/select-next-of-kin/${journey.id}`
-  }
-  if (currentPage === Page.SELECT_NEXT_OF_KIN) {
-    return `/prisoner/${journey.prisonerNumber}/contacts/create/enter-dob/${journey.id}`
-  }
-  if (currentPage === Page.CREATE_CONTACT_DOB_PAGE) {
-    if (journey?.dateOfBirth?.isKnown === 'YES') {
-      return `/prisoner/${journey.prisonerNumber}/contacts/create/enter-relationship-comments/${journey.id}`
-    }
-    if (journey?.dateOfBirth?.isKnown === 'NO') {
-      return `/prisoner/${journey.prisonerNumber}/contacts/create/enter-estimated-dob/${journey.id}`
-    }
-  } else if (currentPage === Page.CREATE_CONTACT_ESTIMATED_DOB_PAGE) {
-    return `/prisoner/${journey.prisonerNumber}/contacts/create/enter-relationship-comments/${journey.id}`
-  } else if (currentPage === Page.ENTER_RELATIONSHIP_COMMENTS) {
-    return `/prisoner/${journey.prisonerNumber}/contacts/create/check-answers/${journey.id}`
-  }
-
   throw new Error(`Couldn't determine next page from (${currentPage}) and journey (${JSON.stringify(journey)})`)
+}
+
+function findSpec(journey: journeys.AddContactJourney, currentPage: Page) {
+  let spec: Spec
+  if (!journey.mode) {
+    spec = PRE_MODE_SPEC[`${currentPage}` as PreModePages]
+  } else if (journey.mode === 'NEW') {
+    spec = CREATE_CONTACT_SPEC[currentPage as CreateContactPages]
+  } else if (journey.mode === 'EXISTING') {
+    spec = EXISTING_CONTACT_SPEC[currentPage as ExistingContactPages]
+  }
+  return spec
 }
 
 export { navigationForAddContactJourney, nextPageForAddContactJourney, AddContactNavigation }

--- a/server/routes/contacts/add/addContactRoutes.ts
+++ b/server/routes/contacts/add/addContactRoutes.ts
@@ -58,7 +58,7 @@ const AddContactRoutes = (
     asyncMiddleware(contactsSearchController.POST),
   )
 
-  const modeController = new AddContactModeController()
+  const modeController = new AddContactModeController(contactsService)
   router.get(
     '/prisoner/:prisonerNumber/contacts/add/mode/:mode/:journeyId',
     ensureInAddContactJourney(),

--- a/server/routes/contacts/add/check-answers/createContactCheckAnswersController.test.ts
+++ b/server/routes/contacts/add/check-answers/createContactCheckAnswersController.test.ts
@@ -47,6 +47,7 @@ beforeEach(() => {
     relationship: {
       type: 'MOT',
     },
+    mode: 'NEW',
   }
 
   app = appWithAllRoutes({
@@ -72,22 +73,26 @@ afterEach(() => {
 })
 
 describe('GET /prisoner/:prisonerNumber/contacts/create/check-answers/:journeyId', () => {
-  it('should render check answers page with dob', async () => {
-    // Given
-    auditService.logPageView.mockResolvedValue(null)
+  it.each(['NEW', 'EXISTING'])(
+    'should render check answers page with dob for mode %s',
+    async (mode: 'NEW' | 'EXISTING') => {
+      // Given
+      auditService.logPageView.mockResolvedValue(null)
+      journey.mode = mode
 
-    // When
-    const response = await request(app).get(`/prisoner/${prisonerNumber}/contacts/create/check-answers/${journeyId}`)
+      // When
+      const response = await request(app).get(`/prisoner/${prisonerNumber}/contacts/create/check-answers/${journeyId}`)
 
-    // Then
-    expect(response.status).toEqual(200)
-    expect(journey.isCheckingAnswers).toStrictEqual(true)
-    const $ = cheerio.load(response.text)
-    expect($('[data-qa=main-heading]').first().text().trim()).toStrictEqual('Check your answers')
-    expect($('[data-qa=cancel-button]').first().attr('href')).toStrictEqual('/foo-bar')
-    expect($('.check-answers-dob-value').first().text().trim()).toStrictEqual('1 January 2024')
-    expect($('[data-qa=contact-list-breadcrumb-link]').first().attr('href')).toStrictEqual('/foo-bar')
-  })
+      // Then
+      expect(response.status).toEqual(200)
+      expect(journey.isCheckingAnswers).toStrictEqual(true)
+      const $ = cheerio.load(response.text)
+      expect($('[data-qa=main-heading]').first().text().trim()).toStrictEqual('Check your answers')
+      expect($('[data-qa=cancel-button]').first().attr('href')).toStrictEqual('/foo-bar')
+      expect($('.check-answers-dob-value').first().text().trim()).toStrictEqual('1 January 2024')
+      expect($('[data-qa=contact-list-breadcrumb-link]').first().attr('href')).toStrictEqual('/foo-bar')
+    },
+  )
 
   it('should render check answers page without dob', async () => {
     // Given

--- a/server/routes/contacts/add/emergency-contact/emergencyContactController.test.ts
+++ b/server/routes/contacts/add/emergency-contact/emergencyContactController.test.ts
@@ -35,6 +35,7 @@ beforeEach(() => {
     relationship: {
       type: 'MOT',
     },
+    mode: 'NEW',
   }
   app = appWithAllRoutes({
     services: {
@@ -56,25 +57,29 @@ afterEach(() => {
 })
 
 describe('GET /prisoner/:prisonerNumber/contacts/create/select-emergency-contact/:journeyId', () => {
-  it('should render enter emergency contact page', async () => {
-    // Given
-    auditService.logPageView.mockResolvedValue(null)
+  it.each(['NEW', 'EXISTING'])(
+    'should render enter emergency contact page for all modes %s',
+    async (mode: 'NEW' | 'EXISTING') => {
+      // Given
+      auditService.logPageView.mockResolvedValue(null)
+      existingJourney.mode = mode
 
-    // When
-    const response = await request(app).get(
-      `/prisoner/${prisonerNumber}/contacts/create/select-emergency-contact/${journeyId}`,
-    )
+      // When
+      const response = await request(app).get(
+        `/prisoner/${prisonerNumber}/contacts/create/select-emergency-contact/${journeyId}`,
+      )
 
-    // Then
-    expect(response.status).toEqual(200)
+      // Then
+      expect(response.status).toEqual(200)
 
-    const $ = cheerio.load(response.text)
-    expect($('[data-qa=main-heading]').first().text().trim()).toStrictEqual(
-      'Is Last, First an emergency contact for the prisoner?',
-    )
-    expect($('[data-qa=cancel-button]').first().attr('href')).toStrictEqual('/foo-bar')
-    expect($('[data-qa=contact-list-breadcrumb-link]').first().attr('href')).toStrictEqual('/foo-bar')
-  })
+      const $ = cheerio.load(response.text)
+      expect($('[data-qa=main-heading]').first().text().trim()).toStrictEqual(
+        'Is Last, First an emergency contact for the prisoner?',
+      )
+      expect($('[data-qa=cancel-button]').first().attr('href')).toStrictEqual('/foo-bar')
+      expect($('[data-qa=contact-list-breadcrumb-link]').first().attr('href')).toStrictEqual('/foo-bar')
+    },
+  )
 
   it('should call the audit service for the page view', async () => {
     // Given

--- a/server/routes/contacts/add/enter-dob/createContactEnterDobController.test.ts
+++ b/server/routes/contacts/add/enter-dob/createContactEnterDobController.test.ts
@@ -32,6 +32,7 @@ beforeEach(() => {
       lastName: 'last',
       firstName: 'first',
     },
+    mode: 'NEW',
   }
   app = appWithAllRoutes({
     services: {

--- a/server/routes/contacts/add/enter-estimated-dob/createContactEnterEstimatedDobController.test.ts
+++ b/server/routes/contacts/add/enter-estimated-dob/createContactEnterEstimatedDobController.test.ts
@@ -32,6 +32,7 @@ beforeEach(() => {
       lastName: 'last',
       firstName: 'first',
     },
+    mode: 'NEW',
   }
   app = appWithAllRoutes({
     services: {

--- a/server/routes/contacts/add/enter-name/createContactEnterNameController.test.ts
+++ b/server/routes/contacts/add/enter-name/createContactEnterNameController.test.ts
@@ -32,6 +32,7 @@ beforeEach(() => {
     prisonerNumber,
     isCheckingAnswers: false,
     returnPoint: { type: 'MANAGE_PRISONER_CONTACTS', url: '/foo-bar' },
+    mode: 'NEW',
   }
   app = appWithAllRoutes({
     services: {

--- a/server/routes/contacts/add/mode/addContactModeController.test.ts
+++ b/server/routes/contacts/add/mode/addContactModeController.test.ts
@@ -4,11 +4,15 @@ import { SessionData } from 'express-session'
 import { v4 as uuidv4 } from 'uuid'
 import { appWithAllRoutes, user } from '../../../testutils/appSetup'
 import AuditService, { Page } from '../../../../services/auditService'
+import ContactsService from '../../../../services/contactsService'
 import AddContactJourney = journeys.AddContactJourney
+import Contact = contactsApiClientTypes.Contact
 
 jest.mock('../../../../services/auditService')
+jest.mock('../../../../services/contactsService')
 
 const auditService = new AuditService(null) as jest.Mocked<AuditService>
+const contactsService = new ContactsService(null) as jest.Mocked<ContactsService>
 
 let app: Express
 let session: Partial<SessionData>
@@ -28,12 +32,13 @@ beforeEach(() => {
   app = appWithAllRoutes({
     services: {
       auditService,
+      contactsService,
     },
     userSupplier: () => user,
     sessionReceiver: (receivedSession: Partial<SessionData>) => {
       session = receivedSession
       session.addContactJourneys = {}
-      session.addContactJourneys[journeyId] = { ...existingJourney }
+      session.addContactJourneys[journeyId] = existingJourney
     },
   })
 })
@@ -43,7 +48,7 @@ afterEach(() => {
 })
 
 describe('GET /prisoner/:prisonerNumber/contacts/add/mode/:mode/:journeyId', () => {
-  it('should pass to the enter-name page if mode is NEW', async () => {
+  it('should audit', async () => {
     // Given
     auditService.logPageView.mockResolvedValue(null)
 
@@ -56,7 +61,139 @@ describe('GET /prisoner/:prisonerNumber/contacts/add/mode/:mode/:journeyId', () 
       correlationId: expect.any(String),
     })
     expect(response.status).toEqual(302)
+  })
+
+  it('should pass to the enter-name page if mode is NEW', async () => {
+    // Given
+    auditService.logPageView.mockResolvedValue(null)
+
+    // When
+    const response = await request(app).get(`/prisoner/${prisonerNumber}/contacts/add/mode/NEW/${journeyId}`)
+
+    // Then
+    expect(response.status).toEqual(302)
     expect(response.headers.location).toContain('/contacts/create/enter-name/')
-    expect(Object.entries(session.addContactJourneys)).toHaveLength(1)
+    expect(existingJourney.mode).toStrictEqual('NEW')
+    expect(existingJourney.names).toBeUndefined()
+    expect(existingJourney.dateOfBirth).toBeUndefined()
+    expect(contactsService.getContact).not.toHaveBeenCalled()
+  })
+
+  it('should pass to the select relationship page if mode is EXISTING and the contact has a DOB', async () => {
+    // Given
+    const contact: Contact = {
+      id: 123456,
+      title: 'MR',
+      lastName: 'last',
+      firstName: 'middle',
+      middleName: 'first',
+      dateOfBirth: '1980-12-10T00:00:00.000Z',
+      createdBy: user.username,
+      createdTime: '2024-01-01',
+    }
+
+    auditService.logPageView.mockResolvedValue(null)
+    contactsService.getContact.mockResolvedValue(contact)
+
+    // When
+    const response = await request(app).get(
+      `/prisoner/${prisonerNumber}/contacts/add/mode/EXISTING/${journeyId}?contactId=123456`,
+    )
+
+    // Then
+    expect(response.status).toEqual(302)
+    expect(response.headers.location).toContain('/contacts/create/select-relationship/')
+    expect(existingJourney.mode).toStrictEqual('EXISTING')
+    expect(contactsService.getContact).toHaveBeenCalledWith(123456, user)
+    expect(existingJourney.names).toStrictEqual({
+      title: 'MR',
+      lastName: 'last',
+      firstName: 'middle',
+      middleName: 'first',
+    })
+    expect(existingJourney.dateOfBirth).toStrictEqual({
+      isKnown: 'YES',
+      year: 1980,
+      month: 12,
+      day: 10,
+    })
+  })
+
+  it('should pass to the select relationship page if mode is EXISTING and the contact has no DOB', async () => {
+    // Given
+    const contact: Contact = {
+      id: 123456,
+      title: 'MR',
+      lastName: 'last',
+      firstName: 'middle',
+      middleName: 'first',
+      dateOfBirth: undefined,
+      estimatedIsOverEighteen: 'YES',
+      createdBy: user.username,
+      createdTime: '2024-01-01',
+    }
+
+    auditService.logPageView.mockResolvedValue(null)
+    contactsService.getContact.mockResolvedValue(contact)
+
+    // When
+    const response = await request(app).get(
+      `/prisoner/${prisonerNumber}/contacts/add/mode/EXISTING/${journeyId}?contactId=123456`,
+    )
+
+    // Then
+    expect(auditService.logPageView).toHaveBeenCalledWith(Page.ADD_CONTACT_MODE_PAGE, {
+      who: user.username,
+      correlationId: expect.any(String),
+    })
+    expect(response.status).toEqual(302)
+    expect(response.headers.location).toContain('/contacts/create/select-relationship/')
+    expect(existingJourney.mode).toStrictEqual('EXISTING')
+    expect(contactsService.getContact).toHaveBeenCalledWith(123456, user)
+    expect(existingJourney.names).toStrictEqual({
+      title: 'MR',
+      lastName: 'last',
+      firstName: 'middle',
+      middleName: 'first',
+    })
+  })
+
+  it('should pass to the select relationship page if mode is EXISTING and the contact has no DOB or estimated DOB', async () => {
+    // Given
+    const contact: Contact = {
+      id: 123456,
+      title: 'MR',
+      lastName: 'last',
+      firstName: 'middle',
+      middleName: 'first',
+      dateOfBirth: undefined,
+      estimatedIsOverEighteen: undefined,
+      createdBy: user.username,
+      createdTime: '2024-01-01',
+    }
+
+    auditService.logPageView.mockResolvedValue(null)
+    contactsService.getContact.mockResolvedValue(contact)
+
+    // When
+    const response = await request(app).get(
+      `/prisoner/${prisonerNumber}/contacts/add/mode/EXISTING/${journeyId}?contactId=123456`,
+    )
+
+    // Then
+    expect(response.status).toEqual(302)
+    expect(response.headers.location).toContain('/contacts/create/select-relationship/')
+    expect(existingJourney.mode).toStrictEqual('EXISTING')
+    expect(contactsService.getContact).toHaveBeenCalledWith(123456, user)
+    expect(existingJourney.names).toStrictEqual({
+      title: 'MR',
+      lastName: 'last',
+      firstName: 'middle',
+      middleName: 'first',
+    })
+    expect(existingJourney.dateOfBirth).toStrictEqual({
+      isKnown: 'NO',
+      isOverEighteen: undefined,
+    })
   })
 })

--- a/server/routes/contacts/add/mode/addContactModeController.ts
+++ b/server/routes/contacts/add/mode/addContactModeController.ts
@@ -2,18 +2,48 @@ import { Request, Response } from 'express'
 import { Page } from '../../../../services/auditService'
 import { PageHandler } from '../../../../interfaces/pageHandler'
 import { nextPageForAddContactJourney } from '../addContactFlowControl'
+import { ContactsService } from '../../../../services'
 import PrisonerJourneyParams = journeys.PrisonerJourneyParams
 
 export default class AddContactModeController implements PageHandler {
+  constructor(private readonly contactService: ContactsService) {}
+
   public PAGE_NAME = Page.ADD_CONTACT_MODE_PAGE
 
   GET = async (
-    req: Request<PrisonerJourneyParams & { mode?: 'EXISTING' | 'NEW' }, unknown, unknown>,
+    req: Request<PrisonerJourneyParams & { mode?: 'EXISTING' | 'NEW' }, unknown, unknown, { contactId?: string }>,
     res: Response,
   ): Promise<void> => {
     const { journeyId, mode } = req.params
+    const { contactId } = req.query
+    const { user } = res.locals
+
     const journey = req.session.addContactJourneys[journeyId]
     journey.mode = mode
+    if (journey.mode === 'EXISTING' && contactId) {
+      journey.contactId = Number(contactId)
+      const existingContact = await this.contactService.getContact(journey.contactId, user)
+      journey.names = {
+        title: existingContact.title,
+        lastName: existingContact.lastName,
+        firstName: existingContact.firstName,
+        middleName: existingContact.middleName,
+      }
+      if (existingContact.dateOfBirth) {
+        const date = new Date(existingContact.dateOfBirth)
+        journey.dateOfBirth = {
+          isKnown: 'YES',
+          year: date.getFullYear(),
+          month: date.getMonth() + 1,
+          day: date.getDate(),
+        }
+      } else {
+        journey.dateOfBirth = {
+          isKnown: 'NO',
+          isOverEighteen: existingContact.estimatedIsOverEighteen,
+        }
+      }
+    }
     res.redirect(nextPageForAddContactJourney(this.PAGE_NAME, journey))
   }
 }

--- a/server/routes/contacts/add/next-of-kin/nextOfKinController.test.ts
+++ b/server/routes/contacts/add/next-of-kin/nextOfKinController.test.ts
@@ -36,6 +36,7 @@ beforeEach(() => {
       type: 'MOT',
       isEmergencyContact: 'YES',
     },
+    mode: 'NEW',
   }
   app = appWithAllRoutes({
     services: {
@@ -57,25 +58,29 @@ afterEach(() => {
 })
 
 describe('GET /prisoner/:prisonerNumber/contacts/create/select-next-of-kin/:journeyId', () => {
-  it('should render enter next of kin page', async () => {
-    // Given
-    auditService.logPageView.mockResolvedValue(null)
+  it.each(['NEW', 'EXISTING'])(
+    'should render enter next of kin page for each mode %s',
+    async (mode: 'NEW' | 'EXISTING') => {
+      // Given
+      auditService.logPageView.mockResolvedValue(null)
+      existingJourney.mode = mode
 
-    // When
-    const response = await request(app).get(
-      `/prisoner/${prisonerNumber}/contacts/create/select-next-of-kin/${journeyId}`,
-    )
+      // When
+      const response = await request(app).get(
+        `/prisoner/${prisonerNumber}/contacts/create/select-next-of-kin/${journeyId}`,
+      )
 
-    // Then
-    expect(response.status).toEqual(200)
+      // Then
+      expect(response.status).toEqual(200)
 
-    const $ = cheerio.load(response.text)
-    expect($('[data-qa=main-heading]').first().text().trim()).toStrictEqual(
-      'Is Last, First next of kin for the prisoner?',
-    )
-    expect($('[data-qa=cancel-button]').first().attr('href')).toStrictEqual('/foo-bar')
-    expect($('[data-qa=contact-list-breadcrumb-link]').first().attr('href')).toStrictEqual('/foo-bar')
-  })
+      const $ = cheerio.load(response.text)
+      expect($('[data-qa=main-heading]').first().text().trim()).toStrictEqual(
+        'Is Last, First next of kin for the prisoner?',
+      )
+      expect($('[data-qa=cancel-button]').first().attr('href')).toStrictEqual('/foo-bar')
+      expect($('[data-qa=contact-list-breadcrumb-link]').first().attr('href')).toStrictEqual('/foo-bar')
+    },
+  )
 
   it('should call the audit service for the page view', async () => {
     // Given

--- a/server/routes/contacts/add/relationship-comments/enterRelationshipCommentsController.test.ts
+++ b/server/routes/contacts/add/relationship-comments/enterRelationshipCommentsController.test.ts
@@ -41,6 +41,7 @@ beforeEach(() => {
       isEmergencyContact: 'YES',
       isNextOfKin: 'YES',
     },
+    mode: 'NEW',
   }
   app = appWithAllRoutes({
     services: {
@@ -62,25 +63,29 @@ afterEach(() => {
 })
 
 describe('GET /prisoner/:prisonerNumber/contacts/create/enter-relationship-comments/:journeyId', () => {
-  it('should render enter relationship comments page', async () => {
-    // Given
-    auditService.logPageView.mockResolvedValue(null)
+  it.each(['NEW', 'EXISTING'])(
+    'should render enter relationship comments page for each mode %s',
+    async (mode: 'NEW' | 'EXISTING') => {
+      // Given
+      auditService.logPageView.mockResolvedValue(null)
+      existingJourney.mode = mode
 
-    // When
-    const response = await request(app).get(
-      `/prisoner/${prisonerNumber}/contacts/create/enter-relationship-comments/${journeyId}`,
-    )
+      // When
+      const response = await request(app).get(
+        `/prisoner/${prisonerNumber}/contacts/create/enter-relationship-comments/${journeyId}`,
+      )
 
-    // Then
-    expect(response.status).toEqual(200)
+      // Then
+      expect(response.status).toEqual(200)
 
-    const $ = cheerio.load(response.text)
-    expect($('[data-qa=main-heading]').first().text().trim()).toStrictEqual(
-      'Add additional information about the relationship between the prisoner and Last, First',
-    )
-    expect($('[data-qa=cancel-button]').first().attr('href')).toStrictEqual('/foo-bar')
-    expect($('[data-qa=contact-list-breadcrumb-link]').first().attr('href')).toStrictEqual('/foo-bar')
-  })
+      const $ = cheerio.load(response.text)
+      expect($('[data-qa=main-heading]').first().text().trim()).toStrictEqual(
+        'Add additional information about the relationship between the prisoner and Last, First',
+      )
+      expect($('[data-qa=cancel-button]').first().attr('href')).toStrictEqual('/foo-bar')
+      expect($('[data-qa=contact-list-breadcrumb-link]').first().attr('href')).toStrictEqual('/foo-bar')
+    },
+  )
 
   it('should call the audit service for the page view', async () => {
     // Given

--- a/server/routes/contacts/add/relationship/selectRelationshipController.test.ts
+++ b/server/routes/contacts/add/relationship/selectRelationshipController.test.ts
@@ -33,6 +33,7 @@ beforeEach(() => {
     isCheckingAnswers: false,
     returnPoint: { type: 'MANAGE_PRISONER_CONTACTS', url: '/foo-bar' },
     names: { firstName: 'First', lastName: 'Last' },
+    mode: 'NEW',
   }
   app = appWithAllRoutes({
     services: {
@@ -56,25 +57,29 @@ afterEach(() => {
 })
 
 describe('GET /prisoner/:prisonerNumber/contacts/create/select-relationship', () => {
-  it('should render select relationship page', async () => {
-    // Given
-    auditService.logPageView.mockResolvedValue(null)
+  it.each(['NEW', 'EXISTING'])(
+    'should render select relationship page for mode %s',
+    async (mode: 'NEW' | 'EXISTING') => {
+      // Given
+      auditService.logPageView.mockResolvedValue(null)
+      existingJourney.mode = mode
 
-    // When
-    const response = await request(app).get(
-      `/prisoner/${prisonerNumber}/contacts/create/select-relationship/${journeyId}`,
-    )
+      // When
+      const response = await request(app).get(
+        `/prisoner/${prisonerNumber}/contacts/create/select-relationship/${journeyId}`,
+      )
 
-    // Then
-    expect(response.status).toEqual(200)
+      // Then
+      expect(response.status).toEqual(200)
 
-    const $ = cheerio.load(response.text)
-    expect($('[data-qa=main-heading]').first().text().trim()).toStrictEqual(
-      'How is Last, First related to the prisoner?',
-    )
-    expect($('[data-qa=cancel-button]').first().attr('href')).toStrictEqual('/foo-bar')
-    expect($('[data-qa=contact-list-breadcrumb-link]').first().attr('href')).toStrictEqual('/foo-bar')
-  })
+      const $ = cheerio.load(response.text)
+      expect($('[data-qa=main-heading]').first().text().trim()).toStrictEqual(
+        'How is Last, First related to the prisoner?',
+      )
+      expect($('[data-qa=cancel-button]').first().attr('href')).toStrictEqual('/foo-bar')
+      expect($('[data-qa=contact-list-breadcrumb-link]').first().attr('href')).toStrictEqual('/foo-bar')
+    },
+  )
 
   it('should call the audit service for the page view', async () => {
     // Given

--- a/server/services/contactsService.test.ts
+++ b/server/services/contactsService.test.ts
@@ -1,13 +1,13 @@
 import createError, { BadRequest } from 'http-errors'
 import ContactsApiClient from '../data/contactsApiClient'
 import ContactsService from './contactsService'
+import { PaginationRequest } from '../data/prisonerOffenderSearchTypes'
+import TestData from '../routes/testutils/testData'
 import AddContactJourney = journeys.AddContactJourney
 import Contact = contactsApiClientTypes.Contact
 import CreateContactRequest = contactsApiClientTypes.CreateContactRequest
 import ContactSearchRequest = contactsApiClientTypes.ContactSearchRequest
 import IsOverEighteenOptions = journeys.YesNoOrDoNotKnow
-import { PaginationRequest } from '../data/prisonerOffenderSearchTypes'
-import TestData from '../routes/testutils/testData'
 
 jest.mock('../data/contactsApiClient')
 const contacts = TestData.contacts()
@@ -243,6 +243,31 @@ describe('contactsService', () => {
       await expect(apiClient.searchContact(contactSearchRequest, user, pagination)).rejects.toEqual(
         new Error('some error'),
       )
+    })
+  })
+
+  describe('getContact', () => {
+    it('Should get the contact', async () => {
+      const expectedContact: Contact = {
+        id: 123456,
+        lastName: 'last',
+        firstName: 'middle',
+        middleName: 'first',
+        dateOfBirth: '1980-12-10T00:00:00.000Z',
+        createdBy: user.username,
+        createdTime: '2024-01-01',
+      }
+      apiClient.getContact.mockResolvedValue(expectedContact)
+
+      const contact = await service.getContact(123456, user)
+
+      expect(contact).toStrictEqual(expectedContact)
+      expect(apiClient.getContact).toHaveBeenCalledWith(123456, user)
+    })
+
+    it('Propagates errors', async () => {
+      apiClient.getContact.mockRejectedValue(new Error('some error'))
+      await expect(apiClient.getContact(123456, user)).rejects.toEqual(new Error('some error'))
     })
   })
 })

--- a/server/services/contactsService.ts
+++ b/server/services/contactsService.ts
@@ -63,4 +63,8 @@ export default class ContactsService {
   ): Promise<Contact> {
     return this.contactsApiClient.searchContact(contactSearchRequest, user, pagination)
   }
+
+  async getContact(contactId: number, user: Express.User): Promise<Contact> {
+    return this.contactsApiClient.getContact(contactId, user)
+  }
 }

--- a/server/views/pages/contacts/manage/contactSearch.njk
+++ b/server/views/pages/contacts/manage/contactSearch.njk
@@ -156,7 +156,7 @@
                 %}
                 
                 {% set contactNameHtml %}
-                    <a href="#" class="govuk-link govuk-link--no-visited-state bapv-result-row">
+                    <a href="/prisoner/{{ prisonerDetails.prisonerNumber }}/contacts/add/mode/EXISTING/{{ journey.id }}?contactId={{ result.id }}" class="govuk-link govuk-link--no-visited-state bapv-result-row" data-qa="add-contact-{{ result.id }}-link">
                         {{ (result.lastName + ", " + result.firstName) | convertToTitleCase }}
                     </a>
                 {% endset %}


### PR DESCRIPTION
An initial version of the add existing contact flow re-using the pages from the create journey.  WIP cypress tests and known issues with the check answers page. Also does not actually call the add contact relationship API yet.