### PR TITLE
PRC-45: Link in existing contact API

### DIFF
--- a/integration_tests/e2e/createContacts.cy.ts
+++ b/integration_tests/e2e/createContacts.cy.ts
@@ -86,9 +86,8 @@ context('Create Contacts', () => {
       .verifyShowRelationshipAs('Mother')
       .verifyShowIsEmergencyContactAs('No')
       .verifyShowIsNextOfKinAs('Yes')
-      .clickCreatePrisonerContact()
+      .continueTo(ListContactsPage)
 
-    Page.verifyOnPage(ListContactsPage)
     cy.verifyLastAPICall(
       {
         method: 'POST',
@@ -148,9 +147,8 @@ context('Create Contacts', () => {
       .verifyShowRelationshipAs('Mother')
       .verifyShowIsEmergencyContactAs('Yes')
       .verifyShowIsNextOfKinAs('No')
-      .clickCreatePrisonerContact()
+      .continueTo(ListContactsPage)
 
-    Page.verifyOnPage(ListContactsPage)
     cy.verifyLastAPICall(
       {
         method: 'POST',

--- a/integration_tests/e2e/createContactsCheckAnswersChangeDob.cy.ts
+++ b/integration_tests/e2e/createContactsCheckAnswersChangeDob.cy.ts
@@ -82,9 +82,7 @@ context('Create contact and update from check answers where we are changing the 
 
     Page.verifyOnPage(CreateContactCheckYourAnswersPage) //
       .verifyShowsDateOfBirthAs('16 July 1983')
-      .clickCreatePrisonerContact()
-
-    Page.verifyOnPage(ListContactsPage)
+      .continueTo(ListContactsPage)
 
     cy.verifyLastAPICall(
       {
@@ -131,9 +129,7 @@ context('Create contact and update from check answers where we are changing the 
     Page.verifyOnPage(CreateContactCheckYourAnswersPage) //
       .verifyShowsDateOfBirthAs('Not provided')
       .verifyShowsEstimatedDateOfBirthAs("I don't know")
-      .clickCreatePrisonerContact()
-
-    Page.verifyOnPage(ListContactsPage)
+      .continueTo(ListContactsPage)
 
     cy.verifyLastAPICall(
       {
@@ -180,9 +176,7 @@ context('Create contact and update from check answers where we are changing the 
 
     Page.verifyOnPage(CreateContactCheckYourAnswersPage) //
       .verifyShowsDateOfBirthAs('15 June 1982')
-      .clickCreatePrisonerContact()
-
-    Page.verifyOnPage(ListContactsPage)
+      .continueTo(ListContactsPage)
 
     cy.verifyLastAPICall(
       {
@@ -227,9 +221,7 @@ context('Create contact and update from check answers where we are changing the 
     Page.verifyOnPage(CreateContactCheckYourAnswersPage) //
       .verifyShowsDateOfBirthAs('Not provided')
       .verifyShowsEstimatedDateOfBirthAs('Yes')
-      .clickCreatePrisonerContact()
-
-    Page.verifyOnPage(ListContactsPage)
+      .continueTo(ListContactsPage)
 
     cy.verifyLastAPICall(
       {

--- a/integration_tests/e2e/createContactsCheckAnswersChangeOther.cy.ts
+++ b/integration_tests/e2e/createContactsCheckAnswersChangeOther.cy.ts
@@ -87,9 +87,7 @@ context('Create contact and update from check answers excluding DOB changes', ()
 
     Page.verifyOnPage(CreateContactCheckYourAnswersPage) //
       .verifyShowsNameAs('Last Updated, First Updated Middle Updated')
-      .clickCreatePrisonerContact()
-
-    Page.verifyOnPage(ListContactsPage)
+      .continueTo(ListContactsPage)
 
     cy.verifyLastAPICall(
       {
@@ -127,9 +125,7 @@ context('Create contact and update from check answers excluding DOB changes', ()
 
     Page.verifyOnPage(CreateContactCheckYourAnswersPage) //
       .verifyShowRelationshipAs('Father')
-      .clickCreatePrisonerContact()
-
-    Page.verifyOnPage(ListContactsPage)
+      .continueTo(ListContactsPage)
 
     cy.verifyLastAPICall(
       {
@@ -165,9 +161,7 @@ context('Create contact and update from check answers excluding DOB changes', ()
 
     Page.verifyOnPage(CreateContactCheckYourAnswersPage) //
       .verifyShowIsEmergencyContactAs('Yes')
-      .clickCreatePrisonerContact()
-
-    Page.verifyOnPage(ListContactsPage)
+      .continueTo(ListContactsPage)
 
     cy.verifyLastAPICall(
       {
@@ -203,9 +197,7 @@ context('Create contact and update from check answers excluding DOB changes', ()
 
     Page.verifyOnPage(CreateContactCheckYourAnswersPage) //
       .verifyShowIsNextOfKinAs('Yes')
-      .clickCreatePrisonerContact()
-
-    Page.verifyOnPage(ListContactsPage)
+      .continueTo(ListContactsPage)
 
     cy.verifyLastAPICall(
       {
@@ -241,9 +233,7 @@ context('Create contact and update from check answers excluding DOB changes', ()
 
     Page.verifyOnPage(CreateContactCheckYourAnswersPage) //
       .verifyShowCommentsAs('Some new comments I entered')
-      .clickCreatePrisonerContact()
-
-    Page.verifyOnPage(ListContactsPage)
+      .continueTo(ListContactsPage)
 
     cy.verifyLastAPICall(
       {

--- a/integration_tests/mockApis/contactsApi.ts
+++ b/integration_tests/mockApis/contactsApi.ts
@@ -22,9 +22,22 @@ export default {
         urlPath: '/contact',
       },
       response: {
-        status: 200,
+        status: 201,
         headers: { 'Content-Type': 'application/json;charset=UTF-8' },
         jsonBody: createdContact,
+      },
+    })
+  },
+
+  stubAddContactRelationship: (contactId: number): SuperAgentRequest => {
+    return stubFor({
+      request: {
+        method: 'POST',
+        urlPath: `/contact/${contactId}/relationship`,
+      },
+      response: {
+        status: 201,
+        headers: { 'Content-Type': 'application/json;charset=UTF-8' },
       },
     })
   },

--- a/integration_tests/pages/createContactCheckYourAnswersPage.ts
+++ b/integration_tests/pages/createContactCheckYourAnswersPage.ts
@@ -5,10 +5,6 @@ export default class CreateContactCheckYourAnswersPage extends Page {
     super(`Check your answers`)
   }
 
-  clickCreatePrisonerContact() {
-    this.createPrisonerContactButton().click()
-  }
-
   clickChangeNameLink() {
     this.changeNameLink().click()
   }
@@ -72,7 +68,20 @@ export default class CreateContactCheckYourAnswersPage extends Page {
     return this
   }
 
-  private createPrisonerContactButton = (): PageElement => cy.get('[data-qa=create-prisoner-contact-button]')
+  verifyNameIsNotChangeable(): CreateContactCheckYourAnswersPage {
+    this.changeNameLink().should('not.exist')
+    return this
+  }
+
+  verifyDateOfBirthIsNotChangeable(): CreateContactCheckYourAnswersPage {
+    this.changeDateOfBirthLink().should('not.exist')
+    return this
+  }
+
+  verifyEstimatedDateOfBirthIsNotChangeable(): CreateContactCheckYourAnswersPage {
+    this.changeEstimatedDateOfBirthLink().should('not.exist')
+    return this
+  }
 
   private checkAnswersNameValue = (): PageElement => cy.get('.check-answers-name-value')
 

--- a/server/data/contactsApiClient.test.ts
+++ b/server/data/contactsApiClient.test.ts
@@ -7,6 +7,7 @@ import Contact = contactsApiClientTypes.Contact
 import CreateContactRequest = contactsApiClientTypes.CreateContactRequest
 import ContactSearchRequest = contactsApiClientTypes.ContactSearchRequest
 import ReferenceCode = contactsApiClientTypes.ReferenceCode
+import AddContactRelationshipRequest = contactsApiClientTypes.AddContactRelationshipRequest
 
 jest.mock('./tokenStore/inMemoryTokenStore')
 
@@ -88,6 +89,67 @@ describe('contactsApiClient', () => {
       }
     })
   })
+
+  describe('addContactRelationship', () => {
+    it('should create the request and return the response', async () => {
+      // Given
+      const request: AddContactRelationshipRequest = {
+        relationship: {
+          prisonerNumber: 'A1234BC',
+          relationshipCode: 'MOT',
+          isNextOfKin: false,
+          isEmergencyContact: true,
+          comments: 'Some comments about this relationship',
+        },
+        createdBy: 'user1',
+      }
+
+      fakeContactsApi
+        .post('/contact/123456/relationship', request)
+        .matchHeader('authorization', `Bearer systemToken`)
+        .reply(201)
+
+      // When
+      await contactsApiClient.addContactRelationship(123456, request, user)
+
+      // Then
+      expect(nock.isDone()).toBe(true)
+    })
+
+    it.each([400, 401, 403, 500])('should propagate errors', async (errorCode: number) => {
+      // Given
+      const request: AddContactRelationshipRequest = {
+        relationship: {
+          prisonerNumber: 'A1234BC',
+          relationshipCode: 'MOT',
+          isNextOfKin: false,
+          isEmergencyContact: true,
+          comments: 'Some comments about this relationship',
+        },
+        createdBy: 'user1',
+      }
+      const expectedErrorBody = {
+        status: errorCode,
+        userMessage: 'Some error',
+        developerMessage: 'Some error',
+      }
+
+      fakeContactsApi
+        .post('/contact/123456/relationship', request)
+        .matchHeader('authorization', `Bearer systemToken`)
+        .reply(errorCode, expectedErrorBody)
+
+      // When
+      try {
+        await contactsApiClient.addContactRelationship(123456, request, user)
+      } catch (e) {
+        // Then
+        expect(e.status).toEqual(errorCode)
+        expect(e.data).toEqual(expectedErrorBody)
+      }
+    })
+  })
+
   describe('getReferenceCodes', () => {
     describe('createContact', () => {
       it('should create the request and return the response', async () => {

--- a/server/data/contactsApiClient.ts
+++ b/server/data/contactsApiClient.ts
@@ -7,6 +7,7 @@ import Pageable = contactsApiClientTypes.Pageable
 import PrisonerContactSummary = contactsApiClientTypes.PrisonerContactSummary
 import ReferenceCode = contactsApiClientTypes.ReferenceCode
 import ReferenceCodeType from '../enumeration/referenceCodeType'
+import AddContactRelationshipRequest = contactsApiClientTypes.AddContactRelationshipRequest
 
 export default class ContactsApiClient extends RestClient {
   constructor() {
@@ -17,6 +18,20 @@ export default class ContactsApiClient extends RestClient {
     return this.post<Contact>(
       {
         path: `/contact`,
+        data: request,
+      },
+      user,
+    )
+  }
+
+  async addContactRelationship(
+    contactId: number,
+    request: AddContactRelationshipRequest,
+    user: Express.User,
+  ): Promise<void> {
+    return this.post(
+      {
+        path: `/contact/${contactId}/relationship`,
         data: request,
       },
       user,

--- a/server/routes/contacts/add/check-answers/createContactCheckAnswersController.test.ts
+++ b/server/routes/contacts/add/check-answers/createContactCheckAnswersController.test.ts
@@ -144,6 +144,7 @@ describe('POST /prisoner/:prisonerNumber/contacts/create/check-answers/:journeyI
         type,
         url: '/some-prisoner-contact-page',
       }
+      journey.mode = 'NEW'
 
       // When
       await request(app)
@@ -154,6 +155,31 @@ describe('POST /prisoner/:prisonerNumber/contacts/create/check-answers/:journeyI
 
       // Then
       expect(contactsService.createContact).toHaveBeenCalledWith(journey, user)
+      expect(session.addContactJourneys[journeyId]).toBeUndefined()
+    },
+  )
+
+  it.each(['MANAGE_PRISONER_CONTACTS', 'PRISONER_CONTACTS'])(
+    'should add the contact relationship and pass to return url',
+    async (type: ReturnPointType) => {
+      // Given
+      contactsService.addContact.mockResolvedValue(null)
+      journey.returnPoint = {
+        type,
+        url: '/some-prisoner-contact-page',
+      }
+      journey.mode = 'EXISTING'
+      journey.contactId = 123456
+
+      // When
+      await request(app)
+        .post(`/prisoner/${prisonerNumber}/contacts/create/check-answers/${journeyId}`)
+        .type('form')
+        .expect(302)
+        .expect('Location', '/some-prisoner-contact-page')
+
+      // Then
+      expect(contactsService.addContact).toHaveBeenCalledWith(journey, user)
       expect(session.addContactJourneys[journeyId]).toBeUndefined()
     },
   )

--- a/server/routes/contacts/add/check-answers/createContactCheckAnswersController.ts
+++ b/server/routes/contacts/add/check-answers/createContactCheckAnswersController.ts
@@ -49,7 +49,13 @@ export default class CreateContactCheckAnswersController implements PageHandler 
     const { user } = res.locals
     const { journeyId } = req.params
     const journey = req.session.addContactJourneys[journeyId]
-    await this.contactService.createContact(journey, user).then(() => delete req.session.addContactJourneys[journeyId])
+    if (journey.mode === 'NEW') {
+      await this.contactService
+        .createContact(journey, user)
+        .then(() => delete req.session.addContactJourneys[journeyId])
+    } else if (journey.mode === 'EXISTING') {
+      await this.contactService.addContact(journey, user).then(() => delete req.session.addContactJourneys[journeyId])
+    }
     res.redirect(journey.returnPoint.url)
   }
 }

--- a/server/services/contactsService.test.ts
+++ b/server/services/contactsService.test.ts
@@ -8,6 +8,7 @@ import Contact = contactsApiClientTypes.Contact
 import CreateContactRequest = contactsApiClientTypes.CreateContactRequest
 import ContactSearchRequest = contactsApiClientTypes.ContactSearchRequest
 import IsOverEighteenOptions = journeys.YesNoOrDoNotKnow
+import AddContactRelationshipRequest = contactsApiClientTypes.AddContactRelationshipRequest
 
 jest.mock('../data/contactsApiClient')
 const contacts = TestData.contacts()
@@ -268,6 +269,123 @@ describe('contactsService', () => {
     it('Propagates errors', async () => {
       apiClient.getContact.mockRejectedValue(new Error('some error'))
       await expect(apiClient.getContact(123456, user)).rejects.toEqual(new Error('some error'))
+    })
+  })
+  describe('addContact', () => {
+    it('should add a contact relationship from the journey dto with all fields', async () => {
+      // Given
+      const expectedCreated: Contact = {
+        id: 2136718213,
+      }
+      apiClient.addContactRelationship.mockResolvedValue(expectedCreated)
+      const journey: AddContactJourney = {
+        id: '1',
+        lastTouched: new Date().toISOString(),
+        prisonerNumber,
+        isCheckingAnswers: false,
+        returnPoint: { type: 'PRISONER_CONTACTS', url: '/foo-bar' },
+        names: {
+          title: 'Mr',
+          lastName: 'last',
+          firstName: 'first',
+          middleName: 'middle',
+        },
+        dateOfBirth: {
+          isKnown: 'YES',
+          day: 1,
+          month: 6,
+          year: 1982,
+        },
+        relationship: {
+          type: 'MOT',
+          isEmergencyContact: 'NO',
+          isNextOfKin: 'YES',
+          comments: 'Some comments about this relationship',
+        },
+        contactId: 123456,
+      }
+      const expectedRequest: AddContactRelationshipRequest = {
+        relationship: {
+          prisonerNumber,
+          relationshipCode: 'MOT',
+          isNextOfKin: true,
+          isEmergencyContact: false,
+          comments: 'Some comments about this relationship',
+        },
+        createdBy: 'user1',
+      }
+
+      // When
+      const created = await service.addContact(journey, user)
+
+      // Then
+      expect(created).toStrictEqual(expectedCreated)
+      expect(apiClient.addContactRelationship).toHaveBeenCalledWith(123456, expectedRequest, user)
+    })
+
+    it('should add a contact relationship from the journey dto with only optional fields', async () => {
+      // Given
+      const expectedCreated: Contact = {
+        id: 2136718213,
+      }
+      apiClient.addContactRelationship.mockResolvedValue(expectedCreated)
+      const journey: AddContactJourney = {
+        id: '1',
+        lastTouched: new Date().toISOString(),
+        prisonerNumber,
+        isCheckingAnswers: false,
+        returnPoint: { type: 'PRISONER_CONTACTS', url: '/foo-bar' },
+        names: {
+          lastName: 'last',
+          firstName: 'first',
+        },
+        dateOfBirth: {
+          isKnown: 'NO',
+          isOverEighteen: 'DO_NOT_KNOW',
+        },
+        relationship: {
+          type: 'MOT',
+          isEmergencyContact: 'YES',
+          isNextOfKin: 'NO',
+        },
+        contactId: 123456,
+      }
+      const expectedRequest: AddContactRelationshipRequest = {
+        relationship: {
+          prisonerNumber,
+          relationshipCode: 'MOT',
+          isNextOfKin: false,
+          isEmergencyContact: true,
+        },
+        createdBy: 'user1',
+      }
+
+      // When
+      const created = await service.addContact(journey, user)
+
+      // Then
+      expect(created).toStrictEqual(expectedCreated)
+      expect(apiClient.addContactRelationship).toHaveBeenCalledWith(123456, expectedRequest, user)
+    })
+
+    it('should handle a bad request', async () => {
+      apiClient.addContactRelationship.mockRejectedValue(createError.BadRequest())
+      await expect(
+        service.addContact(
+          {
+            id: '1',
+            lastTouched: new Date().toISOString(),
+            prisonerNumber,
+            isCheckingAnswers: false,
+            returnPoint: { type: 'PRISONER_CONTACTS', url: '/foo-bar' },
+            names: { firstName: 'first', lastName: 'last' },
+            dateOfBirth: { isKnown: 'NO' },
+            relationship: { type: 'MOT', isEmergencyContact: 'YES', isNextOfKin: 'NO' },
+            contactId: 123456,
+          },
+          user,
+        ),
+      ).rejects.toBeInstanceOf(BadRequest)
     })
   })
 })

--- a/server/services/contactsService.ts
+++ b/server/services/contactsService.ts
@@ -5,6 +5,7 @@ import CreateContactRequest = contactsApiClientTypes.CreateContactRequest
 import ContactSearchRequest = contactsApiClientTypes.ContactSearchRequest
 import Pageable = contactsApiClientTypes.Pageable
 import PrisonerContactSummary = contactsApiClientTypes.PrisonerContactSummary
+import AddContactRelationshipRequest = contactsApiClientTypes.AddContactRelationshipRequest
 
 export default class ContactsService {
   constructor(private readonly contactsApiClient: ContactsApiClient) {}
@@ -46,6 +47,20 @@ export default class ContactsService {
       createdBy: user.username,
     }
     return this.contactsApiClient.createContact(request, user)
+  }
+
+  async addContact(journey: AddContactJourney, user: Express.User): Promise<Contact> {
+    const request: AddContactRelationshipRequest = {
+      relationship: {
+        prisonerNumber: journey.prisonerNumber,
+        relationshipCode: journey.relationship.type,
+        isNextOfKin: journey.relationship.isNextOfKin === 'YES',
+        isEmergencyContact: journey.relationship.isEmergencyContact === 'YES',
+        comments: journey.relationship.comments,
+      },
+      createdBy: user.username,
+    }
+    return this.contactsApiClient.addContactRelationship(journey.contactId, request, user)
   }
 
   async getPrisonerContacts(

--- a/server/views/pages/contacts/add/checkAnswers.njk
+++ b/server/views/pages/contacts/add/checkAnswers.njk
@@ -38,7 +38,7 @@
                                     attributes: {"data-qa": "change-name-link"},
                                     classes: "govuk-link--no-visited-state"
                                 }
-                            ]
+                            ] if journey.mode === 'NEW'
                         }
                     },
                     {
@@ -57,7 +57,7 @@
                                     visuallyHiddenText: "date of birth",
                                     attributes: {"data-qa": "change-dob-link"},
                                     classes: "govuk-link--no-visited-state"
-                                }
+                                } if journey.mode === 'NEW'
                             ]
                         }
                     }
@@ -81,7 +81,7 @@
                                         attributes: {"data-qa": "change-estimated-dob-link"},
                                         classes: "govuk-link--no-visited-state"
                                     }
-                                ]
+                                ] if journey.mode === 'NEW'
                             }
                         }
                     ), contactDetailsRows) %}
@@ -184,12 +184,13 @@
                         }
                     ]
                 }) }}
+                {% set buttonLabel = "Create prisoner contact" if journey.mode === 'NEW' else "Add prisoner contact" %}
                 <div class="govuk-button-group">
                     {{ govukButton({
-                        html: "Create prisoner contact",
+                        html: buttonLabel,
                         type: "submit",
                         classes: 'govuk-!-margin-top-6',
-                        attributes: {"data-qa": "create-prisoner-contact-button"}
+                        attributes: {"data-qa": "continue-button"}
                     }) }}
                     <a class="govuk-link govuk-link--no-visited-state govuk-!-font-size-19" href="{{ journey.returnPoint.url }}" data-qa="cancel-button">Cancel</a>
                 </div>


### PR DESCRIPTION
Existing contact flow now actually calls the API and hides the links on change answers for name and date of birth.