### PR TITLE
PRC-48: Relationship page fixes

### DIFF
--- a/assets/js/unbundled/relationshipHint.js
+++ b/assets/js/unbundled/relationshipHint.js
@@ -1,11 +1,13 @@
 document.addEventListener('DOMContentLoaded', event => {
+  const excludedValues = ['NONE', 'OTHER', 'ILP']
   function updateHint() {
     const hintDiv = document.querySelector('#selected-relationship-hint')
     const name = hintDiv.dataset.contact
-    const selectedRelationship = document.querySelector('#relationship option:checked').innerHTML
-    let hint = ''
-    if (selectedRelationship.length > 0) {
-      hint = '<b>' + name + "</b> is the prisoner's <b>" + selectedRelationship.toLowerCase() + '</b>'
+    const selectedRelationship = document.querySelector('#relationship option:checked')
+    const selectedRelationshipValue = selectedRelationship.value
+    let hint = '&nbsp;'
+    if (selectedRelationshipValue.length > 0 && !excludedValues.includes(selectedRelationshipValue)) {
+      hint = '<b>' + name + "</b> is the prisoner's <b>" + selectedRelationship.innerHTML.toLowerCase() + '</b>.'
     }
     hintDiv.innerHTML = hint
   }

--- a/integration_tests/e2e/addExistingContact.cy.ts
+++ b/integration_tests/e2e/addExistingContact.cy.ts
@@ -29,7 +29,7 @@ context('Add Existing Contact', () => {
         totalElements: 1,
         content: [contact],
       },
-      lastName: 'FOO',
+      lastName: 'Contact',
       firstName: '',
       middleName: '',
       dateOfBirth: '',
@@ -42,7 +42,7 @@ context('Add Existing Contact', () => {
       .clickAddNewContactButton()
 
     Page.verifyOnPage(SearchContactPage) //
-      .enterLastName('FOO')
+      .enterLastName('Contact')
       .clickSearchButton()
   })
 
@@ -58,9 +58,9 @@ context('Add Existing Contact', () => {
       .clickTheContactLink(contactId)
 
     Page.verifyOnPage(SelectRelationshipPage, 'Contact, Existing') //
-      .hasSelectedRelationshipHint('')
+      .hasNoRelationshipHint()
       .selectRelationship('MOT')
-      .hasSelectedRelationshipHint("Contact, Existing is the prisoner's mother")
+      .hasSelectedRelationshipHint("Contact, Existing is the prisoner's mother.")
       .clickContinue()
 
     Page.verifyOnPage(SelectEmergencyContactPage, 'Contact, Existing') //
@@ -117,9 +117,9 @@ context('Add Existing Contact', () => {
       .clickTheContactLink(contactId)
 
     Page.verifyOnPage(SelectRelationshipPage, 'Contact, Existing') //
-      .hasSelectedRelationshipHint('')
+      .hasNoRelationshipHint()
       .selectRelationship('MOT')
-      .hasSelectedRelationshipHint("Contact, Existing is the prisoner's mother")
+      .hasSelectedRelationshipHint("Contact, Existing is the prisoner's mother.")
       .clickContinue()
 
     Page.verifyOnPage(SelectEmergencyContactPage, 'Contact, Existing') //
@@ -174,9 +174,9 @@ context('Add Existing Contact', () => {
       .clickTheContactLink(contactId)
 
     Page.verifyOnPage(SelectRelationshipPage, 'Contact, Existing') //
-      .hasSelectedRelationshipHint('')
+      .hasNoRelationshipHint()
       .selectRelationship('MOT')
-      .hasSelectedRelationshipHint("Contact, Existing is the prisoner's mother")
+      .hasSelectedRelationshipHint("Contact, Existing is the prisoner's mother.")
       .clickContinue()
 
     const selectEmergencyContactPage = Page.verifyOnPage(SelectEmergencyContactPage, 'Contact, Existing')
@@ -216,9 +216,9 @@ context('Add Existing Contact', () => {
       .clickTheContactLink(contactId)
 
     Page.verifyOnPage(SelectRelationshipPage, 'Contact, Existing') //
-      .hasSelectedRelationshipHint('')
+      .hasNoRelationshipHint()
       .selectRelationship('MOT')
-      .hasSelectedRelationshipHint("Contact, Existing is the prisoner's mother")
+      .hasSelectedRelationshipHint("Contact, Existing is the prisoner's mother.")
       .clickContinue()
 
     Page.verifyOnPage(SelectEmergencyContactPage, 'Contact, Existing') //
@@ -228,5 +228,58 @@ context('Add Existing Contact', () => {
     const selectNextOfKinPage = Page.verifyOnPage(SelectNextOfKinPage, 'Contact, Existing')
     selectNextOfKinPage.clickContinue()
     selectNextOfKinPage.hasFieldInError('isNextOfKin', 'Select whether the contact is next of kin for the prisoner')
+  })
+
+  it('Relationship hint is hidden for None, Social - Other and In Loco Parentes', () => {
+    cy.task('stubGetContactById', {
+      id: contactId,
+      firstName: 'Existing',
+      lastName: 'Contact',
+      dateOfBirth: '1990-01-14',
+    })
+
+    Page.verifyOnPage(SearchContactPage) //
+      .clickTheContactLink(contactId)
+
+    Page.verifyOnPage(SelectRelationshipPage, 'Contact, Existing') //
+      .hasNoRelationshipHint()
+      .selectRelationship('MOT')
+      .hasSelectedRelationshipHint("Contact, Existing is the prisoner's mother.")
+      .selectRelationship('NONE')
+      .hasNoRelationshipHint()
+      .selectRelationship('MOT')
+      .hasSelectedRelationshipHint("Contact, Existing is the prisoner's mother.")
+      .selectRelationship('OTHER')
+      .hasNoRelationshipHint()
+      .selectRelationship('MOT')
+      .hasSelectedRelationshipHint("Contact, Existing is the prisoner's mother.")
+      .selectRelationship('ILP')
+      .hasNoRelationshipHint()
+  })
+
+  it('Can navigate all the way back to search from relationship comments', () => {
+    cy.task('stubGetContactById', {
+      id: contactId,
+      firstName: 'Existing',
+      lastName: 'Contact',
+      dateOfBirth: '1990-01-14',
+    })
+
+    Page.verifyOnPage(SearchContactPage) //
+      .clickTheContactLink(contactId)
+
+    Page.verifyOnPage(SelectRelationshipPage, 'Contact, Existing') //
+      .hasNoRelationshipHint()
+      .selectRelationship('MOT')
+      .continueTo(SelectEmergencyContactPage, 'Contact, Existing') //
+      .selectIsEmergencyContact('NO')
+      .continueTo(SelectNextOfKinPage, 'Contact, Existing') //
+      .selectIsNextOfKin('YES')
+      .continueTo(RelationshipCommentsPage, 'Contact, Existing') //
+      .backTo(SelectNextOfKinPage, 'Contact, Existing')
+      .backTo(SelectEmergencyContactPage, 'Contact, Existing')
+      .backTo(SelectRelationshipPage, 'Contact, Existing')
+      .backTo(SearchContactPage)
+      .verifyShowsNameAs('Contact, Existing')
   })
 })

--- a/integration_tests/e2e/addExistingContactCheckAnswers.cy.ts
+++ b/integration_tests/e2e/addExistingContactCheckAnswers.cy.ts
@@ -80,9 +80,9 @@ context('Add Existing Contact Check Answers', () => {
       .clickChangeRelationshipLink()
 
     Page.verifyOnPage(SelectRelationshipPage, 'Contact, Existing') //
-      .hasSelectedRelationshipHint("Contact, Existing is the prisoner's mother")
+      .hasSelectedRelationshipHint("Contact, Existing is the prisoner's mother.")
       .selectRelationship('FA')
-      .hasSelectedRelationshipHint("Contact, Existing is the prisoner's father")
+      .hasSelectedRelationshipHint("Contact, Existing is the prisoner's father.")
       .clickContinue()
 
     Page.verifyOnPage(CreateContactCheckYourAnswersPage) //

--- a/integration_tests/e2e/createContacts.cy.ts
+++ b/integration_tests/e2e/createContacts.cy.ts
@@ -56,9 +56,9 @@ context('Create Contacts', () => {
       .clickContinue()
 
     Page.verifyOnPage(SelectRelationshipPage, 'Last, First') //
-      .hasSelectedRelationshipHint('')
+      .hasNoRelationshipHint()
       .selectRelationship('MOT')
-      .hasSelectedRelationshipHint("Last, First is the prisoner's mother")
+      .hasSelectedRelationshipHint("Last, First is the prisoner's mother.")
       .clickContinue()
 
     Page.verifyOnPage(SelectEmergencyContactPage, 'Last, First') //
@@ -117,9 +117,9 @@ context('Create Contacts', () => {
       .clickContinue()
 
     Page.verifyOnPage(SelectRelationshipPage, 'Last, First Middle') //
-      .hasSelectedRelationshipHint('')
+      .hasNoRelationshipHint()
       .selectRelationship('MOT')
-      .hasSelectedRelationshipHint("Last, First Middle is the prisoner's mother")
+      .hasSelectedRelationshipHint("Last, First Middle is the prisoner's mother.")
       .clickContinue()
 
     Page.verifyOnPage(SelectEmergencyContactPage, 'Last, First Middle') //
@@ -229,9 +229,9 @@ context('Create Contacts', () => {
       .clickContinue()
 
     Page.verifyOnPage(SelectRelationshipPage, 'Last, First') //
-      .hasSelectedRelationshipHint('')
+      .hasNoRelationshipHint()
       .selectRelationship('MOT')
-      .hasSelectedRelationshipHint("Last, First is the prisoner's mother")
+      .hasSelectedRelationshipHint("Last, First is the prisoner's mother.")
       .clickContinue()
 
     const selectEmergencyContactPage = Page.verifyOnPage(SelectEmergencyContactPage, 'Last, First')
@@ -250,9 +250,9 @@ context('Create Contacts', () => {
       .clickContinue()
 
     Page.verifyOnPage(SelectRelationshipPage, 'Last, First') //
-      .hasSelectedRelationshipHint('')
+      .hasNoRelationshipHint()
       .selectRelationship('MOT')
-      .hasSelectedRelationshipHint("Last, First is the prisoner's mother")
+      .hasSelectedRelationshipHint("Last, First is the prisoner's mother.")
       .clickContinue()
 
     Page.verifyOnPage(SelectEmergencyContactPage, 'Last, First') //
@@ -272,9 +272,9 @@ context('Create Contacts', () => {
       .clickContinue()
 
     Page.verifyOnPage(SelectRelationshipPage, 'Last, First') //
-      .hasSelectedRelationshipHint('')
+      .hasNoRelationshipHint()
       .selectRelationship('MOT')
-      .hasSelectedRelationshipHint("Last, First is the prisoner's mother")
+      .hasSelectedRelationshipHint("Last, First is the prisoner's mother.")
       .clickContinue()
 
     Page.verifyOnPage(SelectEmergencyContactPage, 'Last, First') //
@@ -298,9 +298,9 @@ context('Create Contacts', () => {
       .clickContinue()
 
     Page.verifyOnPage(SelectRelationshipPage, 'Last, First') //
-      .hasSelectedRelationshipHint('')
+      .hasNoRelationshipHint()
       .selectRelationship('MOT')
-      .hasSelectedRelationshipHint("Last, First is the prisoner's mother")
+      .hasSelectedRelationshipHint("Last, First is the prisoner's mother.")
       .clickContinue()
 
     Page.verifyOnPage(SelectEmergencyContactPage, 'Last, First') //
@@ -329,9 +329,9 @@ context('Create Contacts', () => {
       .clickContinue()
 
     Page.verifyOnPage(SelectRelationshipPage, 'Last, First') //
-      .hasSelectedRelationshipHint('')
+      .hasNoRelationshipHint()
       .selectRelationship('MOT')
-      .hasSelectedRelationshipHint("Last, First is the prisoner's mother")
+      .hasSelectedRelationshipHint("Last, First is the prisoner's mother.")
       .clickContinue()
 
     Page.verifyOnPage(SelectEmergencyContactPage, 'Last, First') //
@@ -365,9 +365,9 @@ context('Create Contacts', () => {
       .clickContinue()
 
     Page.verifyOnPage(SelectRelationshipPage, 'Last, First') //
-      .hasSelectedRelationshipHint('')
+      .hasNoRelationshipHint()
       .selectRelationship('MOT')
-      .hasSelectedRelationshipHint("Last, First is the prisoner's mother")
+      .hasSelectedRelationshipHint("Last, First is the prisoner's mother.")
       .clickContinue()
 
     Page.verifyOnPage(SelectEmergencyContactPage, 'Last, First') //

--- a/integration_tests/e2e/createContactsCheckAnswersChangeOther.cy.ts
+++ b/integration_tests/e2e/createContactsCheckAnswersChangeOther.cy.ts
@@ -118,9 +118,9 @@ context('Create contact and update from check answers excluding DOB changes', ()
       .clickChangeRelationshipLink()
 
     Page.verifyOnPage(SelectRelationshipPage, 'Last, First Middle') //
-      .hasSelectedRelationshipHint("Last, First Middle is the prisoner's mother")
+      .hasSelectedRelationshipHint("Last, First Middle is the prisoner's mother.")
       .selectRelationship('FA')
-      .hasSelectedRelationshipHint("Last, First Middle is the prisoner's father")
+      .hasSelectedRelationshipHint("Last, First Middle is the prisoner's father.")
       .clickContinue()
 
     Page.verifyOnPage(CreateContactCheckYourAnswersPage) //

--- a/integration_tests/pages/selectRelationshipPage.ts
+++ b/integration_tests/pages/selectRelationshipPage.ts
@@ -15,6 +15,11 @@ export default class SelectRelationshipPage extends Page {
     return this
   }
 
+  hasNoRelationshipHint(): SelectRelationshipPage {
+    this.selectedRelationshipHint().should('contain.html', '&nbsp;')
+    return this
+  }
+
   private relationshipSelect = (): PageElement => cy.get('#relationship')
 
   private selectedRelationshipHint = (): PageElement => cy.get('#selected-relationship-hint')

--- a/server/routes/contacts/add/addContactFlowControl.test.ts
+++ b/server/routes/contacts/add/addContactFlowControl.test.ts
@@ -200,7 +200,7 @@ describe('addContactFlowControl', () => {
     describe('getNavigationForAddContactJourney', () => {
       const journeyId = uuidv4()
       it.each([
-        [Page.SELECT_CONTACT_RELATIONSHIP, undefined],
+        [Page.SELECT_CONTACT_RELATIONSHIP, `/prisoner/A1234BC/contacts/search/${journeyId}`],
         [Page.SELECT_EMERGENCY_CONTACT, `/prisoner/A1234BC/contacts/create/select-relationship/${journeyId}`],
         [Page.SELECT_NEXT_OF_KIN, `/prisoner/A1234BC/contacts/create/select-emergency-contact/${journeyId}`],
         [Page.ENTER_RELATIONSHIP_COMMENTS, `/prisoner/A1234BC/contacts/create/select-next-of-kin/${journeyId}`],

--- a/server/routes/contacts/add/addContactFlowControl.ts
+++ b/server/routes/contacts/add/addContactFlowControl.ts
@@ -138,7 +138,7 @@ const EXISTING_CONTACT_SPEC: Record<ExistingContactPages, Spec> = {
     nextUrl: checkAnswersOr(PAGES.SELECT_CONTACT_RELATIONSHIP.url),
   },
   [Page.SELECT_CONTACT_RELATIONSHIP]: {
-    previousUrl: _ => undefined,
+    previousUrl: PAGES.CONTACT_SEARCH_PAGE.url,
     nextUrl: checkAnswersOr(PAGES.SELECT_EMERGENCY_CONTACT.url),
   },
   [Page.SELECT_EMERGENCY_CONTACT]: {

--- a/server/routes/contacts/add/relationship/selectRelationshipController.test.ts
+++ b/server/routes/contacts/add/relationship/selectRelationshipController.test.ts
@@ -6,7 +6,7 @@ import * as cheerio from 'cheerio'
 import { appWithAllRoutes, user } from '../../../testutils/appSetup'
 import AuditService, { Page } from '../../../../services/auditService'
 import ReferenceDataService from '../../../../services/referenceDataService'
-import { mockedReferenceData } from '../../../testutils/stubReferenceData'
+import { mockedReferenceData, STUBBED_RELATIONSHIP_OPTIONS } from '../../../testutils/stubReferenceData'
 import AddContactJourney = journeys.AddContactJourney
 import PrisonerSearchService from '../../../../services/prisonerSearchService'
 import TestData from '../../../testutils/testData'
@@ -78,8 +78,33 @@ describe('GET /prisoner/:prisonerNumber/contacts/create/select-relationship', ()
       )
       expect($('[data-qa=cancel-button]').first().attr('href')).toStrictEqual('/foo-bar')
       expect($('[data-qa=breadcrumbs]')).toHaveLength(0)
+      expect($('#relationship :nth-child(1)').text()).toStrictEqual('')
+      expect($('#relationship :nth-child(2)').text()).toStrictEqual('Daughter')
+      expect($(`#relationship :nth-child(${STUBBED_RELATIONSHIP_OPTIONS.length + 1})`).text()).toStrictEqual(
+        'ZZZ Alphabetically Last',
+      )
     },
   )
+
+  it('options should be alphabetic', async () => {
+    // Given
+    auditService.logPageView.mockResolvedValue(null)
+
+    // When
+    const response = await request(app).get(
+      `/prisoner/${prisonerNumber}/contacts/create/select-relationship/${journeyId}`,
+    )
+
+    // Then
+    expect(response.status).toEqual(200)
+
+    const $ = cheerio.load(response.text)
+    expect($('#relationship :nth-child(1)').text()).toStrictEqual('')
+    expect($('#relationship :nth-child(2)').text()).toStrictEqual('Daughter')
+    expect($(`#relationship :nth-child(${STUBBED_RELATIONSHIP_OPTIONS.length + 1})`).text()).toStrictEqual(
+      'ZZZ Alphabetically Last',
+    )
+  })
 
   it('should call the audit service for the page view', async () => {
     // Given

--- a/server/routes/contacts/add/relationship/selectRelationshipController.ts
+++ b/server/routes/contacts/add/relationship/selectRelationshipController.ts
@@ -3,10 +3,10 @@ import { Page } from '../../../../services/auditService'
 import { PageHandler } from '../../../../interfaces/pageHandler'
 import ReferenceCodeType from '../../../../enumeration/referenceCodeType'
 import ReferenceDataService from '../../../../services/referenceDataService'
-import ReferenceCode = contactsApiClientTypes.ReferenceCode
 import { SelectRelationshipSchema } from './selectRelationshipSchemas'
-import PrisonerJourneyParams = journeys.PrisonerJourneyParams
 import { navigationForAddContactJourney, nextPageForAddContactJourney } from '../addContactFlowControl'
+import ReferenceCode = contactsApiClientTypes.ReferenceCode
+import PrisonerJourneyParams = journeys.PrisonerJourneyParams
 
 export default class SelectRelationshipController implements PageHandler {
   constructor(private readonly referenceDataService: ReferenceDataService) {}
@@ -55,13 +55,15 @@ export default class SelectRelationshipController implements PageHandler {
     text: string
     selected?: boolean
   }> {
-    const mappedOptions = options.map((relationship: ReferenceCode) => {
-      return {
-        text: relationship.description,
-        value: relationship.code,
-        selected: relationship.code === selected,
-      }
-    })
+    const mappedOptions = options
+      .map((relationship: ReferenceCode) => {
+        return {
+          text: relationship.description,
+          value: relationship.code,
+          selected: relationship.code === selected,
+        }
+      })
+      .sort((a, b) => a.text.localeCompare(b.text))
     return [{ text: '', value: '' }, ...mappedOptions]
   }
 }

--- a/server/routes/testutils/stubReferenceData.ts
+++ b/server/routes/testutils/stubReferenceData.ts
@@ -26,7 +26,11 @@ const STUBBED_RELATIONSHIP_OPTIONS: StubReferenceData[] = [
   { code: 'DAU', description: 'Daughter', groupCode: 'RELATIONSHIP' },
   { code: 'SON', description: 'Son', groupCode: 'RELATIONSHIP' },
   { code: 'WIFE', description: 'Wife', groupCode: 'RELATIONSHIP' },
+  { code: 'FOO', description: 'ZZZ Alphabetically Last', groupCode: 'RELATIONSHIP' },
   { code: 'HUS', description: 'Husband', groupCode: 'RELATIONSHIP' },
+  { code: 'OTHER', description: 'Other - Social', groupCode: 'RELATIONSHIP' },
+  { code: 'NONE', description: 'None', groupCode: 'RELATIONSHIP' },
+  { code: 'ILP', description: 'In Loco Parentes', groupCode: 'RELATIONSHIP' },
 ]
 
 const mockedReferenceData = (type: ReferenceCodeType, _: HmppsUser): Promise<StubReferenceData[]> => {

--- a/server/views/pages/contacts/add/selectRelationship.njk
+++ b/server/views/pages/contacts/add/selectRelationship.njk
@@ -30,7 +30,7 @@
                     items: relationshipOptions,
                     errorMessage: validationErrors | findError('relationship')
                 }) }}
-                <div id="selected-relationship-hint" data-contact="{{ journey.names | formatName }}"></div>
+                <div id="selected-relationship-hint" data-contact="{{ journey.names | formatName }}">&nbsp;</div>
                 <div class="govuk-button-group">
                     {{ govukButton({
                         html: "Continue",


### PR DESCRIPTION
Add missing full stop to hint and default to a blank space so the continue button doesn't jump around.

Exclude NONE, ILP and OTHER from displaying the hint.

Sort options alphabetically.

Add back link to take to back to search results