### PR TITLE
PRC-152: Re-import contacts types and fix test data factories

### DIFF
--- a/integration_tests/e2e/addExistingContact.cy.ts
+++ b/integration_tests/e2e/addExistingContact.cy.ts
@@ -12,7 +12,17 @@ import ContactConfirmationPage from '../pages/contactConfirmationPage'
 context('Add Existing Contact', () => {
   const { prisonerNumber } = TestData.prisoner()
   const contactId = 654321
-  const contact = TestData.contacts({ id: contactId, lastName: 'Contact', firstName: 'Existing', middleName: '' })
+  const contact = TestData.contact({
+    id: contactId,
+    lastName: 'Contact',
+    firstName: 'Existing',
+  })
+  const searchResult = TestData.contactSearchResultItem({
+    id: contact.id,
+    lastName: contact.lastName,
+    firstName: contact.firstName,
+    middleName: contact.middleName,
+  })
 
   beforeEach(() => {
     cy.task('reset')
@@ -28,7 +38,7 @@ context('Add Existing Contact', () => {
       results: {
         totalPages: 1,
         totalElements: 1,
-        content: [contact],
+        content: [searchResult],
       },
       lastName: 'Contact',
       firstName: '',

--- a/integration_tests/e2e/addExistingContactCheckAnswers.cy.ts
+++ b/integration_tests/e2e/addExistingContactCheckAnswers.cy.ts
@@ -12,7 +12,17 @@ import ContactConfirmationPage from '../pages/contactConfirmationPage'
 context('Add Existing Contact Check Answers', () => {
   const { prisonerNumber } = TestData.prisoner()
   const contactId = 654321
-  const contact = TestData.contacts({ id: contactId, lastName: 'Contact', firstName: 'Existing', middleName: '' })
+  const contact = TestData.contact({
+    id: contactId,
+    lastName: 'Contact',
+    firstName: 'Existing',
+  })
+  const searchResult = TestData.contactSearchResultItem({
+    id: contact.id,
+    lastName: contact.lastName,
+    firstName: contact.firstName,
+    middleName: contact.middleName,
+  })
 
   beforeEach(() => {
     cy.task('reset')
@@ -28,7 +38,7 @@ context('Add Existing Contact Check Answers', () => {
       results: {
         totalPages: 1,
         totalElements: 1,
-        content: [contact],
+        content: [searchResult],
       },
       lastName: 'FOO',
       firstName: '',

--- a/integration_tests/e2e/contactConfirmationPage.cy.ts
+++ b/integration_tests/e2e/contactConfirmationPage.cy.ts
@@ -10,7 +10,17 @@ const SELECT_IS_THE_RIGHT_PERSON_MESSAGE = 'Select whether this is the right con
 context('Contact confirmation', () => {
   const { prisonerNumber } = TestData.prisoner()
   const contactId = 654321
-  const contact = TestData.contacts({ id: contactId, lastName: 'Contact', firstName: 'Existing', middleName: '' })
+  const contact = TestData.contact({
+    id: contactId,
+    lastName: 'Contact',
+    firstName: 'Existing',
+  })
+  const searchResult = TestData.contactSearchResultItem({
+    id: contact.id,
+    lastName: contact.lastName,
+    firstName: contact.firstName,
+    middleName: contact.middleName,
+  })
   const journeyId = uuidv4()
 
   beforeEach(() => {
@@ -27,7 +37,7 @@ context('Contact confirmation', () => {
       results: {
         totalPages: 1,
         totalElements: 1,
-        content: [contact],
+        content: [searchResult],
       },
       lastName: 'Contact',
       firstName: '',

--- a/integration_tests/e2e/searchContact.cy.ts
+++ b/integration_tests/e2e/searchContact.cy.ts
@@ -37,7 +37,7 @@ context('Search contact', () => {
       results: {
         totalPages: 1,
         totalElements: 1,
-        content: [TestData.contacts()],
+        content: [TestData.contactSearchResultItem()],
       },
       lastName: 'Mason',
       firstName: '',
@@ -173,7 +173,7 @@ context('Search contact', () => {
       results: {
         totalPages: 1,
         totalElements: 1,
-        content: [TestData.contacts()],
+        content: [TestData.contactSearchResultItem()],
       },
       lastName: 'Mason',
       firstName: 'Jones',
@@ -206,7 +206,7 @@ context('Search contact', () => {
       results: {
         totalPages: 1,
         totalElements: 1,
-        content: [TestData.contacts()],
+        content: [TestData.contactSearchResultItem()],
       },
       lastName: 'Mason',
       firstName: 'Jones',

--- a/integration_tests/mockApis/contactsApi.ts
+++ b/integration_tests/mockApis/contactsApi.ts
@@ -3,19 +3,11 @@ import { stubFor } from './wiremock'
 import { STUBBED_RELATIONSHIP_OPTIONS, STUBBED_TITLE_OPTIONS } from '../../server/routes/testutils/stubReferenceData'
 import { components } from '../../server/@types/contactsApi'
 
-type Contact = components['schemas']['Contact']
+export type StubGetContactResponse = components['schemas']['GetContactResponse']
+export type StubContactSearchResultItem = components['schemas']['ContactSearchResultItem']
 
 export default {
-  stubCreateContact: (createdContact: {
-    id: number
-    title?: string | null
-    lastName: string
-    firstName: string
-    middleName?: string | null
-    dateOfBirth?: string | null
-    createdBy: string
-    createdTime: string
-  }): SuperAgentRequest => {
+  stubCreateContact: (createdContact: StubGetContactResponse): SuperAgentRequest => {
     return stubFor({
       request: {
         method: 'POST',
@@ -152,7 +144,7 @@ export default {
     page = '0',
     size = '10',
   }: {
-    results: { totalPages: number; totalElements: number; content: Contact[] }
+    results: { totalPages: number; totalElements: number; content: StubContactSearchResultItem[] }
     lastName: string
     middleName: string
     firstName: string

--- a/server/@types/contactsApi/index.d.ts
+++ b/server/@types/contactsApi/index.d.ts
@@ -1657,7 +1657,7 @@ export interface components {
       moreInfo?: string
     }
     /** @description The details of a contact as an individual */
-    Contact: {
+    GetContactResponse: {
       /**
        * Format: int64
        * @description The id of the contact
@@ -1696,6 +1696,17 @@ export interface components {
        * @enum {string}
        */
       estimatedIsOverEighteen?: 'YES' | 'NO' | 'DO_NOT_KNOW'
+      /**
+       * @description The date the contact deceased, if known
+       * @example false
+       */
+      isDeceased: boolean
+      /**
+       * Format: date
+       * @description The date the contact deceased, if known
+       * @example 1980-01-01
+       */
+      deceasedDate?: string | null
       /**
        * @description The id of the user who created the contact
        * @example JD000001
@@ -2135,6 +2146,44 @@ export interface components {
        * @example false
        */
       noFixedAddress?: boolean | null
+    }
+    ContactSearchResultItemPage: {
+      content?: components['schemas']['ContactSearchResultItem'][]
+      pageable?: components['schemas']['PageableObject']
+      /** Format: int64 */
+      total?: number
+      last?: boolean
+      /** Format: int64 */
+      totalElements?: number
+      /** Format: int32 */
+      totalPages?: number
+      first?: boolean
+      /** Format: int32 */
+      size?: number
+      /** Format: int32 */
+      number?: number
+      sort?: components['schemas']['SortObject'][]
+      /** Format: int32 */
+      numberOfElements?: number
+      empty?: boolean
+    }
+    PageableObject: {
+      /** Format: int64 */
+      offset?: number
+      sort?: components['schemas']['SortObject'][]
+      /** Format: int32 */
+      pageSize?: number
+      paged?: boolean
+      /** Format: int32 */
+      pageNumber?: number
+      unpaged?: boolean
+    }
+    SortObject: {
+      direction?: string
+      nullHandling?: string
+      ascending?: boolean
+      property?: string
+      ignoreCase?: boolean
     }
     /** @description City reference entity */
     City: {
@@ -2669,7 +2718,7 @@ export interface operations {
           [name: string]: unknown
         }
         content: {
-          'application/json': components['schemas']['Contact']
+          'application/json': components['schemas']['GetContactResponse']
         }
       }
       /** @description The request has invalid or missing fields */
@@ -2734,9 +2783,7 @@ export interface operations {
         headers: {
           [name: string]: unknown
         }
-        content: {
-          'application/json': components['schemas']['Contact']
-        }
+        content?: never
       }
       /** @description The request has invalid or missing fields */
       400: {
@@ -3545,7 +3592,7 @@ export interface operations {
           [name: string]: unknown
         }
         content: {
-          'application/json': components['schemas']['Contact']
+          'application/json': components['schemas']['GetContactResponse']
         }
       }
       /** @description Unauthorised, requires a valid Oauth2 token */
@@ -3597,7 +3644,7 @@ export interface operations {
           [name: string]: unknown
         }
         content: {
-          'application/json': components['schemas']['ContactSearchResultItem']
+          'application/json': components['schemas']['ContactSearchResultItemPage']
         }
       }
       /** @description Invalid request */

--- a/server/@types/contactsApiClient/index.d.ts
+++ b/server/@types/contactsApiClient/index.d.ts
@@ -6,7 +6,7 @@ declare namespace contactsApiClientTypes {
   export type PrisonerContactSummary = components['schemas']['PrisonerContactSummary']
   export type ReferenceCode = components['schemas']['ReferenceCode']
   export type ContactSearchRequest = components['schemas']['ContactSearchRequest']
-  export type ContactSearchResultItem = components['schemas']['ContactSearchResultItem']
+  export type ContactSearchResultItemPage = components['schemas']['ContactSearchResultItemPage']
   export type Pageable = components['schema']['Pageable']
   export type AddContactRelationshipRequest = components['schema']['AddContactRelationshipRequest']
 }

--- a/server/data/contactsApiClient.test.ts
+++ b/server/data/contactsApiClient.test.ts
@@ -8,6 +8,7 @@ import CreateContactRequest = contactsApiClientTypes.CreateContactRequest
 import ContactSearchRequest = contactsApiClientTypes.ContactSearchRequest
 import ReferenceCode = contactsApiClientTypes.ReferenceCode
 import AddContactRelationshipRequest = contactsApiClientTypes.AddContactRelationshipRequest
+import ContactSearchResultItemPage = contactsApiClientTypes.ContactSearchResultItemPage
 
 jest.mock('./tokenStore/inMemoryTokenStore')
 
@@ -214,7 +215,7 @@ describe('contactsApiClient', () => {
         dateOfBirth: '1980-12-10T00:00:00.000Z',
       }
 
-      const results = {
+      const results: ContactSearchResultItemPage = {
         totalPage: 1,
         totalElements: 1,
         content: [

--- a/server/data/contactsApiClient.ts
+++ b/server/data/contactsApiClient.ts
@@ -1,14 +1,14 @@
 import config from '../config'
 import RestClient from './restClient'
+import ReferenceCodeType from '../enumeration/referenceCodeType'
 import Contact = contactsApiClientTypes.Contact
 import CreateContactRequest = contactsApiClientTypes.CreateContactRequest
 import ContactSearchRequest = contactsApiClientTypes.ContactSearchRequest
 import Pageable = contactsApiClientTypes.Pageable
 import PrisonerContactSummary = contactsApiClientTypes.PrisonerContactSummary
 import ReferenceCode = contactsApiClientTypes.ReferenceCode
-import ReferenceCodeType from '../enumeration/referenceCodeType'
 import AddContactRelationshipRequest = contactsApiClientTypes.AddContactRelationshipRequest
-import ContactSearchResultItem = contactsApiClientTypes.ContactSearchResultItem
+import ContactSearchResultItemPage = contactsApiClientTypes.ContactSearchResultItemPage
 
 export default class ContactsApiClient extends RestClient {
   constructor() {
@@ -66,7 +66,7 @@ export default class ContactsApiClient extends RestClient {
     contactSearchRequest: ContactSearchRequest,
     user: Express.User,
     pagination?: Pageable,
-  ): Promise<ContactSearchResultItem> {
+  ): Promise<ContactSearchResultItemPage> {
     const paginationParameters = pagination ?? { page: 0, size: config.apis.contactsApi.pageSize || 10 }
     return this.get(
       {

--- a/server/routes/contacts/manage/contact-confirmation/contactConfirmationController.test.ts
+++ b/server/routes/contacts/manage/contact-confirmation/contactConfirmationController.test.ts
@@ -56,7 +56,6 @@ describe('GET /prisoner/:prisonerNumber/contacts/EXISTING/confirmation/:journeyI
     // Given
     auditService.logPageView.mockResolvedValue(null)
     prisonerSearchService.getByPrisonerNumber.mockResolvedValue(TestData.prisoner())
-    contactsService.searchContact.mockResolvedValue(TestData.contacts())
     existingJourney.mode = 'EXISTING'
 
     // When

--- a/server/routes/contacts/manage/contact-search/contactSearchController.test.ts
+++ b/server/routes/contacts/manage/contact-search/contactSearchController.test.ts
@@ -9,6 +9,7 @@ import PrisonerSearchService from '../../../../services/prisonerSearchService'
 import ContactsService from '../../../../services/contactsService'
 import TestData from '../../../testutils/testData'
 import AddContactJourney = journeys.AddContactJourney
+import ContactSearchResultItemPage = contactsApiClientTypes.ContactSearchResultItemPage
 
 jest.mock('../../../../services/auditService')
 jest.mock('../../../../services/prisonerSearchService')
@@ -56,7 +57,11 @@ describe('GET /prisoner/:prisonerNumber/contacts/search/:journeyId', () => {
     // Given
     auditService.logPageView.mockResolvedValue(null)
     prisonerSearchService.getByPrisonerNumber.mockResolvedValue(TestData.prisoner())
-    contactsService.searchContact.mockResolvedValue(TestData.contacts())
+    contactsService.searchContact.mockResolvedValue({
+      totalPages: 0,
+      totalElements: 0,
+      content: [TestData.contactSearchResultItem()],
+    })
 
     // When
     const response = await request(app).get(`/prisoner/${prisonerNumber}/contacts/search/${journeyId}`)
@@ -188,8 +193,8 @@ describe('POST /prisoner/:prisonerNumber/contacts/search/:journeyId', () => {
 })
 
 describe('Contact seaarch results', () => {
-  let results = {
-    content: [TestData.contacts()],
+  let results: ContactSearchResultItemPage = {
+    content: [TestData.contactSearchResultItem()],
     pageable: {
       pageNumber: 0,
       pageSize: 20,
@@ -265,7 +270,7 @@ describe('Contact seaarch results', () => {
 
     const contactsArray = []
     for (let i = 0; i < 15; i += 1) {
-      contactsArray.push(TestData.contacts())
+      contactsArray.push(TestData.contactSearchResultItem({ id: i }))
     }
 
     results = {

--- a/server/routes/contacts/manage/contact-search/contactSearchController.ts
+++ b/server/routes/contacts/manage/contact-search/contactSearchController.ts
@@ -6,9 +6,9 @@ import { ContactsService } from '../../../../services'
 import { PaginationRequest } from '../../../../data/prisonerOffenderSearchTypes'
 import { formatDateForApi } from '../../../../utils/utils'
 import config from '../../../../config'
-import Contact = contactsApiClientTypes.Contact
-import ContactSearchRequest = contactsApiClientTypes.ContactSearchRequest
 import { navigationForAddContactJourney } from '../../add/addContactFlowControl'
+import ContactSearchRequest = contactsApiClientTypes.ContactSearchRequest
+import ContactSearchResultItemPage = contactsApiClientTypes.ContactSearchResultItemPage
 
 export default class ContactSearchController implements PageHandler {
   constructor(private readonly contactsService: ContactsService) {}
@@ -33,7 +33,7 @@ export default class ContactSearchController implements PageHandler {
       }
 
       results = validationErrors
-        ? ({ totalPages: 0, totalElements: 0, content: [] } as Contact)
+        ? ({ totalPages: 0, totalElements: 0, content: [] } as ContactSearchResultItemPage)
         : await this.contactsService.searchContact(
             contactSearchRequest,
             { page, size: pageSize } as PaginationRequest,

--- a/server/routes/testutils/testData.ts
+++ b/server/routes/testutils/testData.ts
@@ -2,6 +2,7 @@ import { CurrentIncentive, Prisoner } from '../../data/prisonerOffenderSearchTyp
 import { components } from '../../@types/contactsApi'
 
 type ContactSearchResultItem = components['schemas']['ContactSearchResultItem']
+type GetContactResponse = components['schemas']['GetContactResponse']
 export default class TestData {
   static currentIncentive = ({
     level = {
@@ -33,7 +34,7 @@ export default class TestData {
       locationDescription,
     }) as Prisoner
 
-  static contacts = ({
+  static contactSearchResultItem = ({
     id = 13,
     lastName = 'Mason',
     firstName = 'Jones',
@@ -73,4 +74,31 @@ export default class TestData {
       createdBy,
       createdTime,
     }) as ContactSearchResultItem
+
+  static contact = ({
+    id = 1,
+    title = null,
+    lastName = 'Mason',
+    firstName = 'Jones',
+    middleName = null,
+    dateOfBirth = '1990-01-14',
+    estimatedIsOverEighteen = null,
+    isDeceased = false,
+    deceasedDate = null,
+    createdBy = 'USER1',
+    createdTime = '2024-09-20T10:30:00.000000',
+  }: Partial<GetContactResponse> = {}): GetContactResponse =>
+    ({
+      id,
+      title,
+      lastName,
+      firstName,
+      middleName,
+      dateOfBirth,
+      estimatedIsOverEighteen,
+      isDeceased,
+      deceasedDate,
+      createdBy,
+      createdTime,
+    }) as GetContactResponse
 }

--- a/server/services/contactsService.test.ts
+++ b/server/services/contactsService.test.ts
@@ -9,9 +9,10 @@ import CreateContactRequest = contactsApiClientTypes.CreateContactRequest
 import ContactSearchRequest = contactsApiClientTypes.ContactSearchRequest
 import IsOverEighteenOptions = journeys.YesNoOrDoNotKnow
 import AddContactRelationshipRequest = contactsApiClientTypes.AddContactRelationshipRequest
+import ContactSearchResultItemPage = contactsApiClientTypes.ContactSearchResultItemPage
 
 jest.mock('../data/contactsApiClient')
-const contacts = TestData.contacts()
+const searchResult = TestData.contactSearchResultItem()
 const contactSearchRequest: ContactSearchRequest = {
   lastName: 'last',
   middleName: '',
@@ -218,23 +219,23 @@ describe('contactsService', () => {
 
     it('Retrieves search contact details matching the search criteria', async () => {
       // Given
-      const contactResults = {
+      const contactResults: ContactSearchResultItemPage = {
         totalPages: 1,
         totalElements: 1,
         first: true,
         last: true,
         size: 20,
         empty: false,
-        content: [contacts],
-      } as ContactSearchRequest
+        content: [searchResult],
+      }
 
       // When
-      await apiClient.searchContact.mockResolvedValue(contactResults)
+      apiClient.searchContact.mockResolvedValue(contactResults)
       const results = await service.searchContact(contactSearchRequest, pagination, user)
 
       // Then
-      expect(results?.content[0].lastName).toEqual(contacts.lastName)
-      expect(results?.content[0].firstName).toEqual(contacts.firstName)
+      expect(results?.content[0].lastName).toEqual(searchResult.lastName)
+      expect(results?.content[0].firstName).toEqual(searchResult.firstName)
       expect(results.totalPages).toEqual(1)
       expect(results.totalElements).toEqual(1)
     })

--- a/server/services/contactsService.ts
+++ b/server/services/contactsService.ts
@@ -6,7 +6,7 @@ import ContactSearchRequest = contactsApiClientTypes.ContactSearchRequest
 import Pageable = contactsApiClientTypes.Pageable
 import PrisonerContactSummary = contactsApiClientTypes.PrisonerContactSummary
 import AddContactRelationshipRequest = contactsApiClientTypes.AddContactRelationshipRequest
-import ContactSearchResultItem = contactsApiClientTypes.ContactSearchResultItem
+import ContactSearchResultItemPage = contactsApiClientTypes.ContactSearchResultItemPage
 
 export default class ContactsService {
   constructor(private readonly contactsApiClient: ContactsApiClient) {}
@@ -76,7 +76,7 @@ export default class ContactsService {
     contactSearchRequest: ContactSearchRequest,
     pagination: Pageable,
     user: Express.User,
-  ): Promise<ContactSearchResultItem> {
+  ): Promise<ContactSearchResultItemPage> {
     return this.contactsApiClient.searchContact(contactSearchRequest, user, pagination)
   }
 


### PR DESCRIPTION
Contact search now uses page types with contact search items.

Get contact by id and search contacts were using the same test util method but the types have drifted significantly so those have been split.