### PR TITLE
PRC-188: Reset journey on switch mode

### DIFF
--- a/server/routes/contacts/add/mode/addContactModeController.ts
+++ b/server/routes/contacts/add/mode/addContactModeController.ts
@@ -20,6 +20,11 @@ export default class AddContactModeController implements PageHandler {
 
     const journey = req.session.addContactJourneys[journeyId]
     journey.mode = mode
+    journey.isCheckingAnswers = false
+    delete journey.contactId
+    delete journey.names
+    delete journey.dateOfBirth
+    delete journey.relationship
     if (journey.mode === 'EXISTING' && contactId) {
       journey.contactId = Number(contactId)
       const existingContact = await this.contactService.getContact(journey.contactId, user)


### PR DESCRIPTION
When switching from add existing to add new it was prefilling the name and date of birth. This could happen when you select "No" on contact confirmation and then click "The contact is not listed".

You could also proceed a new journey and relationship details would be persisted if you then went back to search results and chose existing contact.

Now the journey is reset whenever you select mode (click a result or not listed).