### PR TITLE
PRC-77: Show deceased date on CYA for existing contact

### DIFF
--- a/integration_tests/pages/createContactCheckYourAnswersPage.ts
+++ b/integration_tests/pages/createContactCheckYourAnswersPage.ts
@@ -43,6 +43,16 @@ export default class CreateContactCheckYourAnswersPage extends Page {
     return this
   }
 
+  verifyShowDeceasedDate(expected: string): CreateContactCheckYourAnswersPage {
+    this.checkAnswersDeceasedValue().should('contain.text', expected)
+    return this
+  }
+
+  verifyNoDeceasedDate(): CreateContactCheckYourAnswersPage {
+    this.checkAnswersDeceasedValue().should('not.exist')
+    return this
+  }
+
   verifyShowsEstimatedDateOfBirthAs(expected: string): CreateContactCheckYourAnswersPage {
     this.checkAnswersEstimatedDobValue().should('contain.text', expected)
     return this
@@ -86,6 +96,8 @@ export default class CreateContactCheckYourAnswersPage extends Page {
   private checkAnswersNameValue = (): PageElement => cy.get('.check-answers-name-value')
 
   private checkAnswersDobValue = (): PageElement => cy.get('.check-answers-dob-value')
+
+  private checkAnswersDeceasedValue = (): PageElement => cy.get('.check-answers-deceased-value')
 
   private checkAnswersEstimatedDobValue = (): PageElement => cy.get('.check-answers-estimated-dob-value')
 

--- a/server/@types/contactsApiClient/index.d.ts
+++ b/server/@types/contactsApiClient/index.d.ts
@@ -3,6 +3,7 @@ declare namespace contactsApiClientTypes {
 
   export type CreateContactRequest = components['schemas']['CreateContactRequest']
   export type Contact = components['schemas']['Contact']
+  export type GetContactResponse = components['schemas']['GetContactResponse']
   export type PrisonerContactSummary = components['schemas']['PrisonerContactSummary']
   export type PrisonerContactSummaryPage = components['schemas']['PrisonerContactSummaryPage']
   export type ReferenceCode = components['schemas']['ReferenceCode']

--- a/server/@types/journeys/index.d.ts
+++ b/server/@types/journeys/index.d.ts
@@ -16,6 +16,10 @@ declare namespace journeys {
     relationship?: PrisonerContactRelationship
     previousAnswers?: CreateContactJourneyPreviousAnswers
     contactId?: number
+    existingContact?: {
+      isDeceased?: boolean
+      deceasedDate?: string
+    }
   }
 
   export interface ContactNames {

--- a/server/data/contactsApiClient.test.ts
+++ b/server/data/contactsApiClient.test.ts
@@ -9,6 +9,7 @@ import ContactSearchRequest = contactsApiClientTypes.ContactSearchRequest
 import ReferenceCode = contactsApiClientTypes.ReferenceCode
 import AddContactRelationshipRequest = contactsApiClientTypes.AddContactRelationshipRequest
 import ContactSearchResultItemPage = contactsApiClientTypes.ContactSearchResultItemPage
+import GetContactResponse = contactsApiClientTypes.GetContactResponse
 
 jest.mock('./tokenStore/inMemoryTokenStore')
 
@@ -251,7 +252,7 @@ describe('contactsApiClient', () => {
   describe('getContact', () => {
     it('should create the request and return the response', async () => {
       // Given
-      const expectedContact: Contact = {
+      const expectedContact: GetContactResponse = {
         id: 123456,
         lastName: 'last',
         firstName: 'middle',

--- a/server/data/contactsApiClient.ts
+++ b/server/data/contactsApiClient.ts
@@ -10,6 +10,7 @@ import ReferenceCode = contactsApiClientTypes.ReferenceCode
 import AddContactRelationshipRequest = contactsApiClientTypes.AddContactRelationshipRequest
 import ContactSearchResultItemPage = contactsApiClientTypes.ContactSearchResultItemPage
 import PrisonerContactSummaryPage = contactsApiClientTypes.PrisonerContactSummaryPage
+import GetContactResponse = contactsApiClientTypes.GetContactResponse
 
 export default class ContactsApiClient extends RestClient {
   constructor() {
@@ -84,7 +85,7 @@ export default class ContactsApiClient extends RestClient {
     )
   }
 
-  async getContact(contactId: number, user: Express.User): Promise<Contact> {
-    return this.get<Contact>({ path: `/contact/${contactId}` }, user)
+  async getContact(contactId: number, user: Express.User): Promise<GetContactResponse> {
+    return this.get<GetContactResponse>({ path: `/contact/${contactId}` }, user)
   }
 }

--- a/server/routes/contacts/add/check-answers/createContactCheckAnswersController.test.ts
+++ b/server/routes/contacts/add/check-answers/createContactCheckAnswersController.test.ts
@@ -157,6 +157,41 @@ describe('GET /prisoner/:prisonerNumber/contacts/create/check-answers/:journeyId
     },
   )
 
+  it('should render check answers page with a deceased date', async () => {
+    // Given
+    auditService.logPageView.mockResolvedValue(null)
+    journey.existingContact = {
+      isDeceased: true,
+      deceasedDate: '2020-12-25',
+    }
+
+    // When
+    const response = await request(app).get(`/prisoner/${prisonerNumber}/contacts/create/check-answers/${journeyId}`)
+
+    // Then
+    expect(response.status).toEqual(200)
+    expect(journey.isCheckingAnswers).toStrictEqual(true)
+    const $ = cheerio.load(response.text)
+    expect($('.check-answers-deceased-value').first().text().trim()).toStrictEqual('25 December 2020')
+  })
+
+  it('should not show deceased date if not present, even if flag set to true', async () => {
+    // Given
+    auditService.logPageView.mockResolvedValue(null)
+    journey.existingContact = {
+      isDeceased: true,
+    }
+
+    // When
+    const response = await request(app).get(`/prisoner/${prisonerNumber}/contacts/create/check-answers/${journeyId}`)
+
+    // Then
+    expect(response.status).toEqual(200)
+    expect(journey.isCheckingAnswers).toStrictEqual(true)
+    const $ = cheerio.load(response.text)
+    expect($('.check-answers-deceased-value')).toHaveLength(0)
+  })
+
   it('should call the audit service for the page view', async () => {
     // Given
     auditService.logPageView.mockResolvedValue(null)

--- a/server/routes/contacts/add/mode/addContactModeController.ts
+++ b/server/routes/contacts/add/mode/addContactModeController.ts
@@ -22,6 +22,7 @@ export default class AddContactModeController implements PageHandler {
     journey.mode = mode
     journey.isCheckingAnswers = false
     delete journey.contactId
+    delete journey.existingContact
     delete journey.names
     delete journey.dateOfBirth
     delete journey.relationship
@@ -33,6 +34,10 @@ export default class AddContactModeController implements PageHandler {
         lastName: existingContact.lastName,
         firstName: existingContact.firstName,
         middleNames: existingContact.middleNames,
+      }
+      journey.existingContact = {
+        isDeceased: existingContact.isDeceased,
+        deceasedDate: existingContact.deceasedDate,
       }
       if (existingContact.dateOfBirth) {
         const date = new Date(existingContact.dateOfBirth)

--- a/server/services/contactsService.test.ts
+++ b/server/services/contactsService.test.ts
@@ -10,6 +10,7 @@ import ContactSearchRequest = contactsApiClientTypes.ContactSearchRequest
 import IsOverEighteenOptions = journeys.YesNoOrDoNotKnow
 import AddContactRelationshipRequest = contactsApiClientTypes.AddContactRelationshipRequest
 import ContactSearchResultItemPage = contactsApiClientTypes.ContactSearchResultItemPage
+import GetContactResponse = contactsApiClientTypes.GetContactResponse
 
 jest.mock('../data/contactsApiClient')
 const searchResult = TestData.contactSearchResultItem()
@@ -250,7 +251,7 @@ describe('contactsService', () => {
 
   describe('getContact', () => {
     it('Should get the contact', async () => {
-      const expectedContact: Contact = {
+      const expectedContact: GetContactResponse = {
         id: 123456,
         lastName: 'last',
         firstName: 'middle',

--- a/server/services/contactsService.ts
+++ b/server/services/contactsService.ts
@@ -7,6 +7,7 @@ import Pageable = contactsApiClientTypes.Pageable
 import AddContactRelationshipRequest = contactsApiClientTypes.AddContactRelationshipRequest
 import ContactSearchResultItemPage = contactsApiClientTypes.ContactSearchResultItemPage
 import PrisonerContactSummaryPage = contactsApiClientTypes.PrisonerContactSummaryPage
+import GetContactResponse = contactsApiClientTypes.GetContactResponse
 
 export default class ContactsService {
   constructor(private readonly contactsApiClient: ContactsApiClient) {}
@@ -80,7 +81,7 @@ export default class ContactsService {
     return this.contactsApiClient.searchContact(contactSearchRequest, user, pagination)
   }
 
-  async getContact(contactId: number, user: Express.User): Promise<Contact> {
+  async getContact(contactId: number, user: Express.User): Promise<GetContactResponse> {
     return this.contactsApiClient.getContact(contactId, user)
   }
 }

--- a/server/views/pages/contacts/add/checkAnswers.njk
+++ b/server/views/pages/contacts/add/checkAnswers.njk
@@ -86,6 +86,20 @@
                         }
                     ), contactDetailsRows) %}
                 {% endif %}
+                {% if journey.existingContact.isDeceased and journey.existingContact.deceasedDate %}
+                    {% set contactDetailsRows = (contactDetailsRows.push(
+                        {
+                            key: {
+                                text: "Deceased date"
+                            },
+                            value: {
+                                html: journey.existingContact.deceasedDate | formatDate,
+                                classes: 'check-answers-deceased-value'
+                            }
+                        }
+                    ), contactDetailsRows) %}
+                {% endif %}
+
                 {{ govukSummaryList({
                     card: {
                         title: {


### PR DESCRIPTION
If a contact is deceased we need to show the deceased date on check your answers when adding an existing contact to a prisoner.

Also, the types were wrong for get contact by id.