### PR TITLE
PRC-56: Improve validation on DOB

### DIFF
--- a/integration_tests/e2e/createContacts.cy.ts
+++ b/integration_tests/e2e/createContacts.cy.ts
@@ -313,12 +313,10 @@ context('Create Contacts', () => {
 
     const enterDobPage = Page.verifyOnPage(EnterContactDateOfBirthPage, 'Last, First')
     enterDobPage.selectIsKnown('YES').clickContinue()
-
+    enterDobPage.hasFieldInError('dob', "Enter the contact's date of birth")
     enterDobPage.errorSummaryItems.spread((...$lis) => {
-      expect($lis).to.have.lengthOf(3)
-      expect($lis[0]).to.contain('Enter a valid day of the month (1-31)')
-      expect($lis[1]).to.contain('Enter a valid month (1-12)')
-      expect($lis[2]).to.contain('Enter a valid year. Must be at least 1900')
+      expect($lis).to.have.lengthOf(1)
+      expect($lis[0]).to.contain("Enter the contact's date of birth")
     })
   })
 
@@ -350,6 +348,10 @@ context('Create Contacts', () => {
       .enterYear('cc')
       .clickContinue()
 
+    enterDobPage.hasFieldInError('dob', 'Enter a valid day of the month (1-31)')
+    enterDobPage.hasFieldInError('dob', 'Enter a valid month (1-12)')
+    enterDobPage.hasFieldInError('dob', 'Enter a valid year. Must be at least 1900')
+    enterDobPage.hasFieldInError('dob', 'The date of birth is invalid')
     enterDobPage.errorSummaryItems.spread((...$lis) => {
       expect($lis).to.have.lengthOf(4)
       expect($lis[0]).to.contain('Enter a valid day of the month (1-31)')

--- a/server/routes/contacts/add/enter-dob/createContactEnterDobSchemas.test.ts
+++ b/server/routes/contacts/add/enter-dob/createContactEnterDobSchemas.test.ts
@@ -21,6 +21,7 @@ describe('createContactEnterDobSchema', () => {
       const deduplicatedFieldErrors = deduplicateFieldErrors(result)
       expect(deduplicatedFieldErrors).toStrictEqual({ isKnown: ['Select whether the date of birth is known'] })
     })
+
     it.each([
       ['YES', 'YES'],
       ['NO', 'NO'],
@@ -59,11 +60,10 @@ describe('createContactEnterDobSchema', () => {
       expect(result.success).toStrictEqual(false)
       const deduplicatedFieldErrors = deduplicateFieldErrors(result)
       expect(deduplicatedFieldErrors).toStrictEqual({
-        day: ['Enter a valid day of the month (1-31)'],
-        month: ['Enter a valid month (1-12)'],
-        year: ['Enter a valid year. Must be at least 1900'],
+        dob: ["Enter the contact's date of birth"],
       })
     })
+
     it('if dob is known then require day, month and year not be empty', async () => {
       // Given
       const form = { isKnown: 'YES', day: '', month: '', year: '' }
@@ -75,9 +75,7 @@ describe('createContactEnterDobSchema', () => {
       expect(result.success).toStrictEqual(false)
       const deduplicatedFieldErrors = deduplicateFieldErrors(result)
       expect(deduplicatedFieldErrors).toStrictEqual({
-        day: ['Enter a valid day of the month (1-31)'],
-        month: ['Enter a valid month (1-12)'],
-        year: ['Enter a valid year. Must be at least 1900'],
+        dob: ["Enter the contact's date of birth"],
       })
     })
 

--- a/server/routes/contacts/add/enter-dob/createContactEnterDobSchemas.ts
+++ b/server/routes/contacts/add/enter-dob/createContactEnterDobSchemas.ts
@@ -9,6 +9,7 @@ const MONTH_TYPE_MESSAGE = 'Enter a valid month (1-12)'
 const YEAR_TYPE_MESSAGE = 'Enter a valid year. Must be at least 1900'
 const DOB_IN_FUTURE_MESSAGE = 'The date of birth must not be in the future'
 const DOB_IS_INVALID = 'The date of birth is invalid'
+const DOB_IS_REQUIRED_MESSAGE = "Enter the contact's date of birth"
 
 export const createContactEnterDobSchema = () => async () => {
   return createSchema({
@@ -49,14 +50,18 @@ export const createContactEnterDobSchema = () => async () => {
   })
     .superRefine((val, ctx) => {
       if (val.isKnown === 'YES') {
-        if (!val.day) {
-          ctx.addIssue({ code: z.ZodIssueCode.custom, message: DAY_TYPE_MESSAGE, path: ['day'] })
-        }
-        if (!val.month) {
-          ctx.addIssue({ code: z.ZodIssueCode.custom, message: MONTH_TYPE_MESSAGE, path: ['month'] })
-        }
-        if (!val.year) {
-          ctx.addIssue({ code: z.ZodIssueCode.custom, message: YEAR_TYPE_MESSAGE, path: ['year'] })
+        if (!val.day && !val.month && !val.year) {
+          ctx.addIssue({ code: z.ZodIssueCode.custom, message: DOB_IS_REQUIRED_MESSAGE, path: ['dob'] })
+        } else {
+          if (!val.day) {
+            ctx.addIssue({ code: z.ZodIssueCode.custom, message: DAY_TYPE_MESSAGE, path: ['day'] })
+          }
+          if (!val.month) {
+            ctx.addIssue({ code: z.ZodIssueCode.custom, message: MONTH_TYPE_MESSAGE, path: ['month'] })
+          }
+          if (!val.year) {
+            ctx.addIssue({ code: z.ZodIssueCode.custom, message: YEAR_TYPE_MESSAGE, path: ['year'] })
+          }
         }
         if (val.day && val.month && val.year) {
           if (new Date(`${val.year}-${val.month}-${val.day}Z`) > new Date()) {

--- a/server/views/pages/contacts/add/enterDob.njk
+++ b/server/views/pages/contacts/add/enterDob.njk
@@ -19,6 +19,12 @@
         <div class="govuk-grid-column-three-quarters">
             <form method='POST'>
                 <input type="hidden" name="_csrf" value="{{ csrfToken }}" />
+                {% if validationErrors %}
+                    {% set dayError = validationErrors['day'] if validationErrors['day'] else '' %}
+                    {% set monthError = validationErrors['month'] if validationErrors['month'] else '' %}
+                    {% set yearError = validationErrors['year']  if validationErrors['year'] else '' %}
+                    {% set dobError = validationErrors['dob'] if validationErrors['dob'] else '' %}
+                {% endif %}
                 {% set dobHtml %}
                     {{ govukDateInput({
                         id: "dob",
@@ -31,26 +37,32 @@
                         hint: {
                             text: "For example, 15 6 2000"
                         },
+                        errorMessage: {
+                            html: '<span class="govuk-error-message">' + dayError + '</span>
+                            <span class="govuk-error-message">' + monthError + '</span>
+                            <span class="govuk-error-message">' + yearError + '</span>
+                            <span class="govuk-error-message">' + dobError + '</span>'
+                        } if dayError or monthError or yearError or dobError,
                         items: [
                             {
                                 id: 'day',
                                 label: 'Day',
                                 name: "day",
-                                classes: 'govuk-input--width-2',
+                                classes: 'govuk-input--width-2' + (' govuk-input--error' if dayError or dobError),
                                 value: day
                             },
                             {
                                 id: 'month',
                                 label: 'Month',
                                 name: "month",
-                                classes: 'govuk-input--width-2',
+                                classes: 'govuk-input--width-2' + (' govuk-input--error' if monthError or dobError),
                                 value: month
                             },
                             {
                                 id: 'year',
                                 label: 'Year',
                                 name: "year",
-                                classes: 'govuk-input--width-4',
+                                classes: 'govuk-input--width-4' + (' govuk-input--error' if yearError or dobError),
                                 value: year
                             }
                         ]
@@ -70,7 +82,7 @@
                         },
                         {
                             value: 'NO',
-                            text: "No, I don’t know",
+                            text: "No, I don’t know it",
                             checked: isKnown === 'NO'
                         }
                     ],

--- a/server/views/pages/contacts/add/selectEmergencyContact.njk
+++ b/server/views/pages/contacts/add/selectEmergencyContact.njk
@@ -1,6 +1,5 @@
 {% extends "../../../partials/layout.njk" %}
 {% from "govuk/components/breadcrumbs/macro.njk" import govukBreadcrumbs %}
-{% from "govuk/components/date-input/macro.njk" import govukDateInput %}
 {% from "govuk/components/button/macro.njk" import govukButton %}
 {% from "govuk/components/radios/macro.njk" import govukRadios %}
 {% from "../../../partials/miniProfile/macro.njk" import miniProfile %}

--- a/server/views/pages/contacts/add/selectNextOfKin.njk
+++ b/server/views/pages/contacts/add/selectNextOfKin.njk
@@ -1,6 +1,5 @@
 {% extends "../../../partials/layout.njk" %}
 {% from "govuk/components/breadcrumbs/macro.njk" import govukBreadcrumbs %}
-{% from "govuk/components/date-input/macro.njk" import govukDateInput %}
 {% from "govuk/components/button/macro.njk" import govukButton %}
 {% from "govuk/components/radios/macro.njk" import govukRadios %}
 {% from "../../../partials/miniProfile/macro.njk" import miniProfile %}

--- a/server/views/pages/contacts/manage/contactSearch.njk
+++ b/server/views/pages/contacts/manage/contactSearch.njk
@@ -84,21 +84,21 @@
                         id: 'day',
                         label: 'Day',
                         name: "day",
-                        classes: 'govuk-input--width-2',
+                        classes: 'govuk-input--width-2' + (' govuk-input--error' if dayError or dobError),
                         value: view.day
                     },
                     {
                         id: 'month',
                         label: 'Month',
                         name: "month",
-                        classes: 'govuk-input--width-2',
+                        classes: 'govuk-input--width-2' + (' govuk-input--error' if monthError or dobError),
                         value: view.month
                     },
                     {
                         id: 'year',
                         label: 'Year',
                         name: "year",
-                        classes: 'govuk-input--width-4',
+                        classes: 'govuk-input--width-4' + (' govuk-input--error' if yearError or dobError),
                         value: view.year
                     }
                 ]

--- a/server/views/pages/contacts/manage/prisonerSearchResults.njk
+++ b/server/views/pages/contacts/manage/prisonerSearchResults.njk
@@ -1,7 +1,6 @@
 {% extends "../../../partials/layout.njk" %}
 
 {% from "govuk/components/input/macro.njk" import govukInput %}
-{% from "govuk/components/date-input/macro.njk" import govukDateInput %}
 {% from "govuk/components/select/macro.njk" import govukSelect %}
 {% from "govuk/components/button/macro.njk" import govukButton %}
 {% from "govuk/components/details/macro.njk" import govukDetails %}


### PR DESCRIPTION
Highlight the individual fields with errors

Show copy of the errors at both top and next to the field.

If no DOB fields entered at all, show a single message instead of individual field errors.

Also fixed highlighting on the search page as fields weren't being marked red.