### PR TITLE
PRC-213 : fix issuing authority 

### DIFF
--- a/server/routes/contacts/add/contact-confirmation/contactConfirmationController.test.ts
+++ b/server/routes/contacts/add/contact-confirmation/contactConfirmationController.test.ts
@@ -91,7 +91,9 @@ describe('GET /prisoner/:prisonerNumber/contacts/EXISTING/confirmation/:journeyI
       correlationId: expect.any(String),
     })
     const $ = cheerio.load(response.text)
+    expect($('.confirm-DL-value').text().trim()).toStrictEqual('LAST-87736799M')
     expect($('.confirm-PASS-value').text().trim()).toStrictEqual('425362965Issuing authority - UK passport office')
+    expect($('.confirm-NINO-value').text().trim()).toStrictEqual('06/614465M')
   })
 
   it('should show the primary address if there is one', async () => {

--- a/server/routes/testutils/testData.ts
+++ b/server/routes/testutils/testData.ts
@@ -284,9 +284,9 @@ export default class TestData {
       this.getContactEmailDetails('PERSONAL', 'Personal email', 'mr.first@example.com', 2),
     ],
     identities = [
-      this.getContactIdentityDetails('DL', 'Driving licence', 'LAST-87736799M', 'UK', 1),
+      this.getContactIdentityDetails('DL', 'Driving licence', 'LAST-87736799M', null, 1),
       this.getContactIdentityDetails('PASS', 'Passport number', '425362965', 'UK passport office', 2),
-      this.getContactIdentityDetails('NINO', 'National insurance number', '06/614465M', 'UK', 3),
+      this.getContactIdentityDetails('NINO', 'National insurance number', '06/614465M', null, 3),
     ],
     domesticStatusCode = 'S',
     domesticStatusDescription = 'Single-not married/in civil partnership',

--- a/server/views/pages/contacts/manage/contactConfirmation/identityNumbers.njk
+++ b/server/views/pages/contacts/manage/contactConfirmation/identityNumbers.njk
@@ -11,7 +11,7 @@
                         text: (item.identityTypeDescription | capitalizeFirstLetter)
                     },
                     value: { 
-                        html: item.identityValue + ('<p>Issuing authority - ' + item.issuingAuthority + '</p>' if item.identityType == 'PASS' else ''),
+                        html: item.identityValue + ('<p>Issuing authority - ' + item.issuingAuthority + '</p>' if item.issuingAuthority else ''),
                         classes: 'confirm-' + item.identityType + '-value'
                     }
                 }

--- a/server/views/pages/contacts/manage/contactDetails/manageIdentityNumbers.njk
+++ b/server/views/pages/contacts/manage/contactDetails/manageIdentityNumbers.njk
@@ -29,7 +29,7 @@
                 text: (item.identityTypeDescription)
             },
             value: {
-                html: item.identityValue + ('<p>Issuing authority - ' + item.issuingAuthority + '</p>' if item.identityType == 'PASS' else ''),
+                html: item.identityValue + ('<p>Issuing authority - ' + item.issuingAuthority + '</p>' if item.issuingAuthority else ''),
                 classes: 'confirm-' + item.identityType + '-value'
             },
             actions: {


### PR DESCRIPTION
 display issuing authority only when it's provided on the summary pages for 'add' and  'manage' contact pages 

Test evidence : Manage

![image](https://github.com/user-attachments/assets/31464b47-30fa-457f-8734-57fc6670e538)

Test evidence : Add
![image](https://github.com/user-attachments/assets/58450e1b-9e87-4402-9f64-4d116f115e9f)



