### PR TITLE
PRC-330: Prevent double click

### DIFF
--- a/server/views/pages/contacts/add/checkAnswers.njk
+++ b/server/views/pages/contacts/add/checkAnswers.njk
@@ -203,7 +203,8 @@
                         html: buttonLabel,
                         type: "submit",
                         classes: 'govuk-!-margin-top-6',
-                        attributes: {"data-qa": "continue-button"}
+                        attributes: {"data-qa": "continue-button"},
+                        preventDoubleClick: true
                     }) }}
                     <a class="govuk-link govuk-link--no-visited-state govuk-!-font-size-19" href="{{ journey.returnPoint.url }}" data-qa="cancel-button">Cancel</a>
                 </div>

--- a/server/views/pages/contacts/add/selectEmergencyContact.njk
+++ b/server/views/pages/contacts/add/selectEmergencyContact.njk
@@ -39,7 +39,8 @@
                         html: "Continue",
                         type: "submit",
                         classes: 'govuk-!-margin-top-6',
-                        attributes: {"data-qa": "continue-button"}
+                        attributes: {"data-qa": "continue-button"},
+                        preventDoubleClick: true
                     }) }}
                     <a class="govuk-link govuk-link--no-visited-state govuk-!-font-size-19" href="{{ journey.returnPoint.url }}" data-qa="cancel-button">Cancel</a>
                 </div>

--- a/server/views/pages/contacts/add/selectNextOfKin.njk
+++ b/server/views/pages/contacts/add/selectNextOfKin.njk
@@ -39,7 +39,8 @@
                         html: "Continue",
                         type: "submit",
                         classes: 'govuk-!-margin-top-6',
-                        attributes: {"data-qa": "continue-button"}
+                        attributes: {"data-qa": "continue-button"},
+                        preventDoubleClick: true
                     }) }}
                     <a class="govuk-link govuk-link--no-visited-state govuk-!-font-size-19" href="{{ journey.returnPoint.url }}" data-qa="cancel-button">Cancel</a>
                 </div>

--- a/server/views/pages/contacts/common/enterDob.njk
+++ b/server/views/pages/contacts/common/enterDob.njk
@@ -93,7 +93,8 @@
                         html: "Continue",
                         type: "submit",
                         classes: 'govuk-!-margin-top-6',
-                        attributes: {"data-qa": "continue-button"}
+                        attributes: {"data-qa": "continue-button"},
+                        preventDoubleClick: true
                     }) }}
                     <a class="govuk-link govuk-link--no-visited-state govuk-!-font-size-19" href="{{ journey.returnPoint.url }}" data-qa="cancel-button">Cancel</a>
                 </div>

--- a/server/views/pages/contacts/common/enterEstimatedDob.njk
+++ b/server/views/pages/contacts/common/enterEstimatedDob.njk
@@ -44,7 +44,8 @@
                         html: continueButtonLabel,
                         type: "submit",
                         classes: 'govuk-!-margin-top-6',
-                        attributes: {"data-qa": "continue-button"}
+                        attributes: {"data-qa": "continue-button"},
+                        preventDoubleClick: true
                     }) }}
                     <a class="govuk-link govuk-link--no-visited-state govuk-!-font-size-19" href="{{ journey.returnPoint.url }}" data-qa="cancel-button">Cancel</a>
                 </div>

--- a/server/views/pages/contacts/common/enterName.njk
+++ b/server/views/pages/contacts/common/enterName.njk
@@ -62,7 +62,8 @@
                         html: continueButtonLabel,
                         type: "submit",
                         classes: 'govuk-!-margin-top-6',
-                        attributes: {"data-qa": "continue-button"}
+                        attributes: {"data-qa": "continue-button"},
+                        preventDoubleClick: true
                     }) }}
                     <a class="govuk-link govuk-link--no-visited-state govuk-!-font-size-19" href="{{ journey.returnPoint.url }}" data-qa="cancel-button">Cancel</a>
                 </div>

--- a/server/views/pages/contacts/common/enterRelationshipComments.njk
+++ b/server/views/pages/contacts/common/enterRelationshipComments.njk
@@ -31,7 +31,8 @@
                         html: continueButtonLabel,
                         type: "submit",
                         classes: 'govuk-!-margin-top-6',
-                        attributes: {"data-qa": "continue-button"}
+                        attributes: {"data-qa": "continue-button"},
+                        preventDoubleClick: true
                     }) }}
                     <a class="govuk-link govuk-link--no-visited-state govuk-!-font-size-19" href="{{ journey.returnPoint.url }}" data-qa="cancel-button">Cancel</a>
                 </div>

--- a/server/views/pages/contacts/common/selectRelationship.njk
+++ b/server/views/pages/contacts/common/selectRelationship.njk
@@ -34,7 +34,8 @@
                         html: "Continue",
                         type: "submit",
                         classes: 'govuk-!-margin-top-6',
-                        attributes: {"data-qa": "continue-button"}
+                        attributes: {"data-qa": "continue-button"},
+                        preventDoubleClick: true
                     }) }}
                     <a class="govuk-link govuk-link--no-visited-state govuk-!-font-size-19" href="{{ journey.returnPoint.url }}" data-qa="cancel-button">Cancel</a>
                 </div>

--- a/server/views/pages/contacts/manage/addEditEmail.njk
+++ b/server/views/pages/contacts/manage/addEditEmail.njk
@@ -32,7 +32,8 @@
                         html: "Confirm and save",
                         type: "submit",
                         classes: 'govuk-!-margin-top-6',
-                        attributes: {"data-qa": "continue-button"}
+                        attributes: {"data-qa": "continue-button"},
+                        preventDoubleClick: true
                     }) }}
                     <a class="govuk-link govuk-link--no-visited-state govuk-!-font-size-19" href="{{ journey.returnPoint.url }}" data-qa="cancel-button">Cancel</a>
                 </div>

--- a/server/views/pages/contacts/manage/addEditIdentity.njk
+++ b/server/views/pages/contacts/manage/addEditIdentity.njk
@@ -54,7 +54,8 @@
                         html: "Confirm and save",
                         type: "submit",
                         classes: 'govuk-!-margin-top-6',
-                        attributes: {"data-qa": "continue-button"}
+                        attributes: {"data-qa": "continue-button"},
+                        preventDoubleClick: true
                     }) }}
                     <a class="govuk-link govuk-link--no-visited-state govuk-!-font-size-19" href="{{ journey.returnPoint.url }}" data-qa="cancel-button">Cancel</a>
                 </div>

--- a/server/views/pages/contacts/manage/addEditPhone.njk
+++ b/server/views/pages/contacts/manage/addEditPhone.njk
@@ -53,7 +53,8 @@
                         html: "Confirm and save",
                         type: "submit",
                         classes: 'govuk-!-margin-top-6',
-                        attributes: {"data-qa": "continue-button"}
+                        attributes: {"data-qa": "continue-button"},
+                        preventDoubleClick: true
                     }) }}
                     <a class="govuk-link govuk-link--no-visited-state govuk-!-font-size-19" href="{{ journey.returnPoint.url }}" data-qa="cancel-button">Cancel</a>
                 </div>

--- a/server/views/pages/contacts/manage/confirmDeleteEmail.njk
+++ b/server/views/pages/contacts/manage/confirmDeleteEmail.njk
@@ -36,14 +36,16 @@
                         html: "Yes, delete",
                         type: "submit",
                         classes: 'govuk-!-margin-top-6 govuk-button--warning',
-                        attributes: {"data-qa": "continue-button"}
+                        attributes: {"data-qa": "continue-button"},
+                        preventDoubleClick: true
                     }) }}
                     {{ govukButton({
                         html: "No, do not delete",
                         type: "button",
                         classes: 'govuk-!-margin-top-6 govuk-button--secondary',
                         attributes: {"data-qa": "cancel-button"},
-                        href: journey.returnPoint.url
+                        href: journey.returnPoint.url,
+                        preventDoubleClick: true
                     }) }}
                 </div>
             </form>

--- a/server/views/pages/contacts/manage/confirmDeleteIdentity.njk
+++ b/server/views/pages/contacts/manage/confirmDeleteIdentity.njk
@@ -54,14 +54,16 @@
                         html: "Yes, delete",
                         type: "submit",
                         classes: 'govuk-!-margin-top-6 govuk-button--warning',
-                        attributes: {"data-qa": "continue-button"}
+                        attributes: {"data-qa": "continue-button"},
+                        preventDoubleClick: true
                     }) }}
                     {{ govukButton({
                         html: "No, do not delete",
                         type: "button",
                         classes: 'govuk-!-margin-top-6 govuk-button--secondary',
                         attributes: {"data-qa": "cancel-button"},
-                        href: journey.returnPoint.url
+                        href: journey.returnPoint.url,
+                        preventDoubleClick: true
                     }) }}
                 </div>
             </form>

--- a/server/views/pages/contacts/manage/confirmDeletePhone.njk
+++ b/server/views/pages/contacts/manage/confirmDeletePhone.njk
@@ -54,14 +54,16 @@
                         html: "Yes, delete",
                         type: "submit",
                         classes: 'govuk-!-margin-top-6 govuk-button--warning',
-                        attributes: {"data-qa": "continue-button"}
+                        attributes: {"data-qa": "continue-button"},
+                        preventDoubleClick: true
                     }) }}
                     {{ govukButton({
                         html: "No, do not delete",
                         type: "button",
                         classes: 'govuk-!-margin-top-6 govuk-button--secondary',
                         attributes: {"data-qa": "cancel-button"},
-                        href: journey.returnPoint.url
+                        href: journey.returnPoint.url,
+                        preventDoubleClick: true
                     }) }}
                 </div>
             </form>

--- a/server/views/pages/contacts/manage/contactConfirmation/confirmation.njk
+++ b/server/views/pages/contacts/manage/contactConfirmation/confirmation.njk
@@ -106,7 +106,8 @@
                     html: "Continue",
                     type: "submit",
                     classes: 'govuk-!-margin-top-6',
-                    attributes: {"data-qa": "continue-button"}
+                    attributes: {"data-qa": "continue-button"},
+                    preventDoubleClick: true
                 }) }}
             </div>
         </form>

--- a/server/views/pages/contacts/manage/contactDetails/manageDomesticStatus.njk
+++ b/server/views/pages/contacts/manage/contactDetails/manageDomesticStatus.njk
@@ -28,7 +28,8 @@
                     html: "Confirm and save",
                     type: "submit",
                     classes: 'govuk-!-margin-top-6',
-                    attributes: {"data-qa": "continue-button"}
+                    attributes: {"data-qa": "continue-button"},
+                    preventDoubleClick: true
                 }) }}
                 <a class="govuk-link govuk-link--no-visited-state govuk-!-font-size-19" href="{{ journey.returnPoint.url }}" data-qa="cancel-button">Cancel</a>
             </div>

--- a/server/views/pages/contacts/manage/contactDetails/manageEmergencyContactStatus.njk
+++ b/server/views/pages/contacts/manage/contactDetails/manageEmergencyContactStatus.njk
@@ -41,7 +41,8 @@
                     html: "Confirm and save",
                     type: "submit",
                     classes: 'govuk-!-margin-top-6',
-                    attributes: {"data-qa": "continue-button"}
+                    attributes: {"data-qa": "continue-button"},
+                    preventDoubleClick: true
                 }) }}
                 <a class="govuk-link govuk-link--no-visited-state govuk-!-font-size-19" href="{{ journey.returnPoint.url }}" data-qa="cancel-button">Cancel</a>
             </div>

--- a/server/views/pages/contacts/manage/contactDetails/manageGender.njk
+++ b/server/views/pages/contacts/manage/contactDetails/manageGender.njk
@@ -27,7 +27,8 @@
                     html: "Confirm and save",
                     type: "submit",
                     classes: 'govuk-!-margin-top-6',
-                    attributes: {"data-qa": "continue-button"}
+                    attributes: {"data-qa": "continue-button"},
+                    preventDoubleClick: true
                 }) }}
                 <a class="govuk-link govuk-link--no-visited-state govuk-!-font-size-19" href="{{ journey.returnPoint.url }}" data-qa="cancel-button">Cancel</a>
             </div>

--- a/server/views/pages/contacts/manage/contactDetails/manageInterpreter.njk
+++ b/server/views/pages/contacts/manage/contactDetails/manageInterpreter.njk
@@ -41,7 +41,8 @@
                     html: "Confirm and save",
                     type: "submit",
                     classes: 'govuk-!-margin-top-6',
-                    attributes: {"data-qa": "continue-button"}
+                    attributes: {"data-qa": "continue-button"},
+                    preventDoubleClick: true
                 }) }}
                 <a class="govuk-link govuk-link--no-visited-state govuk-!-font-size-19" href="{{ journey.returnPoint.url }}" data-qa="cancel-button">Cancel</a>
             </div>

--- a/server/views/pages/contacts/manage/contactDetails/manageNextOfKinContactStatus.njk
+++ b/server/views/pages/contacts/manage/contactDetails/manageNextOfKinContactStatus.njk
@@ -42,7 +42,8 @@
                     html: "Confirm and save",
                     type: "submit",
                     classes: 'govuk-!-margin-top-6',
-                    attributes: {"data-qa": "continue-button"}
+                    attributes: {"data-qa": "continue-button"},
+                    preventDoubleClick: true
                 }) }}
                 <a class="govuk-link govuk-link--no-visited-state govuk-!-font-size-19" href="{{ journey.returnPoint.url }}" data-qa="cancel-button">Cancel</a>
             </div>

--- a/server/views/pages/contacts/manage/contactDetails/manageSpokenLanguage.njk
+++ b/server/views/pages/contacts/manage/contactDetails/manageSpokenLanguage.njk
@@ -43,7 +43,8 @@
                     html: "Confirm and save",
                     type: "submit",
                     classes: 'govuk-!-margin-top-6',
-                    attributes: {"data-qa": "continue-button"}
+                    attributes: {"data-qa": "continue-button"},
+                    preventDoubleClick: true
                 }) }}
                 <a class="govuk-link govuk-link--no-visited-state govuk-!-font-size-19" href="{{ journey.returnPoint.url }}" data-qa="cancel-button">Cancel</a>
             </div>

--- a/server/views/pages/contacts/manage/contactSearch.njk
+++ b/server/views/pages/contacts/manage/contactSearch.njk
@@ -106,7 +106,8 @@
                     html: "Search",
                     type: "submit",
                     classes: 'govuk-!-margin-top-6',
-                    attributes: {"data-qa": "search-button"}
+                    attributes: {"data-qa": "search-button"},
+                    preventDoubleClick: true
                 }) }}
             </div>
         </form>

--- a/server/views/pages/contacts/manage/listContacts.njk
+++ b/server/views/pages/contacts/manage/listContacts.njk
@@ -78,7 +78,8 @@
     {{ govukButton({
         text: "Add prisoner contact",
         href: "/prisoner/" + prisonerNumber + "/contacts/create/start",
-        attributes: {"data-qa": "add-contact-button"}
+        attributes: {"data-qa": "add-contact-button"},
+        preventDoubleClick: true
     }) }}
 
 <div class="govuk-tabs contact-list" data-module="govuk-tabs">

--- a/server/views/pages/contacts/manage/updateStaff.njk
+++ b/server/views/pages/contacts/manage/updateStaff.njk
@@ -39,7 +39,8 @@
                         html: "Confirm and save",
                         type: "submit",
                         classes: 'govuk-!-margin-top-6',
-                        attributes: {"data-qa": "continue-button"}
+                        attributes: {"data-qa": "continue-button"},
+                        preventDoubleClick: true
                     }) }}
                     <a class="govuk-link govuk-link--no-visited-state govuk-!-font-size-19" href="{{ journey.returnPoint.url }}" data-qa="cancel-button">Cancel</a>
                 </div>


### PR DESCRIPTION
Added the preventDoubleClick option to all buttons. This is an optional javascript feature with fallback to prevent double clicking submit buttons. I was able to reproduce issues fairly consistently by double clicking on create contact or email for example