### PR TITLE
PRC-282: Hide offender middle names

### DIFF
--- a/server/routes/contacts/manage/prisoner-search/prisonerSearchResultsController.test.ts
+++ b/server/routes/contacts/manage/prisoner-search/prisonerSearchResultsController.test.ts
@@ -143,7 +143,15 @@ describe('GET /contacts/manage/prisoner-search-results', () => {
       first: true,
       last: true,
       size: 1,
-      content: [{ lastName: 'test', firstName: 'test', prisonerNumber: 'test', dateOfBirth: '2000-01-01' } as Prisoner],
+      content: [
+        {
+          lastName: 'Last',
+          firstName: 'First',
+          middleNames: 'Middle Names',
+          prisonerNumber: 'A1234BC',
+          dateOfBirth: '2000-01-01',
+        } as Prisoner,
+      ],
     })
 
     const response = await request(app).get(`/contacts/manage/prisoner-search-results/${journeyId}`)
@@ -151,13 +159,14 @@ describe('GET /contacts/manage/prisoner-search-results', () => {
     logger.info(`Response = ${JSON.stringify(response)}`)
 
     expect(response.status).toEqual(200)
-    expect(response.text).toContain('search')
+    const $ = cheerio.load(response.text)
+    expect($('[data-qa=main-heading]').first().text().trim()).toStrictEqual('Search for a prisoner')
+    expect($('[data-qa=prisoner-A1234BC-name]').text().trim()).toStrictEqual('Last, First')
 
     expect(auditService.logPageView).toHaveBeenCalledWith(Page.PRISONER_SEARCH_RESULTS_PAGE, {
       who: user.username,
       correlationId: expect.any(String),
     })
-
     expect(prisonerSearchService.searchInCaseload).toHaveBeenCalledWith(
       'test',
       'HEI',

--- a/server/views/pages/contacts/manage/prisonerSearchResults.njk
+++ b/server/views/pages/contacts/manage/prisonerSearchResults.njk
@@ -30,7 +30,7 @@
   <div class="govuk-grid-row">
       <div class="govuk-grid-column-three-quarters">
           <span class="govuk-caption-l">Contacts</span>
-          <h1 class="govuk-heading-l">{{ pageTitle }}</h1>
+          <h1 class="govuk-heading-l" data-qa="main-heading">{{ pageTitle }}</h1>
       </div>
   </div>
 
@@ -84,7 +84,7 @@
             {% for result in results.content %}
                 {% set prisonerNameHtml %}
                    <a href="/prisoner/{{ result.prisonerNumber }}/contacts/list" class="govuk-link govuk-link--no-visited-state bapv-result-row" data-qa="prisoner-{{result.prisonerNumber}}-name">
-                      {{ result | formatNameLastNameFirst }}
+                      {{ result | formatNameLastNameFirst(excludeMiddleNames = true) }}
                    </a>
                 {% endset %}
 


### PR DESCRIPTION
Middle names were being shown in prisoner search results where they should never be shown for prisoners.