### PR TITLE
PRC-139 : Contact confirmation restrictions tab

### DIFF
--- a/integration_tests/e2e/addExistingContact.cy.ts
+++ b/integration_tests/e2e/addExistingContact.cy.ts
@@ -26,6 +26,8 @@ context('Add Existing Contact', () => {
     middleNames: contact.middleNames,
   })
 
+  const globalRestriction = TestData.getContactRestrictionDetails({ contactId: contact.id })
+
   beforeEach(() => {
     cy.task('reset')
     cy.task('stubComponentsMeta')
@@ -35,6 +37,7 @@ context('Add Existing Contact', () => {
     cy.task('stubPrisonerById', TestData.prisoner())
     cy.task('stubContactList', prisonerNumber)
     cy.task('stubGetContactById', contact)
+    cy.task('stubGetGlobalRestrictions', [globalRestriction])
     cy.task('stubGetPrisonerContactRelationshipById', {
       id: 654321,
       response: TestData.prisonerContactRelationship(),

--- a/integration_tests/e2e/addExistingContactCheckAnswers.cy.ts
+++ b/integration_tests/e2e/addExistingContactCheckAnswers.cy.ts
@@ -24,6 +24,7 @@ context('Add Existing Contact Check Answers', () => {
     firstName: contact.firstName,
     middleNames: contact.middleNames,
   })
+  const globalRestriction = TestData.getContactRestrictionDetails({ contactId: contact.id })
 
   beforeEach(() => {
     cy.task('reset')
@@ -35,6 +36,7 @@ context('Add Existing Contact Check Answers', () => {
     cy.task('stubContactList', prisonerNumber)
     cy.task('stubGetContactById', contact)
     cy.task('stubAddContactRelationship', { contactId, createdPrisonerContactId: 654321 })
+    cy.task('stubGetGlobalRestrictions', [globalRestriction])
     cy.task('stubContactSearch', {
       results: {
         totalPages: 1,

--- a/integration_tests/e2e/contactConfirmationPage.cy.ts
+++ b/integration_tests/e2e/contactConfirmationPage.cy.ts
@@ -23,6 +23,8 @@ context('Contact confirmation', () => {
   })
   const journeyId = uuidv4()
 
+  const globalRestriction = TestData.getContactRestrictionDetails({ contactId: contact.id })
+
   beforeEach(() => {
     cy.task('reset')
     cy.task('stubComponentsMeta')
@@ -32,6 +34,8 @@ context('Contact confirmation', () => {
     cy.task('stubPrisonerById', TestData.prisoner())
     cy.task('stubContactList', prisonerNumber)
     cy.task('stubGetContactById', contact)
+    cy.task('stubGetGlobalRestrictions', [globalRestriction])
+
     cy.task('stubContactSearch', {
       results: {
         totalPages: 1,
@@ -64,6 +68,24 @@ context('Contact confirmation', () => {
       .clickTheContactLink(contactId)
 
     Page.verifyOnPage(ContactConfirmationPage, 'John Smith') //
+      .selectIsTheRightPersonYesRadio()
+      .clickContinue()
+  })
+
+  it('should render contact confirmation page with restrictions on restrictions tab', () => {
+    cy.task('stubGetContactById', {
+      id: contactId,
+      firstName: 'Existing',
+      lastName: 'Contact',
+      dateOfBirth: '1990-01-14',
+    })
+
+    Page.verifyOnPage(SearchContactPage) //
+      .clickTheContactLink(contactId)
+
+    Page.verifyOnPage(ContactConfirmationPage, 'John Smith') //
+      .clickRestrictionsTab()
+      .checkRestrictionsDetails()
       .selectIsTheRightPersonYesRadio()
       .clickContinue()
   })

--- a/integration_tests/mockApis/contactsApi.ts
+++ b/integration_tests/mockApis/contactsApi.ts
@@ -23,7 +23,7 @@ export type StubPatchContactResponse = components['schemas']['PatchContactRespon
 export type StubPrisonerContactRelationshipDetails = components['schemas']['PrisonerContactRelationshipDetails']
 export type CreateEmailRequest = components['schemas']['CreateEmailRequest']
 export type UpdateEmailRequest = components['schemas']['UpdateEmailRequest']
-export type ContactEmailDetails = components['schemas']['ContactEmailDetails']
+export type ContactRestrictionDetails = components['schemas']['ContactRestrictionDetails']
 
 export default {
   stubCreateContact: (result: StubContactCreationResult): SuperAgentRequest => {
@@ -95,6 +95,20 @@ export default {
         status: 200,
         headers: { 'Content-Type': 'application/json;charset=UTF-8' },
         jsonBody: contact,
+      },
+    })
+  },
+
+  stubGetGlobalRestrictions: (globalRestrictions: ContactRestrictionDetails[]): SuperAgentRequest => {
+    return stubFor({
+      request: {
+        method: 'GET',
+        urlPath: `/contact/${globalRestrictions[0].contactId}/restriction`,
+      },
+      response: {
+        status: 200,
+        headers: { 'Content-Type': 'application/json;charset=UTF-8' },
+        jsonBody: globalRestrictions,
       },
     })
   },

--- a/integration_tests/mockApis/wiremock.ts
+++ b/integration_tests/mockApis/wiremock.ts
@@ -1,3 +1,5 @@
+import Component from '@ministryofjustice/hmpps-connect-dps-components/dist/types/Component'
+import HeaderFooterMeta from '@ministryofjustice/hmpps-connect-dps-components/dist/types/HeaderFooterMeta'
 import superagent, { Response, SuperAgentRequest } from 'superagent'
 
 const url = 'http://localhost:9091/__admin'
@@ -5,7 +7,7 @@ const url = 'http://localhost:9091/__admin'
 const stubFor = (mapping: Record<string, unknown>): SuperAgentRequest =>
   superagent.post(`${url}/mappings`).send(mapping)
 
-const getMatchingRequests = body => superagent.post(`${url}/requests/find`).send(body)
+const getMatchingRequests = (body: string | object) => superagent.post(`${url}/requests/find`).send(body)
 
 const getLastAPICallMatching = async (matching: string | object): Promise<unknown> => {
   const wiremockApiResponse: Response = await superagent.post(`${url}/requests/find`).send(matching)
@@ -23,7 +25,7 @@ const getAPICallCountMatching = async (matching: string | object): Promise<numbe
 const resetStubs = (): Promise<Array<Response>> =>
   Promise.all([superagent.delete(`${url}/mappings`), superagent.delete(`${url}/requests`)])
 
-const stubGet = (urlPattern, jsonBody?) =>
+const stubGet = (urlPattern: string, jsonBody?: { header: Component; footer: Component; meta: HeaderFooterMeta }) =>
   stubFor({
     request: { method: 'GET', urlPattern },
     response: {
@@ -33,46 +35,4 @@ const stubGet = (urlPattern, jsonBody?) =>
     },
   })
 
-const stubPost = (urlPattern, jsonBody?) =>
-  stubFor({
-    request: { method: 'POST', urlPattern },
-    response: {
-      status: 200,
-      headers: { 'Content-Type': 'application/json;charset=UTF-8' },
-      jsonBody: jsonBody || undefined,
-      body: !jsonBody ? 1 : undefined,
-    },
-  })
-
-const stubPut = (urlPattern, jsonBody?) =>
-  stubFor({
-    request: { method: 'PUT', urlPattern },
-    response: {
-      status: 200,
-      headers: { 'Content-Type': 'application/json;charset=UTF-8' },
-      jsonBody: jsonBody || undefined,
-      body: !jsonBody ? 1 : undefined,
-    },
-  })
-
-const stubDelete = (urlPattern, jsonBody?) =>
-  stubFor({
-    request: { method: 'DELETE', urlPattern },
-    response: {
-      status: 200,
-      headers: { 'Content-Type': 'application/json;charset=UTF-8' },
-      jsonBody,
-    },
-  })
-
-export {
-  stubFor,
-  getMatchingRequests,
-  resetStubs,
-  stubGet,
-  stubPost,
-  stubPut,
-  stubDelete,
-  getLastAPICallMatching,
-  getAPICallCountMatching,
-}
+export { stubFor, getMatchingRequests, resetStubs, stubGet, getLastAPICallMatching, getAPICallCountMatching }

--- a/integration_tests/pages/contactConfirmationPage.ts
+++ b/integration_tests/pages/contactConfirmationPage.ts
@@ -141,6 +141,44 @@ export default class ContactConfirmationPage extends Page {
     return this
   }
 
+  clickRestrictionsTab() {
+    this.getRestrictionsTab().should('contain.text', 'Restrictions(1)').click()
+    return this
+  }
+
+  checkRestrictionsDetails() {
+    this.getRestrictionCard().should('contain.text', 'Child Visitors to be Vetted')
+    this.getRestrictionCardColumnTitleByRaw(1).should('contain.text', 'Start date')
+    this.getRestrictionCardColumnTitleByRaw(2).should('contain.text', 'Expiry date')
+    this.getRestrictionCardColumnTitleByRaw(3).should('contain.text', 'Entered by')
+    this.getRestrictionCardColumnTitleByRaw(4).should('contain.text', 'Comment')
+
+    this.getRestrictionCardColumnValueByRaw(1).should('contain.text', '1 January 2024')
+    this.getRestrictionCardColumnValueByRaw(2).should('contain.text', '1 August 2050')
+    this.getRestrictionCardColumnValueByRaw(3).should('contain.text', 'USER1')
+    this.getRestrictionCardColumnValueByRaw(4).should('contain.text', 'Keep an eye')
+    return this
+  }
+
+  private getRestrictionsTab = (): PageElement => cy.get('#tab_restrictions')
+
+  private getRestrictionCard = (): PageElement =>
+    cy.get(
+      '[data-qa="restrictions-result-message"] > .govuk-summary-card > .govuk-summary-card__title-wrapper > .govuk-summary-card__title',
+    )
+
+  private getRestrictionCardColumnTitleByRaw = (columnNumber: number = 4): PageElement =>
+    cy.get(this.getTitleByRaw(columnNumber))
+
+  private getRestrictionCardColumnValueByRaw = (columnNumber: number = 4): PageElement =>
+    cy.get(this.getSelector(columnNumber))
+
+  getTitleByRaw = (childNumber: number): string =>
+    `[data-qa="restrictions-result-message"] > .govuk-summary-card > .govuk-summary-card__content > .govuk-summary-list > :nth-child(${childNumber}) > .govuk-summary-list__key`
+
+  getSelector = (childNumber: number): string =>
+    `[data-qa="restrictions-result-message"] > .govuk-summary-card > .govuk-summary-card__content > .govuk-summary-list > :nth-child(${childNumber}) > .govuk-summary-list__value`
+
   private contactTab = (elementNumber: number): PageElement => cy.get(`.govuk-tabs__tab:eq(${elementNumber})`)
 
   private contactCard = (elementNumber: number): PageElement =>

--- a/server/@types/contactsApiClient/index.d.ts
+++ b/server/@types/contactsApiClient/index.d.ts
@@ -3,6 +3,7 @@ declare namespace contactsApiClientTypes {
 
   export type CreateContactRequest = components['schemas']['CreateContactRequest']
   export type ContactDetails = components['schemas']['ContactDetails']
+  export type ContactRestrictionDetails = components['schemas']['ContactRestrictionDetails']
   export type ContactCreationResult = components['schemas']['ContactCreationResult']
   export type PrisonerContactRelationshipDetails = components['schemas']['PrisonerContactRelationshipDetails']
   export type ContactAddressDetails = components['schemas']['ContactAddressDetails']

--- a/server/@types/contactsApiClient/index.d.ts
+++ b/server/@types/contactsApiClient/index.d.ts
@@ -3,7 +3,6 @@ declare namespace contactsApiClientTypes {
 
   export type CreateContactRequest = components['schemas']['CreateContactRequest']
   export type ContactDetails = components['schemas']['ContactDetails']
-  export type ContactRestrictionDetails = components['schemas']['ContactRestrictionDetails']
   export type ContactCreationResult = components['schemas']['ContactCreationResult']
   export type PrisonerContactRelationshipDetails = components['schemas']['PrisonerContactRelationshipDetails']
   export type ContactAddressDetails = components['schemas']['ContactAddressDetails']

--- a/server/data/contactsApiClient.ts
+++ b/server/data/contactsApiClient.ts
@@ -286,4 +286,8 @@ export default class ContactsApiClient extends RestClient {
       user,
     )
   }
+
+  async getGlobalContactRestrictions(contactId: number, user: Express.User): Promise<ContactRestrictionDetails[]> {
+    return this.get<ContactRestrictionDetails[]>({ path: `/contact/${contactId}/restriction` }, user)
+  }
 }

--- a/server/routes/contacts/add/contact-confirmation/contactConfirmationController.test.ts
+++ b/server/routes/contacts/add/contact-confirmation/contactConfirmationController.test.ts
@@ -468,8 +468,8 @@ describe('Restrictions', () => {
         // Then
         const $ = cheerio.load(response.text)
 
-        expect($('.view-expiry-date-1-value').text().trim()).toStrictEqual('Not entered')
-        expect($('.view-comment-1-value').text().trim()).toStrictEqual('Not entered')
+        expect($('.view-expiry-date-1-value').text().trim()).toStrictEqual('Not provided')
+        expect($('.view-comment-1-value').text().trim()).toStrictEqual('Not provided')
       })
 
       it('should sort restrictions based on startDate, with the most recent at the top. where multiple restrictions with the same date, sorted them by createdTime', async () => {

--- a/server/routes/contacts/add/contact-confirmation/contactConfirmationController.test.ts
+++ b/server/routes/contacts/add/contact-confirmation/contactConfirmationController.test.ts
@@ -433,7 +433,7 @@ describe('Restrictions', () => {
 
         const cardTitle = $('.govuk-summary-card.restriction-1-card .govuk-summary-card__title').text().trim()
 
-        expect(cardTitle).toStrictEqual('Child Visitors to be Vetted (Expired)')
+        expect(cardTitle).toStrictEqual('Child Visitors to be Vetted (expired)')
         expect($('.view-start-date-1-value').text().trim()).toStrictEqual('1 January 2024')
         expect($('.view-expiry-date-1-value').text().trim()).toStrictEqual('1 August 2024')
         expect($('.view-entered-by-1-value').text().trim()).toStrictEqual('USER1')

--- a/server/routes/contacts/add/contact-confirmation/contactConfirmationController.test.ts
+++ b/server/routes/contacts/add/contact-confirmation/contactConfirmationController.test.ts
@@ -66,309 +66,455 @@ beforeEach(() => {
     },
   })
   referenceDataService.getReferenceDescriptionForCode.mockResolvedValue('Mr')
+  contactsService.getGlobalContactRestrictions.mockResolvedValue([])
 })
 
 afterEach(() => {
   jest.resetAllMocks()
 })
+describe('Contact details', () => {
+  describe('GET /prisoner/:prisonerNumber/contacts/EXISTING/confirmation/:journeyId?contactId=', () => {
+    it('should render confirmation page', async () => {
+      // Given
+      auditService.logPageView.mockResolvedValue(null)
+      prisonerSearchService.getByPrisonerNumber.mockResolvedValue(TestData.prisoner())
+      contactsService.searchContact.mockResolvedValue(TestData.contact())
+      contactsService.getContact.mockResolvedValue(TestData.contact())
+      existingJourney.mode = 'EXISTING'
 
-describe('GET /prisoner/:prisonerNumber/contacts/EXISTING/confirmation/:journeyId?contactId=', () => {
-  it('should render confirmation page', async () => {
-    // Given
+      // When
+      const response = await request(app).get(`/prisoner/${prisonerNumber}/contacts/add/confirmation/${journeyId}`)
+
+      // Then
+      expect(response.status).toEqual(200)
+      expect(auditService.logPageView).toHaveBeenCalledWith(Page.CONTACT_CONFIRMATION_PAGE, {
+        who: user.username,
+        correlationId: expect.any(String),
+      })
+      const $ = cheerio.load(response.text)
+
+      expect($('.govuk-heading-l').text()).toStrictEqual('Is this the right person to add as a contact for John Smith?')
+      expect($('.confirm-DL-value').text().trim()).toStrictEqual('LAST-87736799M')
+      expect($('.confirm-PASS-value').text().trim()).toStrictEqual('425362965Issuing authority - UK passport office')
+      expect($('.confirm-NINO-value').text().trim()).toStrictEqual('06/614465M')
+    })
+
+    it('should show the primary address if there is one', async () => {
+      // Given
+      const contact = TestData.contact({
+        addresses: [
+          { ...blankAddress, property: 'primary', primaryAddress: true, mailFlag: false },
+          { ...blankAddress, property: 'secondary', primaryAddress: false, mailFlag: true },
+        ],
+      })
+
+      auditService.logPageView.mockResolvedValue(null)
+      prisonerSearchService.getByPrisonerNumber.mockResolvedValue(TestData.prisoner())
+      contactsService.getContact.mockResolvedValue(contact)
+
+      // When
+      const response = await request(app).get(`/prisoner/${prisonerNumber}/contacts/add/confirmation/${journeyId}`)
+
+      // Then
+      const $ = cheerio.load(response.text)
+      expect($('.confirm-address-value').text().trim()).toStrictEqual('primary')
+      expect($('.most-relevant-address-label').text().trim()).toStrictEqual('Primary')
+    })
+
+    it('should label as primary and mail', async () => {
+      // Given
+      const contact = TestData.contact({
+        addresses: [{ ...blankAddress, property: 'primary', primaryAddress: true, mailFlag: true }],
+      })
+
+      auditService.logPageView.mockResolvedValue(null)
+      prisonerSearchService.getByPrisonerNumber.mockResolvedValue(TestData.prisoner())
+      contactsService.getContact.mockResolvedValue(contact)
+
+      // When
+      const response = await request(app).get(`/prisoner/${prisonerNumber}/contacts/add/confirmation/${journeyId}`)
+
+      // Then
+      const $ = cheerio.load(response.text)
+      expect($('.confirm-address-value').text().trim()).toStrictEqual('primary')
+      expect($('.most-relevant-address-label').text().trim()).toStrictEqual('Primary and mail')
+    })
+
+    it('should use mail address if no primary', async () => {
+      // Given
+      const contact = TestData.contact({
+        addresses: [
+          { ...blankAddress, property: 'nothing', primaryAddress: false, mailFlag: false },
+          { ...blankAddress, property: 'mail', primaryAddress: false, mailFlag: true },
+        ],
+      })
+
+      auditService.logPageView.mockResolvedValue(null)
+      prisonerSearchService.getByPrisonerNumber.mockResolvedValue(TestData.prisoner())
+      contactsService.getContact.mockResolvedValue(contact)
+
+      // When
+      const response = await request(app).get(`/prisoner/${prisonerNumber}/contacts/add/confirmation/${journeyId}`)
+
+      // Then
+      const $ = cheerio.load(response.text)
+      expect($('.confirm-address-value').text().trim()).toStrictEqual('mail')
+      expect($('.most-relevant-address-label').text().trim()).toStrictEqual('Mail')
+    })
+
+    it('should use latest start date if no primary or mail', async () => {
+      // Given
+      const contact = TestData.contact({
+        addresses: [
+          {
+            ...blankAddress,
+            property: 'earliest start date',
+            primaryAddress: false,
+            mailFlag: false,
+            startDate: '2020-01-01',
+          },
+          { ...blankAddress, property: 'no start date', primaryAddress: false, mailFlag: false, startDate: null },
+          {
+            ...blankAddress,
+            property: 'latest start date',
+            primaryAddress: false,
+            mailFlag: false,
+            startDate: '2024-01-01',
+          },
+        ],
+      })
+
+      auditService.logPageView.mockResolvedValue(null)
+      prisonerSearchService.getByPrisonerNumber.mockResolvedValue(TestData.prisoner())
+      contactsService.getContact.mockResolvedValue(contact)
+
+      // When
+      const response = await request(app).get(`/prisoner/${prisonerNumber}/contacts/add/confirmation/${journeyId}`)
+
+      // Then
+      const $ = cheerio.load(response.text)
+      expect($('.confirm-address-value').text().trim()).toStrictEqual('latest start date')
+      expect($('.most-relevant-address-label').text().trim()).toStrictEqual('')
+    })
+
+    it('should use latest created if no primary, mail or start date', async () => {
+      // Given
+      const contact = TestData.contact({
+        addresses: [
+          {
+            ...blankAddress,
+            property: 'earliest created date',
+            primaryAddress: false,
+            mailFlag: false,
+            startDate: null,
+            createdTime: '2020-01-01',
+          },
+          {
+            ...blankAddress,
+            property: 'latest created date',
+            primaryAddress: false,
+            mailFlag: false,
+            startDate: null,
+            createdTime: '2024-01-01',
+          },
+        ],
+      })
+
+      auditService.logPageView.mockResolvedValue(null)
+      prisonerSearchService.getByPrisonerNumber.mockResolvedValue(TestData.prisoner())
+      contactsService.getContact.mockResolvedValue(contact)
+
+      // When
+      const response = await request(app).get(`/prisoner/${prisonerNumber}/contacts/add/confirmation/${journeyId}`)
+
+      // Then
+      const $ = cheerio.load(response.text)
+      expect($('.confirm-address-value').text().trim()).toStrictEqual('latest created date')
+      expect($('.most-relevant-address-label').text().trim()).toStrictEqual('')
+    })
+
+    it('should not show if has an end date even if primary', async () => {
+      // Given
+      const contact = TestData.contact({
+        addresses: [
+          {
+            ...blankAddress,
+            property: 'would be this one if no end date',
+            primaryAddress: true,
+            mailFlag: true,
+            startDate: '2000-01-01',
+            endDate: '2020-01-01',
+          },
+          {
+            ...blankAddress,
+            property: 'no end date',
+            primaryAddress: false,
+            mailFlag: false,
+            startDate: null,
+            createdTime: '2024-01-01',
+          },
+        ],
+      })
+
+      auditService.logPageView.mockResolvedValue(null)
+      prisonerSearchService.getByPrisonerNumber.mockResolvedValue(TestData.prisoner())
+      contactsService.getContact.mockResolvedValue(contact)
+
+      // When
+      const response = await request(app).get(`/prisoner/${prisonerNumber}/contacts/add/confirmation/${journeyId}`)
+
+      // Then
+      const $ = cheerio.load(response.text)
+      expect($('.confirm-address-value').text().trim()).toStrictEqual('no end date')
+      expect($('.most-relevant-address-label').text().trim()).toStrictEqual('')
+    })
+
+    it('should show not provided if no relevant addresses', async () => {
+      // Given
+      const contact = TestData.contact({
+        addresses: [
+          {
+            ...blankAddress,
+            property: 'would be this one if no end date',
+            primaryAddress: true,
+            mailFlag: true,
+            startDate: '2000-01-01',
+            endDate: '2020-01-01',
+          },
+        ],
+      })
+
+      auditService.logPageView.mockResolvedValue(null)
+      prisonerSearchService.getByPrisonerNumber.mockResolvedValue(TestData.prisoner())
+      contactsService.getContact.mockResolvedValue(contact)
+
+      // When
+      const response = await request(app).get(`/prisoner/${prisonerNumber}/contacts/add/confirmation/${journeyId}`)
+
+      // Then
+      const $ = cheerio.load(response.text)
+      expect($('.confirm-address-value').text().trim()).toStrictEqual('')
+      expect($('.most-relevant-address-label').text().trim()).toStrictEqual('')
+      expect($('.addresses-not-provided').text().trim()).toStrictEqual('Not provided')
+    })
+
+    it('should show email addresses in alphabetic order', async () => {
+      const contact = TestData.contact({
+        emailAddresses: [
+          TestData.getContactEmailDetails('bravo@example.com', 1),
+          TestData.getContactEmailDetails('alpha@example.com', 2),
+        ],
+      })
+
+      auditService.logPageView.mockResolvedValue(null)
+      prisonerSearchService.getByPrisonerNumber.mockResolvedValue(TestData.prisoner())
+      contactsService.getContact.mockResolvedValue(contact)
+
+      const response = await request(app).get(`/prisoner/${prisonerNumber}/contacts/add/confirmation/${journeyId}`)
+
+      const $ = cheerio.load(response.text)
+      const emailContainer = $('.confirm-email-addresses-value')
+
+      const emails = emailContainer
+        .find('p')
+        .map((_, el) => $(el).text().trim())
+        .get()
+
+      expect(emails).toEqual(['alpha@example.com', 'bravo@example.com'])
+    })
+
+    it.each([
+      ['M', 'Male'],
+      ['F', 'Female'],
+      ['NK', 'Not Known / Not Recorded'],
+      ['NS', 'Specified (Indeterminate)'],
+    ])('should show gender if question was answered', async (gender: string, genderDescription: string) => {
+      // Given
+      auditService.logPageView.mockResolvedValue(null)
+      prisonerSearchService.getByPrisonerNumber.mockResolvedValue(TestData.prisoner())
+      contactsService.searchContact.mockResolvedValue(TestData.contact({ gender, genderDescription }))
+      contactsService.getContact.mockResolvedValue(TestData.contact({ gender, genderDescription }))
+      referenceDataService.getReferenceDescriptionForCode.mockResolvedValue(genderDescription)
+      existingJourney.mode = 'EXISTING'
+
+      // When
+      const response = await request(app).get(`/prisoner/${prisonerNumber}/contacts/add/confirmation/${journeyId}`)
+
+      // Then
+      expect(response.status).toEqual(200)
+      expect(auditService.logPageView).toHaveBeenCalledWith(Page.CONTACT_CONFIRMATION_PAGE, {
+        who: user.username,
+        correlationId: expect.any(String),
+      })
+      const $ = cheerio.load(response.text)
+      expect($('.confirm-gender-value').text().trim()).toStrictEqual(genderDescription)
+    })
+
+    it('should show "not provided" for gender if question was not answered', async () => {
+      // Given
+      auditService.logPageView.mockResolvedValue(null)
+      prisonerSearchService.getByPrisonerNumber.mockResolvedValue(TestData.prisoner())
+      contactsService.searchContact.mockResolvedValue(TestData.contact())
+      contactsService.getContact.mockResolvedValue(TestData.contact({ gender: null, genderDescription: null }))
+      referenceDataService.getReferenceDescriptionForCode.mockResolvedValue(null)
+      existingJourney.mode = 'EXISTING'
+
+      // When
+      const response = await request(app).get(`/prisoner/${prisonerNumber}/contacts/add/confirmation/${journeyId}`)
+
+      // Then
+      expect(response.status).toEqual(200)
+      expect(auditService.logPageView).toHaveBeenCalledWith(Page.CONTACT_CONFIRMATION_PAGE, {
+        who: user.username,
+        correlationId: expect.any(String),
+      })
+      const $ = cheerio.load(response.text)
+      expect($('.confirm-gender-value').text().trim()).toStrictEqual('Not provided')
+    })
+  })
+})
+
+describe('Restrictions', () => {
+  beforeEach(() => {
     auditService.logPageView.mockResolvedValue(null)
     prisonerSearchService.getByPrisonerNumber.mockResolvedValue(TestData.prisoner())
     contactsService.searchContact.mockResolvedValue(TestData.contact())
     contactsService.getContact.mockResolvedValue(TestData.contact())
     existingJourney.mode = 'EXISTING'
-
-    // When
-    const response = await request(app).get(`/prisoner/${prisonerNumber}/contacts/add/confirmation/${journeyId}`)
-
-    // Then
-    expect(response.status).toEqual(200)
-    expect(auditService.logPageView).toHaveBeenCalledWith(Page.CONTACT_CONFIRMATION_PAGE, {
-      who: user.username,
-      correlationId: expect.any(String),
-    })
-    const $ = cheerio.load(response.text)
-
-    expect($('.govuk-heading-l').text()).toStrictEqual('Is this the right person to add as a contact for John Smith?')
-    expect($('.confirm-DL-value').text().trim()).toStrictEqual('LAST-87736799M')
-    expect($('.confirm-PASS-value').text().trim()).toStrictEqual('425362965Issuing authority - UK passport office')
-    expect($('.confirm-NINO-value').text().trim()).toStrictEqual('06/614465M')
   })
+  describe('Global Restrictions', () => {
+    describe('GET /prisoner/:prisonerNumber/contacts/add/confirmation/:journeyId?#restrictions', () => {
+      it('should render restrictions tab', async () => {
+        // Given
+        contactsService.getGlobalContactRestrictions.mockResolvedValue([TestData.getContactRestrictionDetails()])
 
-  it('should show the primary address if there is one', async () => {
-    // Given
-    const contact = TestData.contact({
-      addresses: [
-        { ...blankAddress, property: 'primary', primaryAddress: true, mailFlag: false },
-        { ...blankAddress, property: 'secondary', primaryAddress: false, mailFlag: true },
-      ],
+        // When
+        const response = await request(app).get(`/prisoner/${prisonerNumber}/contacts/add/confirmation/${journeyId}`)
+
+        // Then
+        expect(response.status).toEqual(200)
+        expect(auditService.logPageView).toHaveBeenCalledWith(Page.CONTACT_CONFIRMATION_PAGE, {
+          who: user.username,
+          correlationId: expect.any(String),
+        })
+        const $ = cheerio.load(response.text)
+
+        expect($('[data-qa="confim-title-value-top"]').text()).toStrictEqual(
+          'Is this the right person to add as a contact for John Smith?',
+        )
+
+        expect($('[data-qa="confirm-contact-restriction-title"]').text()).toStrictEqual(
+          'Global restrictions for contact Jones Mason',
+        )
+
+        expect($('.restrictions-tab-title').text().trim()).toStrictEqual('Restrictions(1)')
+        const titleText = $('.govuk-summary-card.restriction-1-card .govuk-summary-card__title').text().trim()
+
+        expect(titleText).toStrictEqual('Child Visitors to be Vetted')
+        expect($('.view-start-date-1-value').text().trim()).toStrictEqual('1 January 2024')
+        expect($('.view-expiry-date-1-value').text().trim()).toStrictEqual('1 August 2050')
+        expect($('.view-entered-by-1-value').text().trim()).toStrictEqual('USER1')
+        expect($('.view-comment-1-value').text().trim()).toStrictEqual('Keep an eye')
+      })
+
+      it('should render restrictions tab with expired restrictions', async () => {
+        // Given
+        contactsService.getGlobalContactRestrictions.mockResolvedValue([
+          TestData.getContactRestrictionDetails({ expiryDate: '2024-08-01' }),
+        ])
+
+        // When
+        const response = await request(app).get(`/prisoner/${prisonerNumber}/contacts/add/confirmation/${journeyId}`)
+
+        // Then
+        const $ = cheerio.load(response.text)
+
+        expect($('.restrictions-tab-title').text().trim()).toStrictEqual('Restrictions(1)')
+
+        const cardTitle = $('.govuk-summary-card.restriction-1-card .govuk-summary-card__title').text().trim()
+
+        expect(cardTitle).toStrictEqual('Child Visitors to be Vetted (Expired)')
+        expect($('.view-start-date-1-value').text().trim()).toStrictEqual('1 January 2024')
+        expect($('.view-expiry-date-1-value').text().trim()).toStrictEqual('1 August 2024')
+        expect($('.view-entered-by-1-value').text().trim()).toStrictEqual('USER1')
+        expect($('.view-comment-1-value').text().trim()).toStrictEqual('Keep an eye')
+      })
+
+      it('should render restrictions tab with no restrictions message', async () => {
+        // Given
+        contactsService.getGlobalContactRestrictions.mockResolvedValue([])
+
+        // When
+        const response = await request(app).get(`/prisoner/${prisonerNumber}/contacts/add/confirmation/${journeyId}`)
+
+        // Then
+        const $ = cheerio.load(response.text)
+
+        expect($('.restrictions-tab-title').text().trim()).toStrictEqual('Restrictions(0)')
+        expect($('[data-qa="restrictions-result-message"]').text().trim()).toStrictEqual(
+          'No global restrictions recorded.',
+        )
+      })
+
+      it('should show not entered text for expiry date and comments when not available', async () => {
+        // Given
+        contactsService.getGlobalContactRestrictions.mockResolvedValue([
+          TestData.getContactRestrictionDetails({ expiryDate: '', comments: '' }),
+        ])
+
+        // When
+        const response = await request(app).get(`/prisoner/${prisonerNumber}/contacts/add/confirmation/${journeyId}`)
+
+        // Then
+        const $ = cheerio.load(response.text)
+
+        expect($('.view-expiry-date-1-value').text().trim()).toStrictEqual('Not entered')
+        expect($('.view-comment-1-value').text().trim()).toStrictEqual('Not entered')
+      })
+
+      it('should sort restrictions based on startDate, with the most recent at the top. where multiple restrictions with the same date, sorted them by createdTime', async () => {
+        // Given
+        contactsService.getGlobalContactRestrictions.mockResolvedValue([
+          TestData.getContactRestrictionDetails({
+            startDate: '2024-01-02',
+            createdTime: '2024-08-01T09:00:00.000000',
+            restrictionTypeDescription: 'Third Card - with the one day oder than third record start date',
+          }),
+          TestData.getContactRestrictionDetails({
+            startDate: '2024-01-01',
+            createdTime: '2024-08-01T09:00:00.000000',
+            restrictionTypeDescription: 'Last Card - as the oldest start date',
+          }),
+          TestData.getContactRestrictionDetails({
+            startDate: '2024-01-03',
+            createdTime: '2024-01-03T10:00:00.000000',
+            restrictionTypeDescription:
+              'Second Card - same start date as record below but one hour older in created date time',
+          }),
+          TestData.getContactRestrictionDetails({
+            startDate: '2024-01-03',
+            createdTime: '2024-01-03T11:00:00.000000',
+            restrictionTypeDescription:
+              'First Card - same start date as record above but one hour newer in created date time',
+          }),
+        ])
+
+        // When
+        const response = await request(app).get(`/prisoner/${prisonerNumber}/contacts/add/confirmation/${journeyId}`)
+
+        // Then
+        const $ = cheerio.load(response.text)
+
+        expect($('.restrictions-tab-title').text().trim()).toStrictEqual('Restrictions(4)')
+        const cardTitles = $('.restrictions-cards-titles')
+        const titles = cardTitles.map((i, el) => $(el).text()).get()
+
+        expect(titles[0].trim()).toContain('First Card')
+        expect(titles[1].trim()).toContain('Second Card')
+        expect(titles[2].trim()).toContain('Third Card')
+        expect(titles[3].trim()).toContain('Last Card')
+      })
     })
-
-    auditService.logPageView.mockResolvedValue(null)
-    prisonerSearchService.getByPrisonerNumber.mockResolvedValue(TestData.prisoner())
-    contactsService.getContact.mockResolvedValue(contact)
-
-    // When
-    const response = await request(app).get(`/prisoner/${prisonerNumber}/contacts/add/confirmation/${journeyId}`)
-
-    // Then
-    const $ = cheerio.load(response.text)
-    expect($('.confirm-address-value').text().trim()).toStrictEqual('primary')
-    expect($('.most-relevant-address-label').text().trim()).toStrictEqual('Primary')
-  })
-
-  it('should label as primary and mail', async () => {
-    // Given
-    const contact = TestData.contact({
-      addresses: [{ ...blankAddress, property: 'primary', primaryAddress: true, mailFlag: true }],
-    })
-
-    auditService.logPageView.mockResolvedValue(null)
-    prisonerSearchService.getByPrisonerNumber.mockResolvedValue(TestData.prisoner())
-    contactsService.getContact.mockResolvedValue(contact)
-
-    // When
-    const response = await request(app).get(`/prisoner/${prisonerNumber}/contacts/add/confirmation/${journeyId}`)
-
-    // Then
-    const $ = cheerio.load(response.text)
-    expect($('.confirm-address-value').text().trim()).toStrictEqual('primary')
-    expect($('.most-relevant-address-label').text().trim()).toStrictEqual('Primary and mail')
-  })
-
-  it('should use mail address if no primary', async () => {
-    // Given
-    const contact = TestData.contact({
-      addresses: [
-        { ...blankAddress, property: 'nothing', primaryAddress: false, mailFlag: false },
-        { ...blankAddress, property: 'mail', primaryAddress: false, mailFlag: true },
-      ],
-    })
-
-    auditService.logPageView.mockResolvedValue(null)
-    prisonerSearchService.getByPrisonerNumber.mockResolvedValue(TestData.prisoner())
-    contactsService.getContact.mockResolvedValue(contact)
-
-    // When
-    const response = await request(app).get(`/prisoner/${prisonerNumber}/contacts/add/confirmation/${journeyId}`)
-
-    // Then
-    const $ = cheerio.load(response.text)
-    expect($('.confirm-address-value').text().trim()).toStrictEqual('mail')
-    expect($('.most-relevant-address-label').text().trim()).toStrictEqual('Mail')
-  })
-
-  it('should use latest start date if no primary or mail', async () => {
-    // Given
-    const contact = TestData.contact({
-      addresses: [
-        {
-          ...blankAddress,
-          property: 'earliest start date',
-          primaryAddress: false,
-          mailFlag: false,
-          startDate: '2020-01-01',
-        },
-        { ...blankAddress, property: 'no start date', primaryAddress: false, mailFlag: false, startDate: null },
-        {
-          ...blankAddress,
-          property: 'latest start date',
-          primaryAddress: false,
-          mailFlag: false,
-          startDate: '2024-01-01',
-        },
-      ],
-    })
-
-    auditService.logPageView.mockResolvedValue(null)
-    prisonerSearchService.getByPrisonerNumber.mockResolvedValue(TestData.prisoner())
-    contactsService.getContact.mockResolvedValue(contact)
-
-    // When
-    const response = await request(app).get(`/prisoner/${prisonerNumber}/contacts/add/confirmation/${journeyId}`)
-
-    // Then
-    const $ = cheerio.load(response.text)
-    expect($('.confirm-address-value').text().trim()).toStrictEqual('latest start date')
-    expect($('.most-relevant-address-label').text().trim()).toStrictEqual('')
-  })
-
-  it('should use latest created if no primary, mail or start date', async () => {
-    // Given
-    const contact = TestData.contact({
-      addresses: [
-        {
-          ...blankAddress,
-          property: 'earliest created date',
-          primaryAddress: false,
-          mailFlag: false,
-          startDate: null,
-          createdTime: '2020-01-01',
-        },
-        {
-          ...blankAddress,
-          property: 'latest created date',
-          primaryAddress: false,
-          mailFlag: false,
-          startDate: null,
-          createdTime: '2024-01-01',
-        },
-      ],
-    })
-
-    auditService.logPageView.mockResolvedValue(null)
-    prisonerSearchService.getByPrisonerNumber.mockResolvedValue(TestData.prisoner())
-    contactsService.getContact.mockResolvedValue(contact)
-
-    // When
-    const response = await request(app).get(`/prisoner/${prisonerNumber}/contacts/add/confirmation/${journeyId}`)
-
-    // Then
-    const $ = cheerio.load(response.text)
-    expect($('.confirm-address-value').text().trim()).toStrictEqual('latest created date')
-    expect($('.most-relevant-address-label').text().trim()).toStrictEqual('')
-  })
-
-  it('should not show if has an end date even if primary', async () => {
-    // Given
-    const contact = TestData.contact({
-      addresses: [
-        {
-          ...blankAddress,
-          property: 'would be this one if no end date',
-          primaryAddress: true,
-          mailFlag: true,
-          startDate: '2000-01-01',
-          endDate: '2020-01-01',
-        },
-        {
-          ...blankAddress,
-          property: 'no end date',
-          primaryAddress: false,
-          mailFlag: false,
-          startDate: null,
-          createdTime: '2024-01-01',
-        },
-      ],
-    })
-
-    auditService.logPageView.mockResolvedValue(null)
-    prisonerSearchService.getByPrisonerNumber.mockResolvedValue(TestData.prisoner())
-    contactsService.getContact.mockResolvedValue(contact)
-
-    // When
-    const response = await request(app).get(`/prisoner/${prisonerNumber}/contacts/add/confirmation/${journeyId}`)
-
-    // Then
-    const $ = cheerio.load(response.text)
-    expect($('.confirm-address-value').text().trim()).toStrictEqual('no end date')
-    expect($('.most-relevant-address-label').text().trim()).toStrictEqual('')
-  })
-
-  it('should show not provided if no relevant addresses', async () => {
-    // Given
-    const contact = TestData.contact({
-      addresses: [
-        {
-          ...blankAddress,
-          property: 'would be this one if no end date',
-          primaryAddress: true,
-          mailFlag: true,
-          startDate: '2000-01-01',
-          endDate: '2020-01-01',
-        },
-      ],
-    })
-
-    auditService.logPageView.mockResolvedValue(null)
-    prisonerSearchService.getByPrisonerNumber.mockResolvedValue(TestData.prisoner())
-    contactsService.getContact.mockResolvedValue(contact)
-
-    // When
-    const response = await request(app).get(`/prisoner/${prisonerNumber}/contacts/add/confirmation/${journeyId}`)
-
-    // Then
-    const $ = cheerio.load(response.text)
-    expect($('.confirm-address-value').text().trim()).toStrictEqual('')
-    expect($('.most-relevant-address-label').text().trim()).toStrictEqual('')
-    expect($('.addresses-not-provided').text().trim()).toStrictEqual('Not provided')
-  })
-
-  it('should show email addresses in alphabetic order', async () => {
-    const contact = TestData.contact({
-      emailAddresses: [
-        TestData.getContactEmailDetails('bravo@example.com', 1),
-        TestData.getContactEmailDetails('alpha@example.com', 2),
-      ],
-    })
-
-    auditService.logPageView.mockResolvedValue(null)
-    prisonerSearchService.getByPrisonerNumber.mockResolvedValue(TestData.prisoner())
-    contactsService.getContact.mockResolvedValue(contact)
-
-    const response = await request(app).get(`/prisoner/${prisonerNumber}/contacts/add/confirmation/${journeyId}`)
-
-    const $ = cheerio.load(response.text)
-    const emailContainer = $('.confirm-email-addresses-value')
-
-    const emails = emailContainer
-      .find('p')
-      .map((_, el) => $(el).text().trim())
-      .get()
-
-    expect(emails).toEqual(['alpha@example.com', 'bravo@example.com'])
-  })
-
-  it.each([
-    ['M', 'Male'],
-    ['F', 'Female'],
-    ['NK', 'Not Known / Not Recorded'],
-    ['NS', 'Specified (Indeterminate)'],
-  ])('should show gender if question was answered', async (gender: string, genderDescription: string) => {
-    // Given
-    auditService.logPageView.mockResolvedValue(null)
-    prisonerSearchService.getByPrisonerNumber.mockResolvedValue(TestData.prisoner())
-    contactsService.searchContact.mockResolvedValue(TestData.contact({ gender, genderDescription }))
-    contactsService.getContact.mockResolvedValue(TestData.contact({ gender, genderDescription }))
-    referenceDataService.getReferenceDescriptionForCode.mockResolvedValue(genderDescription)
-    existingJourney.mode = 'EXISTING'
-
-    // When
-    const response = await request(app).get(`/prisoner/${prisonerNumber}/contacts/add/confirmation/${journeyId}`)
-
-    // Then
-    expect(response.status).toEqual(200)
-    expect(auditService.logPageView).toHaveBeenCalledWith(Page.CONTACT_CONFIRMATION_PAGE, {
-      who: user.username,
-      correlationId: expect.any(String),
-    })
-    const $ = cheerio.load(response.text)
-    expect($('.confirm-gender-value').text().trim()).toStrictEqual(genderDescription)
-  })
-
-  it('should show "not provided" for gender if question was not answered', async () => {
-    // Given
-    auditService.logPageView.mockResolvedValue(null)
-    prisonerSearchService.getByPrisonerNumber.mockResolvedValue(TestData.prisoner())
-    contactsService.searchContact.mockResolvedValue(TestData.contact())
-    contactsService.getContact.mockResolvedValue(TestData.contact({ gender: null, genderDescription: null }))
-    referenceDataService.getReferenceDescriptionForCode.mockResolvedValue(null)
-    existingJourney.mode = 'EXISTING'
-
-    // When
-    const response = await request(app).get(`/prisoner/${prisonerNumber}/contacts/add/confirmation/${journeyId}`)
-
-    // Then
-    expect(response.status).toEqual(200)
-    expect(auditService.logPageView).toHaveBeenCalledWith(Page.CONTACT_CONFIRMATION_PAGE, {
-      who: user.username,
-      correlationId: expect.any(String),
-    })
-    const $ = cheerio.load(response.text)
-    expect($('.confirm-gender-value').text().trim()).toStrictEqual('Not provided')
   })
 })
 

--- a/server/routes/contacts/add/contact-confirmation/contactConfirmationController.ts
+++ b/server/routes/contacts/add/contact-confirmation/contactConfirmationController.ts
@@ -68,7 +68,7 @@ export default class ContactConfirmationController implements PageHandler {
       if (expiry < now) {
         return {
           ...item,
-          restrictionTypeDescription: `${item.restrictionTypeDescription} (Expired)`,
+          restrictionTypeDescription: `${item.restrictionTypeDescription} (expired)`,
         }
       }
 

--- a/server/routes/contacts/add/contact-confirmation/contactConfirmationController.ts
+++ b/server/routes/contacts/add/contact-confirmation/contactConfirmationController.ts
@@ -7,9 +7,11 @@ import { ContactsService } from '../../../../services'
 import ReferenceCodeType from '../../../../enumeration/referenceCodeType'
 import { formatNameLastNameFirst } from '../../../../utils/formatName'
 import ReferenceDataService from '../../../../services/referenceDataService'
+import { findMostRelevantAddress, getLabelForAddress } from '../../../../utils/findMostRelevantAddressAndLabel'
 import PrisonerJourneyParams = journeys.PrisonerJourneyParams
 import ContactDetails = contactsApiClientTypes.ContactDetails
-import { findMostRelevantAddress, getLabelForAddress } from '../../../../utils/findMostRelevantAddressAndLabel'
+import ContactRestrictionDetails = contactsApiClientTypes.ContactRestrictionDetails
+import sortGlobalRestrictions from '../../../../utils/sortGlobalRstrictions'
 
 export default class ContactConfirmationController implements PageHandler {
   constructor(
@@ -27,11 +29,15 @@ export default class ContactConfirmationController implements PageHandler {
     const { prisonerDetails, user } = res.locals
     const journey = req.session.addContactJourneys[journeyId]
     const contact: ContactDetails = await this.contactsService.getContact(journey.contactId, user)
+    const globalRestrictionsEnriched = await this.getGlobalRestrictionsEnriched(contact, user)
+    const globalRestrictions = sortGlobalRestrictions(globalRestrictionsEnriched)
+
     const formattedFullName = await this.formattedFullName(contact, user)
     const mostRelevantAddress = findMostRelevantAddress(contact)
     const mostRelevantAddressLabel = getLabelForAddress(mostRelevantAddress)
     return res.render('pages/contacts/manage/contactConfirmation/confirmation', {
       contact,
+      globalRestrictions,
       formattedFullName,
       prisonerDetails,
       journey,
@@ -39,6 +45,34 @@ export default class ContactConfirmationController implements PageHandler {
       mostRelevantAddressLabel,
       isContactConfirmed: res.locals?.formResponses?.isContactConfirmed ?? journey?.isContactConfirmed,
       navigation: navigationForAddContactJourney(this.PAGE_NAME, journey),
+    })
+  }
+
+  private async getGlobalRestrictionsEnriched(
+    contact: ContactDetails,
+    user: Express.User,
+  ): Promise<ContactRestrictionDetails[]> {
+    const globalRestrictions: ContactRestrictionDetails[] = await this.contactsService.getGlobalContactRestrictions(
+      contact.id,
+      user,
+    )
+
+    return this.enrichRestrictionTitle(globalRestrictions)
+  }
+
+  private enrichRestrictionTitle(globalRestrictions: ContactRestrictionDetails[]): ContactRestrictionDetails {
+    return globalRestrictions.map(item => {
+      const expiry = new Date(item.expiryDate)
+      const now = new Date()
+
+      if (expiry < now) {
+        return {
+          ...item,
+          restrictionTypeDescription: `${item.restrictionTypeDescription} (Expired)`,
+        }
+      }
+
+      return item
     })
   }
 

--- a/server/routes/testutils/testData.ts
+++ b/server/routes/testutils/testData.ts
@@ -12,6 +12,7 @@ type PrisonerContactSummary = components['schemas']['PrisonerContactSummary']
 type ContactIdentityDetails = components['schemas']['ContactIdentityDetails']
 type PatchContactResponse = components['schemas']['PatchContactResponse']
 type PrisonerContactRelationshipDetails = components['schemas']['PrisonerContactRelationshipDetails']
+type ContactRestrictionDetails = components['schemas']['ContactRestrictionDetails']
 export default class TestData {
   static address = ({
     contactAddressId = 1,
@@ -397,4 +398,28 @@ export default class TestData {
       updatedBy,
       updatedTime,
     }) as PatchContactResponse
+
+  static getContactRestrictionDetails = ({
+    contactRestrictionId = 1,
+    contactId = 22,
+    restrictionType = 'CHILD',
+    startDate = '2024-01-01',
+    expiryDate = '2050-08-01',
+    createdTime = '2024-09-20T10:30:00.000000',
+    restrictionTypeDescription = 'Child Visitors to be Vetted',
+    comments = 'Keep an eye',
+  }: Partial<ContactRestrictionDetails> = {}): ContactRestrictionDetails =>
+    ({
+      contactRestrictionId,
+      contactId,
+      restrictionType,
+      restrictionTypeDescription,
+      startDate,
+      expiryDate,
+      comments,
+      createdBy: 'USER1',
+      createdTime,
+      updatedBy: 'USER2',
+      updatedTime: '2024-09-21T10:30:00.000000',
+    }) as ContactRestrictionDetails
 }

--- a/server/services/contactsService.ts
+++ b/server/services/contactsService.ts
@@ -16,6 +16,7 @@ import CreateIdentityRequest = contactsApiClientTypes.CreateIdentityRequest
 import UpdateIdentityRequest = contactsApiClientTypes.UpdateIdentityRequest
 import PrisonerContactRelationshipDetails = contactsApiClientTypes.PrisonerContactRelationshipDetails
 import ContactCreationResult = contactsApiClientTypes.ContactCreationResult
+import ContactRestrictionDetails = contactsApiClientTypes.ContactRestrictionDetails
 
 type PageableObject = components['schemas']['PageableObject']
 type UpdateEmailRequest = components['schemas']['UpdateEmailRequest']
@@ -216,5 +217,9 @@ export default class ContactsService {
 
   async deleteContactEmail(contactId: number, contactEmailId: number, user: Express.User) {
     return this.contactsApiClient.deleteContactEmail(contactId, contactEmailId, user)
+  }
+
+  async getGlobalContactRestrictions(contactId: number, user: Express.User): Promise<ContactRestrictionDetails[]> {
+    return this.contactsApiClient.getGlobalContactRestrictions(contactId, user)
   }
 }

--- a/server/utils/sortGlobalRestrictions.test.ts
+++ b/server/utils/sortGlobalRestrictions.test.ts
@@ -1,0 +1,68 @@
+import ContactRestrictionDetails = contactsApiClientTypes.ContactRestrictionDetails
+import sortGlobalRestrictions from './sortGlobalRstrictions'
+
+describe('sortGlobalRestrictions', () => {
+  it('should sort by startDate descending', () => {
+    const input: ContactRestrictionDetails[] = [
+      { startDate: '2024-01-01', createdTime: '2024-09-20T10:30:00.000000' },
+      { startDate: '2024-02-01', createdTime: '2024-09-18T15:00:00.000000' },
+      { startDate: '2023-12-15', createdTime: '2024-08-01T09:00:00.000000' },
+    ]
+
+    const expected = [
+      { startDate: '2024-02-01', createdTime: '2024-09-18T15:00:00.000000' },
+      { startDate: '2024-01-01', createdTime: '2024-09-20T10:30:00.000000' },
+      { startDate: '2023-12-15', createdTime: '2024-08-01T09:00:00.000000' },
+    ]
+
+    const result = sortGlobalRestrictions(input)
+    expect(result).toEqual(expected)
+  })
+
+  it('should sort by createdTime descending when startDate is the same', () => {
+    const input: ContactRestrictionDetails[] = [
+      { startDate: '2024-01-01', createdTime: '2024-09-20T10:30:00.000000' },
+      { startDate: '2024-01-01', createdTime: '2024-09-20T12:30:00.000000' },
+    ]
+
+    const expected = [
+      { startDate: '2024-01-01', createdTime: '2024-09-20T12:30:00.000000' },
+      { startDate: '2024-01-01', createdTime: '2024-09-20T10:30:00.000000' },
+    ]
+
+    const result = sortGlobalRestrictions(input)
+    expect(result).toEqual(expected)
+  })
+
+  it('should handle an empty array', () => {
+    const input: ContactRestrictionDetails[] = []
+    const result = sortGlobalRestrictions(input)
+    expect(result).toEqual([])
+  })
+
+  it('should handle an array with one element', () => {
+    const input: ContactRestrictionDetails[] = [{ startDate: '2024-01-01', createdTime: '2024-09-20T10:30:00.000000' }]
+
+    const result = sortGlobalRestrictions(input)
+    expect(result).toEqual(input)
+  })
+
+  it('should handle mixed dates correctly', () => {
+    const input: ContactRestrictionDetails[] = [
+      { startDate: '2024-01-01', createdTime: '2024-09-20T10:30:00.000000' },
+      { startDate: '2023-12-15', createdTime: '2024-08-01T09:00:00.000000' },
+      { startDate: '2024-01-01', createdTime: '2024-09-20T12:30:00.000000' },
+      { startDate: '2024-02-01', createdTime: '2024-09-18T15:00:00.000000' },
+    ]
+
+    const expected = [
+      { startDate: '2024-02-01', createdTime: '2024-09-18T15:00:00.000000' },
+      { startDate: '2024-01-01', createdTime: '2024-09-20T12:30:00.000000' },
+      { startDate: '2024-01-01', createdTime: '2024-09-20T10:30:00.000000' },
+      { startDate: '2023-12-15', createdTime: '2024-08-01T09:00:00.000000' },
+    ]
+
+    const result = sortGlobalRestrictions(input)
+    expect(result).toEqual(expected)
+  })
+})

--- a/server/utils/sortGlobalRstrictions.ts
+++ b/server/utils/sortGlobalRstrictions.ts
@@ -1,0 +1,13 @@
+import ContactRestrictionDetails = contactsApiClientTypes.ContactRestrictionDetails
+
+function sortGlobalRestrictions(globalRestrictions: ContactRestrictionDetails[]): ContactRestrictionDetails[] {
+  return globalRestrictions.sort((a, b) => {
+    const startDateComparison = new Date(b.startDate).getTime() - new Date(a.startDate).getTime()
+    if (startDateComparison !== 0) {
+      return startDateComparison
+    }
+    return new Date(b.createdTime).getTime() - new Date(a.createdTime).getTime()
+  })
+}
+
+export default sortGlobalRestrictions

--- a/server/views/pages/contacts/manage/contactConfirmation/confirmation.njk
+++ b/server/views/pages/contacts/manage/contactConfirmation/confirmation.njk
@@ -3,6 +3,7 @@
 {% from "govuk/components/tabs/macro.njk" import govukTabs %}
 {% from "govuk/components/radios/macro.njk" import govukRadios %}
 {% from "govuk/components/button/macro.njk" import govukButton %}
+{% from "./restrictions.njk" import restrictionCard %}
 {% from "../../common/notProvided.njk" import notProvided %}
 
 
@@ -60,8 +61,8 @@
                         </a>
                     </li>
                     <li class="govuk-tabs__list-item">
-                        <a class="govuk-tabs__tab" href="#restrictions">
-                            Restrictions
+                        <a class="govuk-tabs__tab restrictions-tab-title" href="#restrictions">
+                            Restrictions({{ globalRestrictions.length }})
                         </a>
                     </li>
                     <li class="govuk-tabs__list-item">
@@ -73,7 +74,15 @@
                 <div class="govuk-tabs__panel--no-border govuk-!-static-padding-top-7" id="contact-details">
                     {{ contactDetailsHtml() }}
                 </div>
-                <div class="govuk-tabs__panel--no-border govuk-!-static-padding-top-7 govuk-tabs__panel--hidden" id="restrictions"></div>
+                <div class="govuk-tabs__panel govuk-!-static-padding-top-7 govuk-tabs__panel--hidden" data-qa="restrictions-result-message" id="restrictions">
+
+                    {% if globalRestrictions.length >0 %}
+                        {{ restrictionCard(globalRestrictions, contact) }}
+                    {% else %}
+                        No global restrictions recorded.
+                    {% endif %}
+
+                </div>
                 <div class="govuk-tabs__panel--no-border govuk-!-static-padding-top-7 govuk-tabs__panel--hidden" id="linked-offenders"></div>
             </div>
             {{ govukRadios({

--- a/server/views/pages/contacts/manage/contactConfirmation/restrictions.njk
+++ b/server/views/pages/contacts/manage/contactConfirmation/restrictions.njk
@@ -27,7 +27,7 @@
                         text: "Expiry date"
                     },
                     value: {
-                        text: restriction.expiryDate | formatDate if restriction.expiryDate else 'Not entered',
+                        text: restriction.expiryDate | formatDate if restriction.expiryDate else 'Not provided',
                         classes: 'view-expiry-date-' + restriction.contactRestrictionId + '-value'
                     }
                 },
@@ -45,7 +45,7 @@
                         text: "Comment"
                     },
                     value: {
-                        text: restriction.comments if restriction.comments else 'Not entered',
+                        text: restriction.comments if restriction.comments else 'Not provided',
                         classes: 'view-comment-' + restriction.contactRestrictionId + '-value'
                     }
                 }]

--- a/server/views/pages/contacts/manage/contactConfirmation/restrictions.njk
+++ b/server/views/pages/contacts/manage/contactConfirmation/restrictions.njk
@@ -1,0 +1,56 @@
+{% from "govuk/components/summary-list/macro.njk" import govukSummaryList %}
+
+{% macro restrictionCard(restrictions, contact) %}
+
+   <h1 class="govuk-heading-l" data-qa="confirm-contact-restriction-title">Global restrictions for contact {{ (contact.firstName + " " + contact.lastName) | capitaliseName }}</h1>
+
+    {% for restriction in restrictions %}
+
+            {{ govukSummaryList({
+                card: {
+                    title: {
+                        text: restriction.restrictionTypeDescription
+                    },
+                    classes: 'restriction-' + restriction.contactRestrictionId + '-card restrictions-cards-titles'
+                },
+                rows: [{
+                    key: {
+                         text: "Start date"
+                    },
+                    value: {
+                        text: restriction.startDate | formatDate,
+                        classes: 'view-start-date-' + restriction.contactRestrictionId + '-value'
+                    }
+                },
+                {
+                    key: {
+                        text: "Expiry date"
+                    },
+                    value: {
+                        text: restriction.expiryDate | formatDate if restriction.expiryDate else 'Not entered',
+                        classes: 'view-expiry-date-' + restriction.contactRestrictionId + '-value'
+                    }
+                },
+                {
+                    key: {
+                        text: "Entered by"
+                    },
+                    value: {
+                        text:  restriction.createdBy,
+                        classes: 'view-entered-by-' + restriction.contactRestrictionId + '-value'
+                    }
+                },
+                {
+                    key: {
+                        text: "Comment"
+                    },
+                    value: {
+                        text: restriction.comments if restriction.comments else 'Not entered',
+                        classes: 'view-comment-' + restriction.contactRestrictionId + '-value'
+                    }
+                }]
+            }) }}
+    {% endfor %}
+
+
+{% endmacro %}


### PR DESCRIPTION
Display the “Restrictions” tab of the Contact confirmation page, with global restrictions for a contact

### Test evidence : 

**Restrictions sorted with dates**
<img width="672" alt="image" src="https://github.com/user-attachments/assets/aa2b84ce-6003-4381-9f71-255cc7f759a6">

**No restrictions**
<img width="422" alt="image" src="https://github.com/user-attachments/assets/00ba99c4-ea1a-4016-bd20-f7f7ab0f87df">

**with more restrictions:**
<img width="460" alt="image" src="https://github.com/user-attachments/assets/02edd318-3762-416a-bcde-7cf10dc3ed9e">

**Expired title**
![image](https://github.com/user-attachments/assets/b3dcab3b-fc1d-483e-b54a-cdbdee72baf8)

