### PR TITLE
PRC-74: Minor create restrictions tweaks

### DIFF
--- a/integration_tests/e2e/createContactGlobalRestriction.cy.ts
+++ b/integration_tests/e2e/createContactGlobalRestriction.cy.ts
@@ -47,7 +47,7 @@ context('Create Contact Global Restriction', () => {
     }
     cy.task('stubCreateContactRestriction', { contactId, created })
 
-    Page.verifyOnPage(EnterRestrictionPage, 'First Middle Names Last', 'CONTACT_GLOBAL') //
+    Page.verifyOnPage(EnterRestrictionPage, 'First Last', 'CONTACT_GLOBAL') //
       .selectType('CCTV')
       .enterStartDate('15/06/1982')
       .clickContinue()
@@ -81,7 +81,7 @@ context('Create Contact Global Restriction', () => {
     }
     cy.task('stubCreateContactRestriction', { contactId, created })
 
-    Page.verifyOnPage(EnterRestrictionPage, 'First Middle Names Last', 'CONTACT_GLOBAL') //
+    Page.verifyOnPage(EnterRestrictionPage, 'First Last', 'CONTACT_GLOBAL') //
       .selectType('CCTV')
       .enterStartDate('15/06/1982')
       .enterExpiryDate('25/12/2025')
@@ -118,7 +118,7 @@ context('Create Contact Global Restriction', () => {
     }
     cy.task('stubCreateContactRestriction', { contactId, created })
 
-    Page.verifyOnPage(EnterRestrictionPage, 'First Middle Names Last', 'CONTACT_GLOBAL') //
+    Page.verifyOnPage(EnterRestrictionPage, 'First Last', 'CONTACT_GLOBAL') //
       .selectType('CCTV')
       .enterStartDate('15/06/1982')
       .enterExpiryDate('25/12/2025')
@@ -132,27 +132,27 @@ context('Create Contact Global Restriction', () => {
       .verifyShowCommentsAs('Some comments')
       .clickChangeTypeLink()
 
-    Page.verifyOnPage(EnterRestrictionPage, 'First Middle Names Last', 'CONTACT_GLOBAL') //
+    Page.verifyOnPage(EnterRestrictionPage, 'First Last', 'CONTACT_GLOBAL') //
       .selectType('BAN')
       .continueTo(CreateRestrictionCheckYourAnswersPage, 'CONTACT_GLOBAL')
       .verifyShowsTypeAs('Banned')
       .clickChangeStartDateLink()
 
-    Page.verifyOnPage(EnterRestrictionPage, 'First Middle Names Last', 'CONTACT_GLOBAL') //
+    Page.verifyOnPage(EnterRestrictionPage, 'First Last', 'CONTACT_GLOBAL') //
       .clearStartDate()
       .enterStartDate('28/02/2024')
       .continueTo(CreateRestrictionCheckYourAnswersPage, 'CONTACT_GLOBAL')
       .verifyShowsStartDateAs('28 February 2024')
       .clickChangeExpiryDateLink()
 
-    Page.verifyOnPage(EnterRestrictionPage, 'First Middle Names Last', 'CONTACT_GLOBAL') //
+    Page.verifyOnPage(EnterRestrictionPage, 'First Last', 'CONTACT_GLOBAL') //
       .clearExpiryDate()
       .enterExpiryDate('15/06/2025')
       .continueTo(CreateRestrictionCheckYourAnswersPage, 'CONTACT_GLOBAL')
       .verifyShowExpiryDateAs('15 June 2025')
       .clickChangeCommentsLink()
 
-    Page.verifyOnPage(EnterRestrictionPage, 'First Middle Names Last', 'CONTACT_GLOBAL') //
+    Page.verifyOnPage(EnterRestrictionPage, 'First Last', 'CONTACT_GLOBAL') //
       .clearComments()
       .enterComments('Different comments')
       .continueTo(CreateRestrictionCheckYourAnswersPage, 'CONTACT_GLOBAL')
@@ -177,7 +177,7 @@ context('Create Contact Global Restriction', () => {
   })
 
   it('Type and start date are required', () => {
-    const enterRestrictionPage = Page.verifyOnPage(EnterRestrictionPage, 'First Middle Names Last', 'CONTACT_GLOBAL')
+    const enterRestrictionPage = Page.verifyOnPage(EnterRestrictionPage, 'First Last', 'CONTACT_GLOBAL')
     enterRestrictionPage.clickContinue()
 
     enterRestrictionPage.hasFieldInError('type', 'Select the restriction type')
@@ -185,7 +185,7 @@ context('Create Contact Global Restriction', () => {
   })
 
   it('Errors are in field order', () => {
-    const enterRestrictionPage = Page.verifyOnPage(EnterRestrictionPage, 'First Middle Names Last', 'CONTACT_GLOBAL')
+    const enterRestrictionPage = Page.verifyOnPage(EnterRestrictionPage, 'First Last', 'CONTACT_GLOBAL')
     enterRestrictionPage //
       .enterStartDate('foo')
       .enterExpiryDate('bar')

--- a/integration_tests/e2e/createPrisonerContactRestriction.cy.ts
+++ b/integration_tests/e2e/createPrisonerContactRestriction.cy.ts
@@ -47,7 +47,7 @@ context('Create Prisoner Contact Restriction', () => {
     }
     cy.task('stubCreatePrisonerContactRestriction', { prisonerContactId, created })
 
-    Page.verifyOnPage(EnterRestrictionPage, 'First Middle Names Last', 'PRISONER_CONTACT') //
+    Page.verifyOnPage(EnterRestrictionPage, 'First Last', 'PRISONER_CONTACT') //
       .selectType('CCTV')
       .enterStartDate('15/06/1982')
       .clickContinue()
@@ -81,7 +81,7 @@ context('Create Prisoner Contact Restriction', () => {
     }
     cy.task('stubCreatePrisonerContactRestriction', { prisonerContactId, created })
 
-    Page.verifyOnPage(EnterRestrictionPage, 'First Middle Names Last', 'PRISONER_CONTACT') //
+    Page.verifyOnPage(EnterRestrictionPage, 'First Last', 'PRISONER_CONTACT') //
       .selectType('CCTV')
       .enterStartDate('15/06/1982')
       .enterExpiryDate('25/12/2025')
@@ -118,7 +118,7 @@ context('Create Prisoner Contact Restriction', () => {
     }
     cy.task('stubCreatePrisonerContactRestriction', { prisonerContactId, created })
 
-    Page.verifyOnPage(EnterRestrictionPage, 'First Middle Names Last', 'PRISONER_CONTACT') //
+    Page.verifyOnPage(EnterRestrictionPage, 'First Last', 'PRISONER_CONTACT') //
       .selectType('CCTV')
       .enterStartDate('15/06/1982')
       .enterExpiryDate('25/12/2025')
@@ -132,27 +132,27 @@ context('Create Prisoner Contact Restriction', () => {
       .verifyShowCommentsAs('Some comments')
       .clickChangeTypeLink()
 
-    Page.verifyOnPage(EnterRestrictionPage, 'First Middle Names Last', 'PRISONER_CONTACT') //
+    Page.verifyOnPage(EnterRestrictionPage, 'First Last', 'PRISONER_CONTACT') //
       .selectType('BAN')
       .continueTo(CreateRestrictionCheckYourAnswersPage, 'PRISONER_CONTACT')
       .verifyShowsTypeAs('Banned')
       .clickChangeStartDateLink()
 
-    Page.verifyOnPage(EnterRestrictionPage, 'First Middle Names Last', 'PRISONER_CONTACT') //
+    Page.verifyOnPage(EnterRestrictionPage, 'First Last', 'PRISONER_CONTACT') //
       .clearStartDate()
       .enterStartDate('28/02/2024')
       .continueTo(CreateRestrictionCheckYourAnswersPage, 'PRISONER_CONTACT')
       .verifyShowsStartDateAs('28 February 2024')
       .clickChangeExpiryDateLink()
 
-    Page.verifyOnPage(EnterRestrictionPage, 'First Middle Names Last', 'PRISONER_CONTACT') //
+    Page.verifyOnPage(EnterRestrictionPage, 'First Last', 'PRISONER_CONTACT') //
       .clearExpiryDate()
       .enterExpiryDate('15/06/2025')
       .continueTo(CreateRestrictionCheckYourAnswersPage, 'PRISONER_CONTACT')
       .verifyShowExpiryDateAs('15 June 2025')
       .clickChangeCommentsLink()
 
-    Page.verifyOnPage(EnterRestrictionPage, 'First Middle Names Last', 'PRISONER_CONTACT') //
+    Page.verifyOnPage(EnterRestrictionPage, 'First Last', 'PRISONER_CONTACT') //
       .clearComments()
       .enterComments('Different comments')
       .continueTo(CreateRestrictionCheckYourAnswersPage, 'PRISONER_CONTACT')
@@ -177,7 +177,7 @@ context('Create Prisoner Contact Restriction', () => {
   })
 
   it('Type and start date are required', () => {
-    const enterRestrictionPage = Page.verifyOnPage(EnterRestrictionPage, 'First Middle Names Last', 'PRISONER_CONTACT')
+    const enterRestrictionPage = Page.verifyOnPage(EnterRestrictionPage, 'First Last', 'PRISONER_CONTACT')
     enterRestrictionPage.clickContinue()
 
     enterRestrictionPage.hasFieldInError('type', 'Select the restriction type')
@@ -185,7 +185,7 @@ context('Create Prisoner Contact Restriction', () => {
   })
 
   it('Errors are in field order', () => {
-    const enterRestrictionPage = Page.verifyOnPage(EnterRestrictionPage, 'First Middle Names Last', 'PRISONER_CONTACT')
+    const enterRestrictionPage = Page.verifyOnPage(EnterRestrictionPage, 'First Last', 'PRISONER_CONTACT')
     enterRestrictionPage //
       .enterStartDate('foo')
       .enterExpiryDate('bar')

--- a/server/routes/contacts/add/success/successfullyAddedContactController.ts
+++ b/server/routes/contacts/add/success/successfullyAddedContactController.ts
@@ -45,6 +45,7 @@ export default class SuccessfullyAddedContactController implements PageHandler {
       successMessage,
       contactId,
       prisonerContactId,
+      showPrisonerNameInSuccessPanel: true,
       navigation: {
         breadcrumbs: ['DPS_HOME', 'DPS_PROFILE', 'PRISONER_CONTACTS'],
       },

--- a/server/routes/restrictions/check-answers/addRestrictionCheckAnswersController.test.ts
+++ b/server/routes/restrictions/check-answers/addRestrictionCheckAnswersController.test.ts
@@ -171,6 +171,16 @@ describe('GET /prisoner/:prisonerNumber/contacts/:contactId/relationship/:prison
     expect($('.check-answers-start-date-value').text().trim()).toStrictEqual('1 February 2024')
     expect($('.check-answers-expiry-date-value').text().trim()).toStrictEqual('2 March 2025')
     expect($('.check-answers-comments-value').text().trim()).toStrictEqual('Some comments')
+
+    const expectedBaseChangeLink = `/prisoner/${prisonerNumber}/contacts/${contactId}/relationship/${prisonerContactId}/restriction/add/PRISONER_CONTACT/enter-restriction/${journeyId}`
+    expect($('[data-qa=change-type-link]').first().attr('href')).toStrictEqual(`${expectedBaseChangeLink}#type`)
+    expect($('[data-qa=change-start-date-link]').first().attr('href')).toStrictEqual(
+      `${expectedBaseChangeLink}#startDate`,
+    )
+    expect($('[data-qa=change-expiry-date-link]').first().attr('href')).toStrictEqual(
+      `${expectedBaseChangeLink}#expiryDate`,
+    )
+    expect($('[data-qa=change-comments-link]').first().attr('href')).toStrictEqual(`${expectedBaseChangeLink}#comments`)
   })
 
   it('should render enter restriction page for estate wide with all details', async () => {
@@ -202,10 +212,21 @@ describe('GET /prisoner/:prisonerNumber/contacts/:contactId/relationship/:prison
     expect($('[data-qa=contact-name-and-id]').first().text().trim()).toStrictEqual('Bar Foo (123)')
     expect($('[data-qa=back-link]')).toHaveLength(0)
     expect($('[data-qa=breadcrumbs]')).toHaveLength(0)
+
     expect($('.check-answers-type-value').text().trim()).toStrictEqual('Banned')
     expect($('.check-answers-start-date-value').text().trim()).toStrictEqual('1 February 2024')
     expect($('.check-answers-expiry-date-value').text().trim()).toStrictEqual('2 March 2025')
     expect($('.check-answers-comments-value').text().trim()).toStrictEqual('Some comments')
+
+    const expectedBaseChangeLink = `/prisoner/${prisonerNumber}/contacts/${contactId}/relationship/${prisonerContactId}/restriction/add/CONTACT_GLOBAL/enter-restriction/${journeyId}`
+    expect($('[data-qa=change-type-link]').first().attr('href')).toStrictEqual(`${expectedBaseChangeLink}#type`)
+    expect($('[data-qa=change-start-date-link]').first().attr('href')).toStrictEqual(
+      `${expectedBaseChangeLink}#startDate`,
+    )
+    expect($('[data-qa=change-expiry-date-link]').first().attr('href')).toStrictEqual(
+      `${expectedBaseChangeLink}#expiryDate`,
+    )
+    expect($('[data-qa=change-comments-link]').first().attr('href')).toStrictEqual(`${expectedBaseChangeLink}#comments`)
   })
 
   it('should call the audit service for the page view', async () => {
@@ -244,7 +265,7 @@ describe('GET /prisoner/:prisonerNumber/contacts/:contactId/relationship/:prison
 
 describe('POST /prisoner/:prisonerNumber/contacts/:contactId/relationship/:prisonerContactId/restriction/add/:restrictionClass/check-answers/:journeyId', () => {
   it.each([['PRISONER_CONTACT'], ['CONTACT_GLOBAL']])(
-    'should pass to check answers page if there are no validation errors',
+    'should pass to success page and remove from session',
     async (restrictionClass: RestrictionClass) => {
       existingJourney.restrictionClass = restrictionClass
       restrictionsService.createRestriction.mockResolvedValue({})
@@ -262,6 +283,7 @@ describe('POST /prisoner/:prisonerNumber/contacts/:contactId/relationship/:priso
         )
 
       expect(restrictionsService.createRestriction).toHaveBeenCalledWith(existingJourney, user)
+      expect(session.addRestrictionJourneys[journeyId]).toBeUndefined()
     },
   )
 

--- a/server/routes/restrictions/check-answers/addRestrictionCheckAnswersController.ts
+++ b/server/routes/restrictions/check-answers/addRestrictionCheckAnswersController.ts
@@ -72,7 +72,9 @@ export default class AddRestrictionCheckAnswersController implements PageHandler
     const { journeyId, prisonerNumber, contactId, prisonerContactId, restrictionClass } = req.params
     const { user } = res.locals
     const journey = req.session.addRestrictionJourneys[journeyId]
-    await this.restrictionsService.createRestriction(journey, user)
+    await this.restrictionsService
+      .createRestriction(journey, user)
+      .then(_ => delete req.session.addRestrictionJourneys[journeyId])
     res.redirect(
       `/prisoner/${prisonerNumber}/contacts/${contactId}/relationship/${prisonerContactId}/restriction/add/${restrictionClass}/success`,
     )

--- a/server/routes/restrictions/enter-restriction/enterRestrictionController.test.ts
+++ b/server/routes/restrictions/enter-restriction/enterRestrictionController.test.ts
@@ -103,7 +103,7 @@ describe('GET /prisoner/:prisonerNumber/contacts/:contactId/relationship/:prison
     expect($('[data-qa=main-heading]').first().text().trim()).toStrictEqual('Add a new global restriction for Bar Foo')
     expect($('[data-qa=back-link]').first().attr('href')).toStrictEqual('/foo-bar')
     expect($('[data-qa=prisoner-name-and-id]')).toHaveLength(0)
-    expect($('[data-qa=contact-name-and-id]').first().text().trim()).toStrictEqual('Bar Foo (123)')
+    expect($('[data-qa=contact-name-and-id]')).toHaveLength(0)
     expect($('[data-qa=cancel-button]')).toHaveLength(0)
     expect($('[data-qa=breadcrumbs]')).toHaveLength(0)
   })

--- a/server/routes/restrictions/enter-restriction/enterRestrictionController.ts
+++ b/server/routes/restrictions/enter-restriction/enterRestrictionController.ts
@@ -74,15 +74,13 @@ export default class EnterRestrictionController implements PageHandler {
     text: string
     selected?: boolean
   }> {
-    const mappedOptions = options
-      .map((title: ReferenceCode) => {
-        return {
-          text: title.description,
-          value: title.code,
-          selected: title.code === selectedOption,
-        }
-      })
-      .sort((a, b) => a.text.localeCompare(b.text))
+    const mappedOptions = options.map((referenceCode: ReferenceCode) => {
+      return {
+        text: referenceCode.description,
+        value: referenceCode.code,
+        selected: referenceCode.code === selectedOption,
+      }
+    })
     return [{ text: 'Select restriction type', value: '' }, ...mappedOptions]
   }
 }

--- a/server/routes/restrictions/success/successfullyAddedRestrictionController.test.ts
+++ b/server/routes/restrictions/success/successfullyAddedRestrictionController.test.ts
@@ -35,11 +35,10 @@ afterEach(() => {
 })
 
 describe('GET /prisoner/:prisonerNumber/contacts/:contactId/relationship/:prisonerContactId/restriction/add/:restrictionClass/success', () => {
-  it.each([
-    ['CONTACT_GLOBAL', 'New global restriction recorded'],
-    ['PRISONER_CONTACT', 'New prisoner-contact restriction recorded'],
-  ])('should render success for restriction class %s', async (restrictionClass: RestrictionClass, message: string) => {
+  it('should render success for restriction class PRISONER_CONTACT', async () => {
     // Given
+    const restrictionClass: RestrictionClass = 'PRISONER_CONTACT'
+    const message: string = 'New prisoner-contact restriction recorded'
     auditService.logPageView.mockResolvedValue(null)
     const contactDetails = TestData.contact()
     contactsService.getContact.mockResolvedValue(contactDetails)
@@ -53,6 +52,37 @@ describe('GET /prisoner/:prisonerNumber/contacts/:contactId/relationship/:prison
     const $ = cheerio.load(response.text)
     expect($('.govuk-panel__title').text().trim()).toStrictEqual(message)
     expect($('[data-qa=prisoner-name]').text().trim()).toContain('John Smith')
+    expect($('[data-qa=contact-name]').text().trim()).toContain('Jones Mason')
+    expect($('[data-qa=breadcrumbs]')).toHaveLength(1)
+    expect($('[data-qa=breadcrumbs] a').eq(0).attr('href')).toStrictEqual('http://localhost:3001')
+    expect($('[data-qa=breadcrumbs] a').eq(1).attr('href')).toStrictEqual('http://localhost:3001/prisoner/A1234BC')
+    expect($('[data-qa=breadcrumbs] a').eq(2).attr('href')).toStrictEqual('/prisoner/A1234BC/contacts/list')
+    expect($('[data-qa=go-to-contact-info-link]').first().attr('href')).toStrictEqual(
+      '/prisoner/A1234BC/contacts/manage/22/relationship/123456',
+    )
+    expect($('[data-qa=go-to-contacts-list-link]').first().attr('href')).toStrictEqual(
+      '/prisoner/A1234BC/contacts/list',
+    )
+    expect($('.govuk-caption-l').first().text().trim()).toStrictEqual('Manage contact restrictions')
+  })
+
+  it('should render success for restriction class CONTACT_GLOBAL', async () => {
+    // Given
+    const restrictionClass: RestrictionClass = 'CONTACT_GLOBAL'
+    const message: string = 'New global restriction recorded'
+    auditService.logPageView.mockResolvedValue(null)
+    const contactDetails = TestData.contact()
+    contactsService.getContact.mockResolvedValue(contactDetails)
+
+    // When
+    const response = await request(app).get(
+      `/prisoner/${prisonerNumber}/contacts/${contactDetails.id}/relationship/123456/restriction/add/${restrictionClass}/success`,
+    )
+
+    // Then
+    const $ = cheerio.load(response.text)
+    expect($('.govuk-panel__title').text().trim()).toStrictEqual(message)
+    expect($('[data-qa=prisoner-name]')).toHaveLength(0)
     expect($('[data-qa=contact-name]').text().trim()).toContain('Jones Mason')
     expect($('[data-qa=breadcrumbs]')).toHaveLength(1)
     expect($('[data-qa=breadcrumbs] a').eq(0).attr('href')).toStrictEqual('http://localhost:3001')

--- a/server/routes/restrictions/success/successfullyAddedRestrictionController.ts
+++ b/server/routes/restrictions/success/successfullyAddedRestrictionController.ts
@@ -31,12 +31,15 @@ export default class SuccessfullyAddedRestrictionController implements PageHandl
       middleNames: contact.middleNames,
     }
     let successMessage
+    let showPrisonerNameInSuccessPanel
     switch (restrictionClass) {
       case 'CONTACT_GLOBAL':
         successMessage = 'New global restriction recorded'
+        showPrisonerNameInSuccessPanel = false
         break
       case 'PRISONER_CONTACT':
         successMessage = 'New prisoner-contact restriction recorded'
+        showPrisonerNameInSuccessPanel = true
         break
       default:
         break
@@ -46,6 +49,7 @@ export default class SuccessfullyAddedRestrictionController implements PageHandl
       successMessage,
       contactId,
       prisonerContactId,
+      showPrisonerNameInSuccessPanel,
       navigation: {
         breadcrumbs: ['DPS_HOME', 'DPS_PROFILE', 'PRISONER_CONTACTS'],
       },

--- a/server/views/pages/contacts/common/success.njk
+++ b/server/views/pages/contacts/common/success.njk
@@ -10,18 +10,19 @@
 {{ miniProfile(prisonerDetails) }}
 <span class="govuk-caption-l">{{ caption }}</span>
  <div class="govuk-grid-row">
+        {% set prisonerNameForPanel = '<div><strong>Prisoner: </strong><span data-qa="prisoner-name">' + prisonerDetails | formatNameFirstNameFirst(excludeMiddleNames = true) + '</span></div>' if showPrisonerNameInSuccessPanel %}
         <div class="govuk-grid-column-two-thirds">
             {{ govukPanel({
                 titleText: successMessage,
                 attributes: {"data-qa": "success-message"},
                 html: (
-                    '<div><strong>Prisoner: </strong><span data-qa="prisoner-name">' + prisonerDetails | formatNameFirstNameFirst(excludeMiddleNames = true) + '</span></div>' +
-                    '<div><strong>Contact: </strong><span data-qa="contact-name">' + journey.names | formatNameFirstNameFirst + '</span></div>'
+                     prisonerNameForPanel +
+                    '<div><strong>Contact: </strong><span data-qa="contact-name">' + journey.names | formatNameFirstNameFirst(excludeMiddleNames = true) + '</span></div>'
                 )
             }) }}
             <div>
                 <a href="/prisoner/{{ prisonerDetails.prisonerNumber }}/contacts/manage/{{ contactId }}/relationship/{{ prisonerContactId }}" class="govuk-body govuk-link--no-visited-state" data-qa="go-to-contact-info-link">
-                    View {{ journey.names | formatNameFirstNameFirst }}’s contact information
+                    View {{ journey.names | formatNameFirstNameFirst(excludeMiddleNames = true) }}’s contact information
                 </a>
             </div>
             <div class="govuk-!-margin-top-4">

--- a/server/views/pages/contacts/restrictions/addRestrictionCheckAnswers.njk
+++ b/server/views/pages/contacts/restrictions/addRestrictionCheckAnswers.njk
@@ -16,10 +16,12 @@
         <div class="govuk-grid-column-two-thirds">
             <span class="govuk-caption-l">Manage contact restrictions</span>
             <h1 class="govuk-heading-l" data-qa="main-heading">{{ title }}</h1>
-            {% if journey.restrictionClass === 'PRISONER_CONTACT' %}
-            <p><b>Prisoner:</b> <span data-qa="prisoner-name-and-id">{{ prisonerDetails | formatNameFirstNameFirst(excludeMiddleNames = true) }} ({{ prisonerDetails.prisonerNumber }})</span></p>
-            {% endif %}
-            <p><b>Contact:</b> <span data-qa="contact-name-and-id">{{ journey.contactNames | formatNameFirstNameFirst }} ({{ journey.contactId }})</span></p>
+            <p>
+                {% if journey.restrictionClass === 'PRISONER_CONTACT' %}
+                    <b>Prisoner:</b> <span data-qa="prisoner-name-and-id">{{ prisonerDetails | formatNameFirstNameFirst(excludeMiddleNames = true) }} ({{ prisonerDetails.prisonerNumber }})</span><br/>
+                {% endif %}
+                <b>Contact:</b> <span data-qa="contact-name-and-id">{{ journey.contactNames | formatNameFirstNameFirst }} ({{ journey.contactId }})</span>
+            </p>
             <form method='POST'>
                 <input type="hidden" name="_csrf" value="{{ csrfToken }}" />
                 {% set  formattedExpiryDate %}{% if expiryDate %}{{ expiryDate | formatDate }}{% else %}Not provided{% endif %}{% endset %}
@@ -36,7 +38,7 @@
                             actions: {
                                 items: [
                                     {
-                                        href: changeUrl,
+                                        href: changeUrl + "#type",
                                         text: "Change",
                                         visuallyHiddenText: " restriction type",
                                         attributes: {"data-qa": "change-type-link"},
@@ -56,7 +58,7 @@
                             actions: {
                                 items: [
                                     {
-                                        href: changeUrl,
+                                        href: changeUrl + "#startDate",
                                         text: "Change",
                                         visuallyHiddenText: " start date",
                                         attributes: {"data-qa": "change-start-date-link"},
@@ -76,7 +78,7 @@
                             actions: {
                                 items: [
                                     {
-                                        href: changeUrl,
+                                        href: changeUrl + "#expiryDate",
                                         text: "Change",
                                         visuallyHiddenText: " expiry date",
                                         attributes: {"data-qa": "change-expiry-date-link"},
@@ -96,7 +98,7 @@
                             actions: {
                                 items: [
                                     {
-                                        href: changeUrl,
+                                        href: changeUrl + "#comments",
                                         text: "Change",
                                         visuallyHiddenText: " comments",
                                         attributes: {"data-qa": "change-comments-link"},
@@ -116,9 +118,7 @@
                         attributes: {"data-qa": "continue-button"},
                         preventDoubleClick: true
                     }) }}
-                    {% if navigation.cancelButton %}
-                        <a class="govuk-link govuk-link--no-visited-state govuk-!-font-size-19" href="{{ journey.returnPoint.url }}" data-qa="cancel-button">Cancel</a>
-                    {% endif %}
+                    <a class="govuk-link govuk-link--no-visited-state govuk-!-font-size-19" href="{{ journey.returnPoint.url }}" data-qa="cancel-button">Cancel</a>
                 </div>
             </form>
 

--- a/server/views/pages/contacts/restrictions/enterRestriction.njk
+++ b/server/views/pages/contacts/restrictions/enterRestriction.njk
@@ -8,7 +8,7 @@
 {% if journey.restrictionClass === 'PRISONER_CONTACT' %}
     {% set title = "Add a new prisoner-contact restriction" %}
 {% else %}
-    {% set title = "Add a new global restriction for " + journey.contactNames | formatNameFirstNameFirst %}
+    {% set title = "Add a new global restriction for " + journey.contactNames | formatNameFirstNameFirst(excludeMiddleNames = true) %}
 {% endif %}
 {% set pageTitle = applicationName + " - " + title %}
 {% set mainClasses = "app-container govuk-body" %}
@@ -23,9 +23,12 @@
             <span class="govuk-caption-l">Manage contact restrictions</span>
             <h1 class="govuk-heading-l" data-qa="main-heading">{{ title }}</h1>
             {% if journey.restrictionClass === 'PRISONER_CONTACT' %}
-            <p><b>Prisoner:</b> <span data-qa="prisoner-name-and-id">{{ prisonerDetails | formatNameFirstNameFirst(excludeMiddleNames = true) }} ({{ prisonerDetails.prisonerNumber }})</span></p>
+            <p>
+                <b>Prisoner:</b> <span data-qa="prisoner-name-and-id">{{ prisonerDetails | formatNameFirstNameFirst(excludeMiddleNames = true) }} ({{ prisonerDetails.prisonerNumber }})</span>
+                <br/>
+                <b>Contact:</b> <span data-qa="contact-name-and-id">{{ journey.contactNames | formatNameFirstNameFirst }} ({{ journey.contactId }})</span>
+            </p>
             {% endif %}
-            <p><b>Contact:</b> <span data-qa="contact-name-and-id">{{ journey.contactNames | formatNameFirstNameFirst }} ({{ journey.contactId }})</span></p>
             <form method='POST'>
                 <input type="hidden" name="_csrf" value="{{ csrfToken }}" />
 


### PR DESCRIPTION
* Was sorting types incorrectly
* Hide contact name on enter restrictions page as it's in the question
* Re-format contact name & prisoner name hints to match design
* Hide prisoner name on success page
* Hide contact middle names throughout restrictions journey as per AC
* Delete journey on success (you could go back then create a 2nd restriction)
* Set focus to field selected in change link on CYA
* Always show cancel on CYA