### PR TITLE
PRC-163: Addresses fixes

### DIFF
--- a/server/routes/contacts/add/contact-confirmation/contactConfirmationController.test.ts
+++ b/server/routes/contacts/add/contact-confirmation/contactConfirmationController.test.ts
@@ -40,6 +40,7 @@ const blankAddress = TestData.address({
   countyDescription: '',
   countryCode: '',
   countryDescription: '',
+  postcode: '',
   primaryAddress: false,
   mailFlag: false,
   startDate: null,

--- a/server/routes/contacts/manage/addresses/manageAddressesController.test.ts
+++ b/server/routes/contacts/manage/addresses/manageAddressesController.test.ts
@@ -59,7 +59,7 @@ describe('Addresses', () => {
     expect(response.status).toEqual(200)
     expect($('.most-relevant-address-label').text().trim()).toStrictEqual('Primary')
     expect($('.confirm-address-value').text().trim()).toStrictEqual(
-      '24, Acacia AvenueBuntingSheffieldSouth YorkshireEngland',
+      '24, Acacia AvenueBuntingSheffieldSouth YorkshireS2 3LKEngland',
     )
     expect($('.address-specific-phone-numbers-not-provided').text().trim()).toStrictEqual('Home: 01111 777777 (+0123)')
     expect($('[data-qa=confirm-start-date-value]').first().text().trim()).toStrictEqual('From January 2020')
@@ -145,9 +145,15 @@ describe('Addresses', () => {
     expect(cardTitles.eq(2).text().trim()).toStrictEqual('Business address')
 
     const addressLines = $('.confirm-address-value')
-    expect(addressLines.eq(0).text()).toContain('Flat no 1, 24, Acacia AvenueBuntingSheffieldSouth YorkshireEngland')
-    expect(addressLines.eq(1).text()).toContain('Flat no 2, 24, Acacia AvenueBuntingSheffieldSouth YorkshireEngland')
-    expect(addressLines.eq(2).text()).toContain('Flat no 3, 24, Acacia AvenueBuntingSheffieldSouth YorkshireEngland')
+    expect(addressLines.eq(0).text()).toContain(
+      'Flat no 1, 24, Acacia AvenueBuntingSheffieldSouth YorkshireS2 3LKEngland',
+    )
+    expect(addressLines.eq(1).text()).toContain(
+      'Flat no 2, 24, Acacia AvenueBuntingSheffieldSouth YorkshireS2 3LKEngland',
+    )
+    expect(addressLines.eq(2).text()).toContain(
+      'Flat no 3, 24, Acacia AvenueBuntingSheffieldSouth YorkshireS2 3LKEngland',
+    )
 
     const mostRelevantLabel = $('.most-relevant-address-label')
     expect(mostRelevantLabel.length).toStrictEqual(2)

--- a/server/routes/contacts/manage/contact-details/contactDetailsController.test.ts
+++ b/server/routes/contacts/manage/contact-details/contactDetailsController.test.ts
@@ -490,7 +490,7 @@ describe('GET /contacts/manage/:contactId/relationship/:prisonerContactId', () =
 
       const confirmAddressValueClass = '.confirm-address-value'
       expect($(confirmAddressValueClass).text().trim()).toStrictEqual(
-        '24, Acacia AvenueBuntingSheffieldSouth YorkshireEngland',
+        '24, Acacia AvenueBuntingSheffieldSouth YorkshireS2 3LKEngland',
       )
     })
 
@@ -524,6 +524,9 @@ describe('GET /contacts/manage/:contactId/relationship/:prisonerContactId', () =
       const $ = cheerio.load(response.text)
       expect(response.status).toEqual(200)
       expect($('.addresses-not-provided').text().trim()).toStrictEqual('Not provided')
+      expect($('[data-qa=add-new-addresses-link]').first().attr('href')).toStrictEqual(
+        `/prisoner/${prisonerNumber}/contacts/manage/1/address/add/start?returnUrl=/prisoner/${prisonerNumber}/contacts/manage/1/relationship/99/view-addresses`,
+      )
     })
 
     it('should not show comments when theres no comments', async () => {

--- a/server/views/pages/contacts/common/addresses.njk
+++ b/server/views/pages/contacts/common/addresses.njk
@@ -22,7 +22,7 @@
                 area: addressItem.area,
                 city: addressItem.cityDescription,
                 county: addressItem.countyDescription,
-                postalCode: addressItem.postCode,
+                postalCode: addressItem.postcode,
                 country: addressItem.countryDescription
             }
         %}

--- a/server/views/pages/contacts/common/notProvided.njk
+++ b/server/views/pages/contacts/common/notProvided.njk
@@ -5,6 +5,9 @@
         card: {
             title: {
                 text: param.title
+            },
+            actions: {
+                items: param.actions
             }
         },
         rows: [{

--- a/server/views/pages/contacts/manage/address/addressMetadata.njk
+++ b/server/views/pages/contacts/manage/address/addressMetadata.njk
@@ -124,7 +124,7 @@
                     name: "mailAddress",
                     fieldset: {
                         legend: {
-                            text: "Is this the contact's primary address?"
+                            text: "Is this the contact's mail address?"
                         }
                     },
                     items: [

--- a/server/views/pages/contacts/manage/contactConfirmation/addresses.njk
+++ b/server/views/pages/contacts/manage/contactConfirmation/addresses.njk
@@ -20,7 +20,7 @@
                 area: mostRelevantAddress.area,
                 city: mostRelevantAddress.cityDescription,
                 county: mostRelevantAddress.countyDescription,
-                postalCode: mostRelevantAddress.postCode,
+                postalCode: mostRelevantAddress.postcode,
                 country: mostRelevantAddress.countryDescription
             }
         %}
@@ -70,7 +70,7 @@
                         text: "Type"
                     },
                     value: {
-                        text: mostRelevantAddress.addressType | capitalizeFirstLetter,
+                        text: mostRelevantAddress.addressTypeDescription or 'Address',
                         classes: 'confirm-type-value'
                     }
                 }
@@ -132,14 +132,6 @@
     card: {
         title: {
             text: "Addresses"
-        },
-        actions: {
-            items: [
-              {
-                href: "#",
-                text: "View all addresses"
-              }
-            ]
         }
     },
     rows: mostRelevantAddressRow

--- a/server/views/pages/contacts/manage/contactDetails/details.njk
+++ b/server/views/pages/contacts/manage/contactDetails/details.njk
@@ -31,7 +31,19 @@
                 ]
             )}}
         {% else %}
-            {{ notProvided({title: 'Addresses', key: 'Address', className: 'addresses-not-provided' }) }}
+            {{ notProvided({
+                title: 'Addresses',
+                key: 'Address',
+                className: 'addresses-not-provided',
+                actions: [
+                    {
+                        href: "/prisoner/" + prisonerNumber + "/contacts/manage/" + contactId + "/address/add/start?returnUrl=" + manageContactRelationshipUrl + '/view-addresses' ,
+                        text: 'Add address',
+                        attributes: { 'data-qa': 'add-new-addresses-link' },
+                        classes: 'govuk-link--no-visited-state'
+                    }
+                ]
+            }) }}
         {% endif %}
         {%- include "./managePhoneNumbers.njk" -%}
         {%- include "./manageEmailAddresses.njk" -%}
@@ -70,7 +82,7 @@
                 </div>
                 <div class="govuk-tabs__panel govuk-!-static-padding-top-7 govuk-tabs__panel--hidden" data-qa="restrictions-result-message" id="restrictions">
 
-                    {% set heading = 'Prisoner-contact restrictions between prisoner ' + (prisonerDetails | formatNameFirstNameFirst(excludeMiddleNames = true))  + ' and contact ' + ((contact.firstName + " " + contact.lastName) | capitaliseName ) %}
+                    {% set heading = 'Prisoner-contact restrictions between prisoner ' + (prisonerDetails | formatNameFirstNameFirst(excludeMiddleNames = true))  + ' and contact ' + (contact | formatNameFirstNameFirst(excludeMiddleNames = true)) %}
                     <h1 class="govuk-heading-l" data-qa="manage-restriction-title">Restrictions</h1>
                     <h2 class="govuk-heading-m" data-qa="confirm-prisoner-contact-restriction-title">{{ heading }}</h2>
                     {% if prisonerContactRestrictions.length >0 %}


### PR DESCRIPTION
Could not link a contact if they had an address with no address type.

Mail address question had wrong label.

Postcode was missing in several places addresses are rendered.

There was no way to add an address on a new contact as you only get the link to view all addresses if you have an address.  PRC-163 defined an add address link so adding it here.