### PR TITLE
PRC-74: Navigation fixes for restrictions

### DIFF
--- a/integration_tests/e2e/createContactGlobalRestriction.cy.ts
+++ b/integration_tests/e2e/createContactGlobalRestriction.cy.ts
@@ -4,6 +4,7 @@ import { StubContactRestrictionDetails } from '../mockApis/contactsApi'
 import EnterRestrictionPage from '../pages/enterRestrictionPage'
 import CreateRestrictionCheckYourAnswersPage from '../pages/createRestrictionCheckYourAnswersPage'
 import CreateRestrictionSuccessPage from '../pages/createRestrictionSuccessPage'
+import ManageContactDetailsPage from '../pages/manageContactDetails'
 
 context('Create Contact Global Restriction', () => {
   const contactId = 654321
@@ -29,13 +30,21 @@ context('Create Contact Global Restriction', () => {
       id: prisonerContactId,
       response: TestData.prisonerContactRelationship(),
     })
+    cy.task('stubGetPrisonerContactRestrictions', {
+      prisonerContactId,
+      response: {
+        prisonerContactRestrictions: [],
+        contactGlobalRestrictions: [],
+      },
+    })
 
     cy.signIn()
 
-    // TODO visit here from the prisoner contact page instead of directly
-    cy.visit(
-      `/prisoner/${prisonerNumber}/contacts/${contactId}/relationship/${prisonerContactId}/restriction/add/CONTACT_GLOBAL/start?returnUrl=foo`,
-    )
+    cy.visit(`/prisoner/${prisonerNumber}/contacts/manage/${contactId}/relationship/${prisonerContactId}`)
+    Page.verifyOnPage(ManageContactDetailsPage, 'First Middle Names Last') //
+      .clickRestrictionsTab('0')
+      .verifyOnRestrictionsTab()
+      .clickAddGlobalRestriction()
   })
 
   it('Can create a new global restriction for a contact with minimal fields', () => {
@@ -204,5 +213,11 @@ context('Create Contact Global Restriction', () => {
       expect($lis[2]).to.contain('Expiry date must be a real date')
       expect($lis[3]).to.contain('Comment must be 240 characters or less')
     })
+  })
+
+  it('Back link goes to manage contacts restrictions tab', () => {
+    Page.verifyOnPage(EnterRestrictionPage, enterPageTitle) //
+      .backTo(ManageContactDetailsPage, 'First Middle Names Last')
+      .verifyOnRestrictionsTab()
   })
 })

--- a/integration_tests/e2e/createPrisonerContactRestriction.cy.ts
+++ b/integration_tests/e2e/createPrisonerContactRestriction.cy.ts
@@ -4,6 +4,7 @@ import { StubPrisonerContactRestrictionDetails } from '../mockApis/contactsApi'
 import EnterRestrictionPage from '../pages/enterRestrictionPage'
 import CreateRestrictionCheckYourAnswersPage from '../pages/createRestrictionCheckYourAnswersPage'
 import CreateRestrictionSuccessPage from '../pages/createRestrictionSuccessPage'
+import ManageContactDetailsPage from '../pages/manageContactDetails'
 
 context('Create Prisoner Contact Restriction', () => {
   const contactId = 654321
@@ -30,13 +31,21 @@ context('Create Prisoner Contact Restriction', () => {
       id: prisonerContactId,
       response: TestData.prisonerContactRelationship(),
     })
+    cy.task('stubGetPrisonerContactRestrictions', {
+      prisonerContactId,
+      response: {
+        prisonerContactRestrictions: [],
+        contactGlobalRestrictions: [],
+      },
+    })
 
     cy.signIn()
 
-    // TODO visit here from the prisoner contact page instead of directly
-    cy.visit(
-      `/prisoner/${prisonerNumber}/contacts/${contactId}/relationship/${prisonerContactId}/restriction/add/PRISONER_CONTACT/start?returnUrl=foo`,
-    )
+    cy.visit(`/prisoner/${prisonerNumber}/contacts/manage/${contactId}/relationship/${prisonerContactId}`)
+    Page.verifyOnPage(ManageContactDetailsPage, 'First Middle Names Last') //
+      .clickRestrictionsTab('0')
+      .verifyOnRestrictionsTab()
+      .clickAddPrisonerContactRestriction()
   })
 
   it('Can create a new prisoner contact restriction for a contact with minimal fields', () => {
@@ -205,5 +214,11 @@ context('Create Prisoner Contact Restriction', () => {
       expect($lis[2]).to.contain('Expiry date must be a real date')
       expect($lis[3]).to.contain('Comment must be 255 characters or less')
     })
+  })
+
+  it('Back link goes to manage contacts restrictions tab', () => {
+    Page.verifyOnPage(EnterRestrictionPage, enterPageTitle) //
+      .backTo(ManageContactDetailsPage, 'First Middle Names Last')
+      .verifyOnRestrictionsTab()
   })
 })

--- a/integration_tests/e2e/updateContactGlobalRestriction.cy.ts
+++ b/integration_tests/e2e/updateContactGlobalRestriction.cy.ts
@@ -43,16 +43,17 @@ context('Update Contact Global Restriction', () => {
       prisonerContactId,
       response: {
         prisonerContactRestrictions: [],
-        contactGlobalRestrictions: [],
+        contactGlobalRestrictions: [globalRestriction],
       },
     })
 
     cy.signIn()
 
-    // TODO visit here from the prisoner contact page instead of directly
-    cy.visit(
-      `/prisoner/${prisonerNumber}/contacts/${contactId}/relationship/${prisonerContactId}/restriction/update/CONTACT_GLOBAL/enter-restriction/${restrictionId}?returnUrl=/prisoner/${prisonerNumber}/contacts/manage/${contactId}/relationship/${prisonerContactId}`,
-    )
+    cy.visit(`/prisoner/${prisonerNumber}/contacts/manage/${contactId}/relationship/${prisonerContactId}`)
+    Page.verifyOnPage(ManageContactDetailsPage, 'First Middle Names Last') //
+      .clickRestrictionsTab('1')
+      .verifyOnRestrictionsTab()
+      .clickManageGlobalRestriction(globalRestriction.contactRestrictionId)
   })
 
   it('Can update a global restriction for a contact with minimal fields', () => {
@@ -139,5 +140,17 @@ context('Update Contact Global Restriction', () => {
 
     enterRestrictionPage.hasFieldInError('type', 'Select the restriction type')
     enterRestrictionPage.hasFieldInError('startDate', 'Enter the start date')
+  })
+
+  it('Back link goes to manage contacts restrictions tab', () => {
+    Page.verifyOnPage(EnterRestrictionPage, enterPageTitle) //
+      .backTo(ManageContactDetailsPage, 'First Middle Names Last')
+      .verifyOnRestrictionsTab()
+  })
+
+  it('Cancel goes to manage contacts restrictions tab', () => {
+    Page.verifyOnPage(EnterRestrictionPage, enterPageTitle) //
+      .cancelTo(ManageContactDetailsPage, 'First Middle Names Last')
+      .verifyOnRestrictionsTab()
   })
 })

--- a/integration_tests/e2e/updatePrisonerContactRestriction.cy.ts
+++ b/integration_tests/e2e/updatePrisonerContactRestriction.cy.ts
@@ -47,10 +47,11 @@ context('Update Prisoner Contact Restriction', () => {
     })
     cy.signIn()
 
-    // TODO visit here from the prisoner contact page instead of directly
-    cy.visit(
-      `/prisoner/${prisonerNumber}/contacts/${contactId}/relationship/${prisonerContactId}/restriction/update/PRISONER_CONTACT/enter-restriction/${restrictionId}?returnUrl=/prisoner/${prisonerNumber}/contacts/manage/${contactId}/relationship/${prisonerContactId}`,
-    )
+    cy.visit(`/prisoner/${prisonerNumber}/contacts/manage/${contactId}/relationship/${prisonerContactId}`)
+    Page.verifyOnPage(ManageContactDetailsPage, 'First Middle Names Last') //
+      .clickRestrictionsTab('1')
+      .verifyOnRestrictionsTab()
+      .clickManagePrisonerContactRestriction(prisonerContactRestriction.prisonerContactRestrictionId)
   })
 
   it('Can update a prisoner contact restriction with minimal fields', () => {
@@ -138,5 +139,17 @@ context('Update Prisoner Contact Restriction', () => {
 
     enterRestrictionPage.hasFieldInError('type', 'Select the restriction type')
     enterRestrictionPage.hasFieldInError('startDate', 'Enter the start date')
+  })
+
+  it('Back link goes to manage contacts restrictions tab', () => {
+    Page.verifyOnPage(EnterRestrictionPage, enterPageTitle) //
+      .backTo(ManageContactDetailsPage, 'First Middle Names Last')
+      .verifyOnRestrictionsTab()
+  })
+
+  it('Cancel goes to manage contacts restrictions tab', () => {
+    Page.verifyOnPage(EnterRestrictionPage, enterPageTitle) //
+      .cancelTo(ManageContactDetailsPage, 'First Middle Names Last')
+      .verifyOnRestrictionsTab()
   })
 })

--- a/integration_tests/pages/manageContactDetails.ts
+++ b/integration_tests/pages/manageContactDetails.ts
@@ -170,13 +170,13 @@ export default class ManageContactDetailsPage extends Page {
     return this
   }
 
-  clickManageGlobalRestriction() {
-    this.getManageGlobalRestriction().should('contain.text', `Manage`).click()
+  clickManageGlobalRestriction(id: number = 1) {
+    this.getManageGlobalRestriction(id).should('contain.text', `Manage`).click()
     return this
   }
 
-  clickManagePrisonerContactRestriction() {
-    this.getManagePrisonerContactRestriction().should('contain.text', `Manage`).click()
+  clickManagePrisonerContactRestriction(id: number = 1) {
+    this.getManagePrisonerContactRestriction(id).should('contain.text', `Manage`).click()
     return this
   }
 
@@ -247,10 +247,11 @@ export default class ManageContactDetailsPage extends Page {
 
   private getAddGlobalRestriction = (): PageElement => cy.get('[data-qa="add-global-restriction-button"]')
 
-  private getManageGlobalRestriction = (): PageElement => cy.get('[data-qa="manage-CONTACT_GLOBAL-restriction-link-1"]')
+  private getManageGlobalRestriction = (id: number): PageElement =>
+    cy.get(`[data-qa="manage-CONTACT_GLOBAL-restriction-link-${id}"]`)
 
-  private getManagePrisonerContactRestriction = (): PageElement =>
-    cy.get('[data-qa="manage-PRISONER_CONTACT-restriction-link-1"]')
+  private getManagePrisonerContactRestriction = (id: number): PageElement =>
+    cy.get(`[data-qa="manage-PRISONER_CONTACT-restriction-link-${id}"]`)
 
   private getRestrictionCard = (): PageElement =>
     cy.get(
@@ -339,6 +340,31 @@ export default class ManageContactDetailsPage extends Page {
     this.deleteIdentityLink(id).click()
   }
 
+  verifyShowIsEmergencyContactAs(expected: string) {
+    this.checkAnswersEmergencyContactValue().should('contain.text', expected)
+  }
+
+  verifyShowIsNextOfKinContactAs(expected: string) {
+    this.checkAnswersNextOfKinValue().should('contain.text', expected)
+  }
+
+  verifyShowIsApprovedVisitorAs(expected: string) {
+    this.checkApprovedVisitorValue().should('contain.text', expected)
+  }
+
+  verifyShowIsRelationshipActiveAs(expected: string) {
+    this.checkRelationshipStatusValue().should('contain.text', expected)
+  }
+
+  verifyShowIsRelationshipCommentsAs(expected: string) {
+    this.checkAnswersRelationshipCommentsValue().should('contain.text', expected)
+  }
+
+  verifyOnRestrictionsTab(): ManageContactDetailsPage {
+    this.restrictionsTabHeading().should('be.visible')
+    return this
+  }
+
   private addIdentityLink = (): PageElement => cy.get('[data-qa="add-identity-number"]')
 
   private editIdentityLink = (id: number): PageElement => cy.get(`[data-qa="edit-identity-number-${id}"]`)
@@ -355,23 +381,7 @@ export default class ManageContactDetailsPage extends Page {
 
   private confirmAddressValue = (): PageElement => cy.get(`.confirm-address-value`)
 
-  verifyShowIsEmergencyContactAs(expected: string) {
-    this.checkAnswersEmergencyContactValue().should('contain.text', expected)
-  }
-
   private checkAnswersEmergencyContactValue = (): PageElement => cy.get('.emergency-contact-value')
-
-  verifyShowIsNextOfKinContactAs(expected: string) {
-    this.checkAnswersNextOfKinValue().should('contain.text', expected)
-  }
-
-  verifyShowIsApprovedVisitorAs(expected: string) {
-    this.checkApprovedVisitorValue().should('contain.text', expected)
-  }
-
-  verifyShowIsRelationshipActiveAs(expected: string) {
-    this.checkRelationshipStatusValue().should('contain.text', expected)
-  }
 
   private checkAnswersNextOfKinValue = (): PageElement => cy.get('.next-of-kin-value')
 
@@ -379,9 +389,7 @@ export default class ManageContactDetailsPage extends Page {
 
   private checkRelationshipStatusValue = (): PageElement => cy.get('.relationship-active-value')
 
-  verifyShowIsRelationshipCommentsAs(expected: string) {
-    this.checkAnswersRelationshipCommentsValue().should('contain.text', expected)
-  }
-
   private checkAnswersRelationshipCommentsValue = (): PageElement => cy.get('.relationship-comments-value')
+
+  private restrictionsTabHeading = (): PageElement => cy.get('[data-qa="manage-restriction-title"]')
 }

--- a/server/routes/contacts/manage/contact-details/contactDetailsController.test.ts
+++ b/server/routes/contacts/manage/contact-details/contactDetailsController.test.ts
@@ -778,11 +778,11 @@ describe('GET /contacts/manage/:contactId/relationship/:prisonerContactId', () =
       const $ = cheerio.load(response.text)
 
       expect($('[data-qa=add-global-restriction-button]').first().attr('href')).toStrictEqual(
-        '/prisoner/A1234BC/contacts/1/relationship/99/restriction/add/CONTACT_GLOBAL/start',
+        '/prisoner/A1234BC/contacts/1/relationship/99/restriction/add/CONTACT_GLOBAL/start?returnUrl=/prisoner/A1234BC/contacts/manage/1/relationship/99%23restrictions',
       )
 
       expect($('[data-qa=add-prisoner-contact-restriction-button]').first().attr('href')).toStrictEqual(
-        '/prisoner/A1234BC/contacts/1/relationship/99/restriction/add/PRISONER_CONTACT/start',
+        '/prisoner/A1234BC/contacts/1/relationship/99/restriction/add/PRISONER_CONTACT/start?returnUrl=/prisoner/A1234BC/contacts/manage/1/relationship/99%23restrictions',
       )
     })
 
@@ -802,17 +802,17 @@ describe('GET /contacts/manage/:contactId/relationship/:prisonerContactId', () =
       })
 
       // When
-      const response = await request(app).get(`/prisoner/${prisonerNumber}/contacts/manage/1/relationship/99`)
+      const response = await request(app).get(`/prisoner/${prisonerNumber}/contacts/manage/22/relationship/99`)
 
       // Then
       const $ = cheerio.load(response.text)
 
       expect($('[data-qa=manage-CONTACT_GLOBAL-restriction-link-1]').first().attr('href')).toStrictEqual(
-        '/prisoner/A1234BC/contacts/22/relationship/99/restriction/update/CONTACT_GLOBAL/enter-restriction/1?returnUrl=/prisoner/A1234BC/contacts/manage/22/relationship/99',
+        '/prisoner/A1234BC/contacts/22/relationship/99/restriction/update/CONTACT_GLOBAL/enter-restriction/1?returnUrl=/prisoner/A1234BC/contacts/manage/22/relationship/99%23restrictions',
       )
 
       expect($('[data-qa=manage-PRISONER_CONTACT-restriction-link-2]').first().attr('href')).toStrictEqual(
-        '/prisoner/A1234BC/contacts/22/relationship/99/restriction/update/PRISONER_CONTACT/enter-restriction/2?returnUrl=/prisoner/A1234BC/contacts/manage/22/relationship/99',
+        '/prisoner/A1234BC/contacts/22/relationship/99/restriction/update/PRISONER_CONTACT/enter-restriction/2?returnUrl=/prisoner/A1234BC/contacts/manage/22/relationship/99%23restrictions',
       )
     })
   })

--- a/server/routes/restrictions/update-restriction/updateRestrictionController.test.ts
+++ b/server/routes/restrictions/update-restriction/updateRestrictionController.test.ts
@@ -107,7 +107,7 @@ describe('GET /prisoner/:prisonerNumber/contacts/:contactId/relationship/:prison
     expect($('[data-qa=back-link]').first().attr('href')).toStrictEqual('/foo-bar')
     expect($('[data-qa=prisoner-name-and-id]').first().text().trim()).toStrictEqual('John Smith (A1234BC)')
     expect($('[data-qa=contact-name-and-id]').first().text().trim()).toStrictEqual('First Middle Last (123)')
-    expect($('[data-qa=cancel-button]')).toHaveLength(0)
+    expect($('[data-qa=cancel-button]').first().attr('href')).toStrictEqual('/foo-bar')
     expect($('[data-qa=breadcrumbs]')).toHaveLength(0)
 
     expect($('#type').val()).toStrictEqual('BAN')
@@ -135,7 +135,7 @@ describe('GET /prisoner/:prisonerNumber/contacts/:contactId/relationship/:prison
     expect($('[data-qa=back-link]').first().attr('href')).toStrictEqual('/foo-bar')
     expect($('[data-qa=prisoner-name-and-id]')).toHaveLength(0)
     expect($('[data-qa=contact-name-and-id]')).toHaveLength(0)
-    expect($('[data-qa=cancel-button]')).toHaveLength(0)
+    expect($('[data-qa=cancel-button]').first().attr('href')).toStrictEqual('/foo-bar')
     expect($('[data-qa=breadcrumbs]')).toHaveLength(0)
 
     expect($('#type').val()).toStrictEqual('BAN')

--- a/server/routes/restrictions/update-restriction/updateRestrictionController.ts
+++ b/server/routes/restrictions/update-restriction/updateRestrictionController.ts
@@ -74,6 +74,7 @@ export default class UpdateRestrictionController implements PageHandler {
 
     const navigation: Navigation = {
       backLink: journey.returnPoint.url,
+      cancelButton: journey.returnPoint.url,
     }
 
     const viewModel = {

--- a/server/views/pages/contacts/manage/contactDetails/details.njk
+++ b/server/views/pages/contacts/manage/contactDetails/details.njk
@@ -88,16 +88,17 @@
                 <div class="govuk-tabs__panel govuk-!-static-padding-top-7 govuk-tabs__panel--hidden" data-qa="restrictions-result-message" id="restrictions">
 
                     {% set heading = 'Prisoner-contact restrictions between prisoner ' + (prisonerDetails | formatNameFirstNameFirst(excludeMiddleNames = true))  + ' and contact ' + (contact | formatNameFirstNameFirst(excludeMiddleNames = true)) %}
+                    {% set restrictionsTabUrl  = manageContactRelationshipUrl + "#restrictions" | urlencode  %}
                     <h1 class="govuk-heading-l" data-qa="manage-restriction-title">Restrictions</h1>
                     <h2 class="govuk-heading-m" data-qa="confirm-prisoner-contact-restriction-title">{{ heading }}</h2>
                     {% if prisonerContactRestrictions.length >0 %}
-                        {{ restrictionCard(prisonerContactRestrictions, contact, prisonerNumber, prisonerContactId, 'PRISONER_CONTACT' ) }}
+                        {{ restrictionCard(prisonerContactRestrictions, contact, prisonerNumber, prisonerContactId, 'PRISONER_CONTACT', restrictionsTabUrl ) }}
                     {% else %}
                         <p class="govuk-body no_prisoner_contact_restriction_card__description">No prisoner-contact restrictions recorded.</p>
                     {% endif %}
                     {{ govukButton({
                         text: "Add prisoner-contact restriction",
-                        href: "/prisoner/" + prisonerNumber + "/contacts/" + contactId + "/relationship/" + prisonerContactId+ "/restriction/add/PRISONER_CONTACT/start",
+                        href: "/prisoner/" + prisonerNumber + "/contacts/" + contactId + "/relationship/" + prisonerContactId+ "/restriction/add/PRISONER_CONTACT/start?returnUrl=" + restrictionsTabUrl,
                         classes: 'govuk-!-margin-top-6 govuk-button--secondary',
                         attributes: {"data-qa": "add-prisoner-contact-restriction-button"},
                         preventDoubleClick: true
@@ -107,14 +108,14 @@
                     {% set heading = 'Global restrictions for contact ' + ((contact.firstName + " " + contact.lastName) | capitaliseName ) %}
                     <h2 class="govuk-heading-m" data-qa="confirm-global-restriction-title">{{ heading }}</h1>
                     {% if globalRestrictions.length >0 %}
-                        {{ restrictionCard(globalRestrictions, contact, prisonerNumber, prisonerContactId, 'CONTACT_GLOBAL' ) }}
+                        {{ restrictionCard(globalRestrictions, contact, prisonerNumber, prisonerContactId, 'CONTACT_GLOBAL', restrictionsTabUrl ) }}
                     {% else %}
 
                         <p class="govuk-body no_global_restrictions_card__description">No global restrictions recorded.</p>
                     {% endif %}
                       {{ govukButton({
                             text: "Add global restriction",
-                            href: "/prisoner/" + prisonerNumber + "/contacts/" + contactId + "/relationship/" + prisonerContactId+ "/restriction/add/CONTACT_GLOBAL/start",
+                            href: "/prisoner/" + prisonerNumber + "/contacts/" + contactId + "/relationship/" + prisonerContactId+ "/restriction/add/CONTACT_GLOBAL/start?returnUrl=" + restrictionsTabUrl,
                             classes: 'govuk-!-margin-top-6 govuk-button--secondary',
                             attributes: {"data-qa": "add-global-restriction-button"},
                             preventDoubleClick: true

--- a/server/views/pages/contacts/restrictions/manageRestrictions.njk
+++ b/server/views/pages/contacts/restrictions/manageRestrictions.njk
@@ -1,6 +1,6 @@
 {% from "govuk/components/summary-list/macro.njk" import govukSummaryList %}
 
-{% macro restrictionCard(restrictions, contact, prisonerNumber, prisonerContactId, restrictionClass ) %}
+{% macro restrictionCard(restrictions, contact, prisonerNumber, prisonerContactId, restrictionClass, returnUrl ) %}
 
     {% for restriction in restrictions %}
 
@@ -13,7 +13,7 @@
                     actions: {
                         items: [
                             {
-                                href: "/prisoner/" +  prisonerNumber + "/contacts/" +  contact.id + "/relationship/" +  prisonerContactId + "/restriction/update/" +  restrictionClass + "/enter-restriction/" +  restrictionId + "?returnUrl=/prisoner/" +  prisonerNumber + "/contacts/manage/" +  contact.id + "/relationship/" +  prisonerContactId ,
+                                href: "/prisoner/" +  prisonerNumber + "/contacts/" +  contact.id + "/relationship/" +  prisonerContactId + "/restriction/update/" +  restrictionClass + "/enter-restriction/" +  restrictionId + "?returnUrl=" + returnUrl,
                                 text: "Manage",
                                 visuallyHiddenText: "restrictions",
                                 attributes: {"data-qa": "manage-"+ restrictionClass +"-restriction-link-" + restrictionId},


### PR DESCRIPTION
Some returnUrl where missing on the new restrictions tab. Updated the tests to navigate via the restrictions tab rather than directly.

Added missing cancel button on update restriction.