### PR TITLE
PRC-321: Use town, county, country codes for use prisoner address

### DIFF
--- a/integration_tests/e2e/addAddress.cy.ts
+++ b/integration_tests/e2e/addAddress.cy.ts
@@ -212,10 +212,13 @@ context('Add Address', () => {
       premise: 'Prisoner Premises',
       street: 'Prisoner Street',
       locality: 'Prisoner Locality',
-      town: '7521',
-      county: 'W.SUSSEX',
+      town: 'Ilfracombe',
+      townCode: '7521',
+      county: 'West Sussex',
+      countyCode: 'W.SUSSEX',
       postalCode: 'PPCODE',
-      country: 'WALES',
+      country: 'Wales',
+      countryCode: 'WALES',
     }
     cy.task('stubOffenderAddresses', { prisonerNumber, addresses: [prisonerAddress] })
 

--- a/server/@types/prison-api.d.ts
+++ b/server/@types/prison-api.d.ts
@@ -2803,6 +2803,26 @@ export interface paths {
     patch?: never
     trace?: never
   }
+  '/api/reference-domains/domains/{domain}/all-codes': {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    /**
+     * List of reference codes for reference domain.
+     * @description List of reference codes / profile codes for reference domain / profile type, ordered by code ascending. The list is an un-paged flat list<p>This endpoint uses the REPLICA database.</p>
+     */
+    get: operations['getReferenceOrProfileCodesByDomain']
+    put?: never
+    post?: never
+    delete?: never
+    options?: never
+    head?: never
+    patch?: never
+    trace?: never
+  }
   '/api/reference-domains/alertTypes': {
     parameters: {
       query?: never
@@ -5840,25 +5860,40 @@ export interface components {
        */
       locality?: string
       /**
-       * @description Town/City. Note: Reference domain is CITY
+       * @description Town/City description. Note: Reference domain is CITY
        * @example Liverpool
        */
       town?: string
+      /**
+       * @description Town/City code. Note: Reference domain is CITY
+       * @example 17743
+       */
+      townCode?: string
       /**
        * @description Postal Code
        * @example LI1 5TH
        */
       postalCode?: string
       /**
-       * @description County. Note: Reference domain is COUNTY
-       * @example HEREFORD
+       * @description County description. Note: Reference domain is COUNTY
+       * @example Herefordshire
        */
       county?: string
       /**
-       * @description Country. Note: Reference domain is COUNTRY
-       * @example ENG
+       * @description County code. Note: Reference domain is COUNTY
+       * @example HEREFORD
+       */
+      countyCode?: string
+      /**
+       * @description Country description. Note: Reference domain is COUNTRY
+       * @example England
        */
       country?: string
+      /**
+       * @description Country code. Note: Reference domain is COUNTRY
+       * @example ENG
+       */
+      countryCode?: string
       /**
        * @description Comment
        * @example This is a comment text
@@ -23427,6 +23462,56 @@ export interface operations {
       header?: never
       path: {
         /** @description The domain identifier/name. */
+        domain: string
+      }
+      cookie?: never
+    }
+    requestBody?: never
+    responses: {
+      /** @description OK */
+      200: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['ReferenceCode'][]
+        }
+      }
+      /** @description Invalid request. */
+      400: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['ErrorResponse']
+        }
+      }
+      /** @description Requested resource not found. */
+      404: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['ErrorResponse']
+        }
+      }
+      /** @description Unrecoverable error occurred whilst processing request. */
+      500: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['ErrorResponse']
+        }
+      }
+    }
+  }
+  getReferenceOrProfileCodesByDomain: {
+    parameters: {
+      query?: never
+      header?: never
+      path: {
+        /** @description The domain or profile type identifier/name. */
         domain: string
       }
       cookie?: never

--- a/server/routes/contacts/manage/addresses/use-prisoner-address/usePrisonerAddressController.test.ts
+++ b/server/routes/contacts/manage/addresses/use-prisoner-address/usePrisonerAddressController.test.ts
@@ -106,10 +106,13 @@ describe('GET /prisoner/:prisonerNumber/contacts/manage/:contactId/address/use-p
       premise: 'Prisoner Premises',
       street: 'Prisoner Street',
       locality: 'Prisoner Locality',
-      town: '9999',
-      county: 'CORNWALL',
+      town: 'Falmouth',
+      townCode: '9999',
+      county: 'Cornwall',
+      countyCode: 'CORNWALL',
       postalCode: 'Prisoner Postcode',
-      country: 'WALES',
+      country: 'Wales',
+      countryCode: 'WALES',
     }
     prisonerAddressService.getPrimaryAddress.mockResolvedValue(prisonerAddress)
 

--- a/server/routes/contacts/manage/addresses/use-prisoner-address/usePrisonerAddressController.ts
+++ b/server/routes/contacts/manage/addresses/use-prisoner-address/usePrisonerAddressController.ts
@@ -23,10 +23,10 @@ export default class UsePrisonerAddressController implements PageHandler {
           premises: primaryAddress.premise,
           street: primaryAddress.street,
           locality: primaryAddress.locality,
-          town: primaryAddress.town,
-          county: primaryAddress.county,
+          town: primaryAddress.townCode,
+          county: primaryAddress.countyCode,
           postcode: primaryAddress.postalCode,
-          country: primaryAddress.country,
+          country: primaryAddress.countryCode,
         }
       }
     })

--- a/server/services/prisonerAddressService.test.ts
+++ b/server/services/prisonerAddressService.test.ts
@@ -90,10 +90,13 @@ describe('Prisoner address service', () => {
         premise: 'Prisoner Premises 2',
         street: 'Prisoner Street 2',
         locality: 'Prisoner Locality 2',
-        town: '9999',
-        county: 'CORNWALL',
+        town: 'Falmouth',
+        townCode: '9999',
+        county: 'Cornwall',
+        countyCode: 'CORNWALL',
         postalCode: 'Prisoner Postcode',
-        country: 'WALES',
+        country: 'Wales',
+        countryCode: 'WALES',
       }
       prisonApiClient.getOffenderAddresses.mockResolvedValue([primaryPrisonerAddress, nonPrimaryAddress])
       const primaryAddress = await prisonerAddressService.getPrimaryAddress('ABC123', user)


### PR DESCRIPTION
Now prison API returns the codes so this updates the Prison API types and uses the codes for "use prisoner address" button.