### PR TITLE
PRC-165: Fix expired address label

### DIFF
--- a/server/routes/contacts/manage/addresses/manageAddressesController.test.ts
+++ b/server/routes/contacts/manage/addresses/manageAddressesController.test.ts
@@ -315,7 +315,7 @@ describe('Addresses', () => {
     const $ = cheerio.load(response.text)
     expect(response.status).toEqual(200)
     expect($('[data-qa="main-heading"]').text().trim()).toStrictEqual('Addresses for Jones Mason')
-    expect($('.govuk-summary-card__title').text().trim()).toContain('Expired home address')
+    expect($('.govuk-summary-card__title').text().trim()).toContain('Home address (expired)')
   })
 
   it('should show expired next to address card title if no address type', async () => {
@@ -338,6 +338,6 @@ describe('Addresses', () => {
     const $ = cheerio.load(response.text)
     expect(response.status).toEqual(200)
     expect($('[data-qa="main-heading"]').text().trim()).toStrictEqual('Addresses for Jones Mason')
-    expect($('.govuk-summary-card__title').text().trim()).toContain('Expired address')
+    expect($('.govuk-summary-card__title').text().trim()).toContain('Address (expired)')
   })
 })

--- a/server/routes/contacts/manage/addresses/manageAddressesController.ts
+++ b/server/routes/contacts/manage/addresses/manageAddressesController.ts
@@ -61,7 +61,7 @@ export default class ManageAddressesController implements PageHandler {
   }
 
   private getExpiredAddressTitle(endDate: string, addressTypeDescription: string): string {
-    return this.isExpired(endDate) ? `Expired ${addressTypeDescription?.toLowerCase()}` : addressTypeDescription
+    return this.isExpired(endDate) ? `${addressTypeDescription} (expired)` : addressTypeDescription
   }
 
   private isExpired(endDate: string): boolean {


### PR DESCRIPTION
Should be "[Home|Business|Work] address (expired)" or "Address (expired)".