### PR TITLE
PRC-341: Prisoner image default location (esbuild has changed this)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -52,7 +52,6 @@ jobs:
             - node_modules
             - build
             - dist
-            - assets
 
   unit_test:
     executor:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -61,6 +61,8 @@ jobs:
       - checkout
       - restore_cache:
           key: dependency-cache-{{ checksum "package-lock.json" }}
+      - attach_workspace:
+          at: ~/app
       - run:
           name: unit tests
           command: npm run test:ci

--- a/server/routes/prisonerImage/prisonerImageRoutes.ts
+++ b/server/routes/prisonerImage/prisonerImageRoutes.ts
@@ -2,7 +2,7 @@ import { Request, Response } from 'express'
 import path from 'path'
 import PrisonerImageService from '../../services/prisonerImageService'
 
-const placeHolderImage = path.join(process.cwd(), 'dist/assets/images/prisoner-profile-image.png')
+const placeHolderImage = path.join(process.cwd(), '/dist/assets/images/prisoner-profile-image.png')
 
 export default class PrisonerImageRoutes {
   constructor(private readonly prisonerImageService: PrisonerImageService) {}

--- a/server/routes/prisonerImage/prisonerImageRoutes.ts
+++ b/server/routes/prisonerImage/prisonerImageRoutes.ts
@@ -2,7 +2,7 @@ import { Request, Response } from 'express'
 import path from 'path'
 import PrisonerImageService from '../../services/prisonerImageService'
 
-const placeHolderImage = path.join(process.cwd(), '/assets/images/prisoner-profile-image.png')
+const placeHolderImage = path.join(process.cwd(), 'dist/assets/images/prisoner-profile-image.png')
 
 export default class PrisonerImageRoutes {
   constructor(private readonly prisonerImageService: PrisonerImageService) {}


### PR DESCRIPTION
Turns out we needed additional config in circle to account for the different location of images during the build.
Hopefully this resolves - works in unit tests, int tests, running locally and in circle CI now.
*should* also work in DEV, PRE, PROD etc..