### PR TITLE
PRC-165: Fix age calculation

### DIFF
--- a/server/utils/nunjucksSetup.ts
+++ b/server/utils/nunjucksSetup.ts
@@ -3,7 +3,7 @@ import path from 'path'
 import nunjucks from 'nunjucks'
 import express from 'express'
 import fs from 'fs'
-import { initialiseName, formatDate, getFormatDistanceToNow, capitalizeFirstLetter, capitaliseName } from './utils'
+import { initialiseName, formatDate, ageInYears, capitalizeFirstLetter, capitaliseName } from './utils'
 import config from '../config'
 import logger from '../../logger'
 import { buildErrorSummaryList, findError } from '../middleware/validationMiddleware'
@@ -62,7 +62,7 @@ export default function nunjucksSetup(app: express.Express): void {
   njkEnv.addGlobal('DPS_HOME_PAGE_URL', config.serviceUrls.digitalPrison)
   njkEnv.addFilter('pluralise', (word, count, plural = `${word}s`) => (count === 1 ? word : plural))
   njkEnv.addFilter('addressToLines', addressToLines)
-  njkEnv.addFilter('getFormatDistanceToNow', getFormatDistanceToNow)
+  njkEnv.addFilter('ageInYears', ageInYears)
   njkEnv.addFilter('formatDate', formatDate)
   njkEnv.addFilter('formatYesNo', formatYesNo)
   njkEnv.addFilter('formatNameLastNameFirst', formatNameLastNameFirst)

--- a/server/utils/utils.test.ts
+++ b/server/utils/utils.test.ts
@@ -7,7 +7,7 @@ import {
   formatDateForApi,
   capitalizeFirstLetter,
   capitaliseName,
-  getFormatDistanceToNow,
+  ageInYears,
 } from './utils'
 
 describe('convert to title case', () => {
@@ -123,40 +123,58 @@ describe('capitalizeFirstLetter', () => {
   })
 })
 
-describe('getFormatDistanceToNow', () => {
-  it('should format to years if more than one year', () => {
+describe('ageInYears', () => {
+  it.each([
+    ['1973-01-10', '2025-01-06', '51 years'],
+    ['1982-06-15', '2024-12-25', '42 years'],
+    ['2024-01-01', '2025-01-01', '1 year'],
+    ['2024-01-02', '2025-01-01', '0 years'],
+    ['2024-02-29', '2025-02-28', '0 years'],
+    ['2024-02-29', '2025-03-01', '1 year'],
+  ])(
+    'should calculate years correctly with date input',
+    (dateOfBirth: string, currentDate: string, expected: string) => {
+      // Given
+      const today = new Date(currentDate)
+
+      // When
+      const results = ageInYears(new Date(dateOfBirth), today)
+
+      // Then
+      expect(results).toEqual(expected)
+    },
+  )
+
+  it.each([
+    ['1973-01-10', '2025-01-06', '51 years'],
+    ['1982-06-15', '2024-12-25', '42 years'],
+    ['2024-01-01', '2025-01-01', '1 year'],
+    ['2024-01-02', '2025-01-01', '0 years'],
+    ['2024-02-29', '2025-02-28', '0 years'],
+    ['2024-02-29', '2025-03-01', '1 year'],
+  ])(
+    'should calculate years correctly with string input',
+    (dateOfBirth: string, currentDate: string, expected: string) => {
+      // Given
+      const today = new Date(currentDate)
+
+      // When
+      const results = ageInYears(dateOfBirth, today)
+
+      // Then
+      expect(results).toEqual(expected)
+    },
+  )
+
+  it('should default to today for current date', () => {
     // Given
-    const date = new Date()
-    date.setDate(date.getDate() - 365)
+    const dateOfBirth = new Date()
+    dateOfBirth.setDate(dateOfBirth.getDate() - (365 + 365 + 2))
 
     // When
-    const results = getFormatDistanceToNow(date)
+    const results = ageInYears(dateOfBirth)
 
     // Then
-    expect(results).toEqual('1 year')
-  })
-
-  it('should format to months if less than one year', () => {
-    // Given
-    const date = new Date()
-    date.setMonth(date.getMonth() - 9)
-
-    // When
-    const results = getFormatDistanceToNow(date)
-
-    // Then
-    expect(results).toEqual('9 months')
-  })
-
-  it('should round down years', () => {
-    // Given
-    const date = new Date()
-    date.setDate(date.getDate() - (365 + 365 - 1))
-
-    // When
-    const results = getFormatDistanceToNow(date)
-
-    // Then
-    expect(results).toEqual('1 year')
+    expect(results).toEqual('2 years')
   })
 })

--- a/server/utils/utils.ts
+++ b/server/utils/utils.ts
@@ -1,4 +1,4 @@
-import { format, formatDistanceStrict, isValid, parseISO } from 'date-fns'
+import { format, isValid, parseISO } from 'date-fns'
 import DateOfBirth = journeys.DateOfBirth
 
 const isBlank = (str: string): boolean => !str || /^\s*$/.test(str)
@@ -50,8 +50,17 @@ export const extractPrisonerNumber = (search: string): string | false => {
   return (searchTerms && searchTerms.find(term => isValidPrisonerNumber(term))) || false
 }
 
-export const getFormatDistanceToNow = (date: Date) => {
-  return formatDistanceStrict(date, new Date(), { roundingMethod: 'floor' })
+export const ageInYears = (date: string | Date, now: Date = new Date()) => {
+  const dateOfBirth = new Date(date)
+  let age = now.getFullYear() - dateOfBirth.getFullYear()
+  const monthDiff = now.getMonth() - dateOfBirth.getMonth()
+  if (monthDiff < 0 || (monthDiff === 0 && now.getDate() < dateOfBirth.getDate())) {
+    age -= 1
+  }
+  if (age === 1) {
+    return '1 year'
+  }
+  return `${age} years`
 }
 
 export const formatDateForApi = (dateOfBirth: Partial<DateOfBirth>) => {

--- a/server/views/pages/contacts/manage/listContacts.njk
+++ b/server/views/pages/contacts/manage/listContacts.njk
@@ -50,7 +50,7 @@
             <td class="govuk-table__cell"  data-qa="contact-{{ item.prisonerContactId }}-dob">
                 {% if item.dateOfBirth %}
                     {{ item.dateOfBirth | formatDate }}<br />
-                    ({{ item.dateOfBirth | getFormatDistanceToNow }} old)
+                    ({{ item.dateOfBirth | ageInYears }} old)
                 {% else %}
                     Not provided
                 {% endif %}


### PR DESCRIPTION
Some tests had started failing as date-fns rounds to the nearest year in minutes which doesn't work properly for age due to leap years. Changed to a custom implementation which diffs the years and then takes off one year if it hasn't been their birthday yet this year. If you were born on 29th Feb then your age doesn't tick up until 1st March on non-leap years which is safest for an under-18 check. Renamed function to reflect it's only used for age.