### PR TITLE
PRC-450: Add missing legends

### DIFF
--- a/integration_tests/support/accessibilityViolations.ts
+++ b/integration_tests/support/accessibilityViolations.ts
@@ -28,6 +28,8 @@ export const checkAxeAccessibility = () => {
   } as Spec)
   cy.checkA11y(undefined, undefined, logAccessibilityViolations)
 
+  checkRadioGroupsHaveLegends()
+
   checkStyleRules()
 }
 
@@ -43,6 +45,25 @@ const checkStyleRules = () => {
         fail(`Non-curly apostrophe found in the following text: ${element.text()}`)
       }
     })
+}
+
+const checkRadioGroupsHaveLegends = () => {
+  cy.get('body').then($body => {
+    const expectedRadios = $body.find('.govuk-radios').length
+    const radiosInFieldset = $body.find('.govuk-fieldset > .govuk-radios').length
+    if (expectedRadios > radiosInFieldset) {
+      fail(
+        `Expected ${expectedRadios} radios to be within a fieldset with a legend but only found ${radiosInFieldset} within a fieldset`,
+      )
+    }
+    if (expectedRadios > 0) {
+      cy.get('.govuk-fieldset > .govuk-radios').then($fieldsetRadioGroup => {
+        if ($fieldsetRadioGroup.parent().find('.govuk-fieldset__legend').length === 0) {
+          fail(`Found radio group fieldset without legend`)
+        }
+      })
+    }
+  })
 }
 
 export default {

--- a/server/routes/contacts/add/emergency-contact/emergencyContactController.test.ts
+++ b/server/routes/contacts/add/emergency-contact/emergencyContactController.test.ts
@@ -74,7 +74,7 @@ describe('GET /prisoner/:prisonerNumber/contacts/create/select-emergency-contact
     expect(response.status).toEqual(200)
 
     const $ = cheerio.load(response.text)
-    expect($('[data-qa=main-heading]').first().text().trim()).toStrictEqual(
+    expect($('.main-heading').first().text().trim()).toStrictEqual(
       'Is First Middle Last an emergency contact for the prisoner?',
     )
     expect($('.govuk-caption-l').first().text().trim()).toStrictEqual(expectedCaption)

--- a/server/routes/contacts/add/enter-dob/createContactEnterDobController.test.ts
+++ b/server/routes/contacts/add/enter-dob/createContactEnterDobController.test.ts
@@ -65,9 +65,7 @@ describe('GET /prisoner/:prisonerNumber/contacts/create/enter-dob/:journeyId', (
     expect(response.status).toEqual(200)
 
     const $ = cheerio.load(response.text)
-    expect($('[data-qa=main-heading]').first().text().trim()).toStrictEqual(
-      'Do you know First Middle Last’s date of birth?',
-    )
+    expect($('.main-heading').first().text().trim()).toStrictEqual('Do you know First Middle Last’s date of birth?')
     expect($('.govuk-caption-l').first().text().trim()).toStrictEqual('Add a contact and link to a prisoner')
     expect($('[data-qa=cancel-button]').first().attr('href')).toStrictEqual('/foo-bar')
     expect($('[data-qa=breadcrumbs]')).toHaveLength(0)

--- a/server/routes/contacts/add/next-of-kin/nextOfKinController.test.ts
+++ b/server/routes/contacts/add/next-of-kin/nextOfKinController.test.ts
@@ -75,9 +75,7 @@ describe('GET /prisoner/:prisonerNumber/contacts/create/select-next-of-kin/:jour
     expect(response.status).toEqual(200)
 
     const $ = cheerio.load(response.text)
-    expect($('[data-qa=main-heading]').first().text().trim()).toStrictEqual(
-      'Is First Middle Last next of kin for the prisoner?',
-    )
+    expect($('.main-heading').first().text().trim()).toStrictEqual('Is First Middle Last next of kin for the prisoner?')
     expect($('.govuk-caption-l').first().text().trim()).toStrictEqual(expectedCaption)
     expect($('[data-qa=cancel-button]').first().attr('href')).toStrictEqual('/foo-bar')
     expect($('[data-qa=breadcrumbs]')).toHaveLength(0)

--- a/server/routes/contacts/add/relationship-type/relationshipTypeController.test.ts
+++ b/server/routes/contacts/add/relationship-type/relationshipTypeController.test.ts
@@ -73,7 +73,7 @@ describe('GET /prisoner/:prisonerNumber/contacts/create/select-relationship-type
       expect(response.status).toEqual(200)
 
       const $ = cheerio.load(response.text)
-      expect($('[data-qa=main-heading]').first().text().trim()).toStrictEqual(
+      expect($('.main-heading').first().text().trim()).toStrictEqual(
         'Is First Middle Last a social or official contact for John Smith?',
       )
       expect($('[data-qa=back-link]').first().attr('href')).toStrictEqual(expectedBackLink)

--- a/server/routes/contacts/manage/addresses/address-type/addressTypeController.test.ts
+++ b/server/routes/contacts/manage/addresses/address-type/addressTypeController.test.ts
@@ -74,7 +74,7 @@ describe('GET /prisoner/:prisonerNumber/contacts/manage/:contactId/address/selec
     expect(response.status).toEqual(200)
 
     const $ = cheerio.load(response.text)
-    expect($('[data-qa=main-heading]').first().text().trim()).toStrictEqual(
+    expect($('.main-heading').first().text().trim()).toStrictEqual(
       'What type of address do you want to add for First Middle Last?',
     )
     expect($('[data-qa=cancel-button]').first().attr('href')).toStrictEqual('/foo-bar')

--- a/server/routes/contacts/manage/relationship/manageEmergencyContactController.test.ts
+++ b/server/routes/contacts/manage/relationship/manageEmergencyContactController.test.ts
@@ -55,9 +55,7 @@ describe('GET /prisoner/:prisonerNumber/contacts/manage/:contactId/relationship/
     // Then
     expect(response.status).toEqual(200)
     const $ = cheerio.load(response.text)
-    expect($('[data-qa=main-heading]').text().trim()).toBe(
-      'Is First Middle Last an emergency contact for the prisoner?',
-    )
+    expect($('.main-heading').text().trim()).toBe('Is First Middle Last an emergency contact for the prisoner?')
     expect($('[data-qa=cancel-button]').first().attr('href')).toStrictEqual('/foo-bar')
     expect($('[data-qa=back-link]').first().attr('href')).toStrictEqual('/foo-bar')
     expect($('[data-qa=continue-button]').first().text().trim()).toStrictEqual('Confirm and save')

--- a/server/routes/contacts/manage/relationship/manageNextOfKinContactController.test.ts
+++ b/server/routes/contacts/manage/relationship/manageNextOfKinContactController.test.ts
@@ -49,7 +49,7 @@ describe('GET /prisoner/:prisonerNumber/contacts/manage/:contactId/relationship/
     // Then
     expect(response.status).toEqual(200)
     const $ = cheerio.load(response.text)
-    expect($('[data-qa=main-heading]').text().trim()).toBe('Is Jones Mason next of kin for the prisoner?')
+    expect($('.main-heading').text().trim()).toBe('Is Jones Mason next of kin for the prisoner?')
     expect($('[data-qa=cancel-button]').first().attr('href')).toStrictEqual('/foo-bar')
     expect($('[data-qa=back-link]').first().attr('href')).toStrictEqual('/foo-bar')
     expect($('[data-qa=continue-button]').first().text().trim()).toStrictEqual('Confirm and save')

--- a/server/routes/contacts/manage/relationship/manageRelationshipStatusController.test.ts
+++ b/server/routes/contacts/manage/relationship/manageRelationshipStatusController.test.ts
@@ -49,9 +49,7 @@ describe('GET /prisoner/:prisonerNumber/contacts/manage/:contactId/relationship/
     // Then
     expect(response.status).toEqual(200)
     const $ = cheerio.load(response.text)
-    expect($('[data-qa=main-heading]').text().trim()).toBe(
-      'Is the relationship between Jones Mason and the prisoner active?',
-    )
+    expect($('.main-heading').text().trim()).toBe('Is the relationship between Jones Mason and the prisoner active?')
     expect($('[data-qa=cancel-button]').first().attr('href')).toStrictEqual('/foo-bar')
     expect($('[data-qa=back-link]').first().attr('href')).toStrictEqual('/foo-bar')
     expect($('[data-qa=continue-button]').first().text().trim()).toStrictEqual('Save and continue')

--- a/server/routes/contacts/manage/update-dob/manageContactEnterDobController.test.ts
+++ b/server/routes/contacts/manage/update-dob/manageContactEnterDobController.test.ts
@@ -55,9 +55,7 @@ describe('GET /prisoner/:prisonerNumber/contacts/manage/:contactId/update-dob?re
     expect(response.status).toEqual(200)
 
     const $ = cheerio.load(response.text)
-    expect($('[data-qa=main-heading]').first().text().trim()).toStrictEqual(
-      'Do you know First Middle Last’s date of birth?',
-    )
+    expect($('.main-heading').first().text().trim()).toStrictEqual('Do you know First Middle Last’s date of birth?')
     expect($('[data-qa=cancel-button]').first().attr('href')).toStrictEqual('/foo-bar')
     expect($('[data-qa=breadcrumbs]')).toHaveLength(0)
     expect($('#day').val()).toStrictEqual('15')
@@ -86,9 +84,7 @@ describe('GET /prisoner/:prisonerNumber/contacts/manage/:contactId/update-dob?re
     expect(response.status).toEqual(200)
 
     const $ = cheerio.load(response.text)
-    expect($('[data-qa=main-heading]').first().text().trim()).toStrictEqual(
-      'Do you know First Middle Last’s date of birth?',
-    )
+    expect($('.main-heading').first().text().trim()).toStrictEqual('Do you know First Middle Last’s date of birth?')
     expect($('[data-qa=cancel-button]').first().attr('href')).toStrictEqual('/foo-bar')
     expect($('[data-qa=breadcrumbs]')).toHaveLength(0)
     expect($('#day').val()).toBeUndefined()

--- a/server/views/pages/contacts/add/relationshipType.njk
+++ b/server/views/pages/contacts/add/relationshipType.njk
@@ -14,10 +14,16 @@
  <div class="govuk-grid-row">
         <div class="govuk-grid-column-two-thirds">
             <span class="govuk-caption-l">{{ caption }}</span>
-            <h1 class="govuk-heading-l" data-qa="main-heading">{{ title }}</h1>
             <form method='POST'>
                 <input type="hidden" name="_csrf" value="{{ csrfToken }}" />
                 {{ govukRadios({
+                    fieldset: {
+                      legend: {
+                        text: title,
+                        isPageHeading: true,
+                        classes: "govuk-fieldset__legend--l govuk-!-margin-bottom-6 main-heading"
+                      }
+                    },
                     name: "relationshipType",
                     items: [
                         {

--- a/server/views/pages/contacts/add/selectEmergencyContact.njk
+++ b/server/views/pages/contacts/add/selectEmergencyContact.njk
@@ -14,11 +14,17 @@
  <div class="govuk-grid-row">
         <div class="govuk-grid-column-two-thirds">
             <span class="govuk-caption-l">{{ caption or 'Contacts' }}</span>
-            <h1 class="govuk-heading-l" data-qa="main-heading">{{ title }}</h1>
             <form method='POST'>
                 <input type="hidden" name="_csrf" value="{{ csrfToken }}" />
                 {{ govukRadios({
-                    name: "isEmergencyContact",
+                  fieldset: {
+                    legend: {
+                      text: title,
+                      isPageHeading: true,
+                      classes: "govuk-fieldset__legend--l govuk-!-margin-bottom-6 main-heading"
+                    }
+                  },
+                  name: "isEmergencyContact",
                     items: [
                         {
                             value: 'YES',

--- a/server/views/pages/contacts/add/selectNextOfKin.njk
+++ b/server/views/pages/contacts/add/selectNextOfKin.njk
@@ -14,11 +14,17 @@
  <div class="govuk-grid-row">
         <div class="govuk-grid-column-two-thirds">
             <span class="govuk-caption-l">{{ caption or 'Contacts' }}</span>
-            <h1 class="govuk-heading-l" data-qa="main-heading">{{ title }}</h1>
             <form method='POST'>
                 <input type="hidden" name="_csrf" value="{{ csrfToken }}" />
                 {{ govukRadios({
-                    name: "isNextOfKin",
+                  fieldset: {
+                    legend: {
+                      text: title,
+                      isPageHeading: true,
+                      classes: "govuk-fieldset__legend--l govuk-!-margin-bottom-6 main-heading"
+                    }
+                  },
+                  name: "isNextOfKin",
                     items: [
                         {
                             value: 'YES',

--- a/server/views/pages/contacts/common/enterDob.njk
+++ b/server/views/pages/contacts/common/enterDob.njk
@@ -15,7 +15,6 @@
  <div class="govuk-grid-row">
         <div class="govuk-grid-column-two-thirds">
             <span class="govuk-caption-l">{{ caption or 'Contacts' }}</span>
-            <h1 class="govuk-heading-l" data-qa="main-heading">{{ title }}</h1>
             <form method='POST'>
                 <input type="hidden" name="_csrf" value="{{ csrfToken }}" />
                 {% if validationErrors %}
@@ -69,7 +68,14 @@
 
                 {% endset %}
                 {{ govukRadios({
-                    name: "isKnown",
+                  fieldset: {
+                    legend: {
+                      text: title,
+                      isPageHeading: true,
+                      classes: "govuk-fieldset__legend--l govuk-!-margin-bottom-6 main-heading"
+                    }
+                  },
+                  name: "isKnown",
                     items: [
                         {
                             value: 'YES',

--- a/server/views/pages/contacts/manage/address/addressType.njk
+++ b/server/views/pages/contacts/manage/address/addressType.njk
@@ -15,7 +15,6 @@
     <span class="govuk-caption-l">Contacts</span>
     <div class="govuk-grid-row">
         <div class="govuk-grid-column-two-thirds">
-            <h1 class="govuk-heading-l" data-qa="main-heading">{{ title }}</h1>
             <form method='POST'>
                 <input type="hidden" name="_csrf" value="{{ csrfToken }}" />
                 {% set defaultOptions = [
@@ -29,7 +28,14 @@
                 {% set radios = typeOptions.concat(defaultOptions) %}
 
                 {{ govukRadios({
-                    name: "addressType",
+                  fieldset: {
+                    legend: {
+                      text: title,
+                      isPageHeading: true,
+                      classes: "govuk-fieldset__legend--l govuk-!-margin-bottom-6 main-heading"
+                    }
+                  },
+                  name: "addressType",
                     items: radios })
                 }}
 

--- a/server/views/pages/contacts/manage/contactDetails/manageEmergencyContactStatus.njk
+++ b/server/views/pages/contacts/manage/contactDetails/manageEmergencyContactStatus.njk
@@ -13,14 +13,20 @@
 {% include '../../../../partials/navigation.njk' %}
 {{ miniProfile(prisonerDetails) }}
 <div class="govuk-grid-row">
-    <div class="govuk-grid-column-one-half">
+    <div class="govuk-grid-column-two-thirds">
         <span class="govuk-caption-l">Contacts</span>
-        <h1 class="govuk-heading-l" data-qa="main-heading">{{ title }}</h1>
         <form method='POST'>
             <input type="hidden" name="_csrf" value="{{ csrfToken }}" />
-            
+
             {{ govukRadios({
-                    name: "emergencyContactStatus",
+              fieldset: {
+                legend: {
+                  text: title,
+                  isPageHeading: true,
+                  classes: "govuk-fieldset__legend--l govuk-!-margin-bottom-6 main-heading"
+                }
+              },
+              name: "emergencyContactStatus",
                     items: [
                         {
                             value: "YES",

--- a/server/views/pages/contacts/manage/contactDetails/manageGender.njk
+++ b/server/views/pages/contacts/manage/contactDetails/manageGender.njk
@@ -12,13 +12,19 @@
 {% include '../../../../partials/navigation.njk' %}
 {{ miniProfile(prisonerDetails) }}
 <div class="govuk-grid-row">
-    <div class="govuk-grid-column-one-half">
+    <div class="govuk-grid-column-two-thirds">
         <span class="govuk-caption-l">Contacts</span>
-        <h1 class="govuk-heading-l" data-qa="main-heading">{{ title }}</h1>
         <form method='POST'>
             <input type="hidden" name="_csrf" value="{{ csrfToken }}" />
             {{ govukRadios({
-                id: "gender",
+              fieldset: {
+                legend: {
+                  text: title,
+                  isPageHeading: true,
+                  classes: "govuk-fieldset__legend--l govuk-!-margin-bottom-6 main-heading"
+                }
+              },
+              id: "gender",
                 name: "gender",
                 items: genderOptions
             }) }}

--- a/server/views/pages/contacts/manage/contactDetails/manageInterpreter.njk
+++ b/server/views/pages/contacts/manage/contactDetails/manageInterpreter.njk
@@ -13,14 +13,20 @@
 {% include '../../../../partials/navigation.njk' %}
 {{ miniProfile(prisonerDetails) }}
 <div class="govuk-grid-row">
-    <div class="govuk-grid-column-one-half">
+    <div class="govuk-grid-column-two-thirds">
         <span class="govuk-caption-l">Contacts</span>
-        <h1 class="govuk-heading-l" data-qa="main-heading">{{ title }}</h1>
         <form method='POST'>
             <input type="hidden" name="_csrf" value="{{ csrfToken }}" />
-            
+
             {{ govukRadios({
-                    name: "interpreterRequired",
+              fieldset: {
+                legend: {
+                  text: title,
+                  isPageHeading: true,
+                  classes: "govuk-fieldset__legend--l govuk-!-margin-bottom-6 main-heading"
+                }
+              },
+              name: "interpreterRequired",
                     items: [
                         {
                             value: "YES",

--- a/server/views/pages/contacts/manage/contactDetails/manageNextOfKinContactStatus.njk
+++ b/server/views/pages/contacts/manage/contactDetails/manageNextOfKinContactStatus.njk
@@ -14,14 +14,20 @@
 
 {{ miniProfile(prisonerDetails) }}
 <div class="govuk-grid-row">
-    <div class="govuk-grid-column-one-half">
+    <div class="govuk-grid-column-two-thirds">
         <span class="govuk-caption-l">Contacts</span>
-        <h1 class="govuk-heading-l" data-qa="main-heading">{{ title }}</h1>
         <form method='POST'>
             <input type="hidden" name="_csrf" value="{{ csrfToken }}" />
-            
+
             {{ govukRadios({
-                    name: "nextOfKinStatus",
+              fieldset: {
+                legend: {
+                  text: title,
+                  isPageHeading: true,
+                  classes: "govuk-fieldset__legend--l govuk-!-margin-bottom-6 main-heading"
+                }
+              },
+              name: "nextOfKinStatus",
                     items: [
                         {
                             value: "YES",

--- a/server/views/pages/contacts/manage/contactDetails/manageRelationshipStatus.njk
+++ b/server/views/pages/contacts/manage/contactDetails/manageRelationshipStatus.njk
@@ -14,14 +14,20 @@
 
 {{ miniProfile(prisonerDetails) }}
 <div class="govuk-grid-row">
-    <div class="govuk-grid-column-one-half">
+    <div class="govuk-grid-column-two-thirds">
         <span class="govuk-caption-l">Contacts</span>
-        <h1 class="govuk-heading-l" data-qa="main-heading">{{ title }}</h1>
         <form method='POST'>
             <input type="hidden" name="_csrf" value="{{ csrfToken }}" />
-            
+
             {{ govukRadios({
-                    name: "relationshipStatus",
+              fieldset: {
+                legend: {
+                  text: title,
+                  isPageHeading: true,
+                  classes: "govuk-fieldset__legend--l govuk-!-margin-bottom-6 main-heading"
+                }
+              },
+              name: "relationshipStatus",
                     items: [
                         {
                             value: "YES",

--- a/server/views/pages/contacts/manage/updateApprovedToVisit.njk
+++ b/server/views/pages/contacts/manage/updateApprovedToVisit.njk
@@ -12,14 +12,20 @@
     {% include '../../../partials/navigation.njk' %}
     {{ miniProfile(prisonerDetails) }}
     <span class="govuk-caption-l">Contacts</span>
-    <h1 class="govuk-heading-l">{{ title }}</h1>
     <div class="govuk-grid-row">
         <div class="govuk-grid-column-three-quarters">
             <form method='POST'>
                 <input type="hidden" name="_csrf" value="{{ csrfToken }}" />
 
                 {{ govukRadios({
-                    name: "isApprovedToVisit",
+                  fieldset: {
+                    legend: {
+                      text: title,
+                      isPageHeading: true,
+                      classes: "govuk-fieldset__legend--l govuk-!-margin-bottom-6 main-heading"
+                    }
+                  },
+                  name: "isApprovedToVisit",
                     items: [
                         {
                             value: 'YES',

--- a/server/views/pages/contacts/manage/updateStaff.njk
+++ b/server/views/pages/contacts/manage/updateStaff.njk
@@ -12,14 +12,20 @@
     {% include '../../../partials/navigation.njk' %}
     {{ miniProfile(prisonerDetails) }}
     <span class="govuk-caption-l">Contacts</span>
-    <h1 class="govuk-heading-l">{{ title }}</h1>
     <div class="govuk-grid-row">
         <div class="govuk-grid-column-three-quarters">
             <form method='POST'>
                 <input type="hidden" name="_csrf" value="{{ csrfToken }}" />
 
                 {{ govukRadios({
-                    name: "isStaff",
+                  fieldset: {
+                    legend: {
+                      text: title,
+                      isPageHeading: true,
+                      classes: "govuk-fieldset__legend--l govuk-!-margin-bottom-6 main-heading"
+                    }
+                  },
+                  name: "isStaff",
                     items: [
                         {
                             value: 'YES',


### PR DESCRIPTION
Questions with radio button answers that are also the H1 did not have an accessible legend. Moved the H1 to the fieldset for these questions as per GDS guidelines. Annoyingly, fieldset does not allow setting custom attributes so accessors in tests changed to class.