### PR TITLE
PRC-279: Update delete contact phone

### DIFF
--- a/integration_tests/e2e/deleteContactPhone.cy.ts
+++ b/integration_tests/e2e/deleteContactPhone.cy.ts
@@ -55,12 +55,11 @@ context('Delete Contact Phones', () => {
     Page.verifyOnPage(EditContactMethodsPage, 'First Middle Names Last') //
       .clickDeletePhoneNumberLink('07878 111111, ext. 123')
 
-    Page.verifyOnPage(ConfirmDeletePhonePage) //
+    Page.verifyOnPage(ConfirmDeletePhonePage, 'First Middle Names Last') //
       .hasPhoneNumber('07878 111111')
       .hasType('Mobile')
       .hasExtension('123')
-      .continueTo(EditContactMethodsPage, 'First Middle Names Last')
-      .backTo(ManageContactDetailsPage, 'First Middle Names Last')
+      .continueTo(ManageContactDetailsPage, 'First Middle Names Last')
       .verifyOnContactsMethodsTab()
 
     cy.verifyAPIWasCalled(
@@ -72,6 +71,28 @@ context('Delete Contact Phones', () => {
     )
   })
 
+  it('Can go back from deleting a contact phone', () => {
+    Page.verifyOnPage(ManageContactDetailsPage, 'First Middle Names Last') //
+      .clickContactMethodsTab()
+      .clickEditContactMethodsLink()
+
+    Page.verifyOnPage(EditContactMethodsPage, 'First Middle Names Last') //
+      .clickDeletePhoneNumberLink('01111 777777')
+
+    Page.verifyOnPage(ConfirmDeletePhonePage, 'First Middle Names Last') //
+      .backTo(EditContactMethodsPage, 'First Middle Names Last')
+      .backTo(ManageContactDetailsPage, 'First Middle Names Last')
+      .verifyOnContactsMethodsTab()
+
+    cy.verifyAPIWasCalled(
+      {
+        method: 'DELETE',
+        urlPath: `/contact/${contactId}/phone/77`,
+      },
+      0,
+    )
+  })
+
   it('Can cancel deleting a contact phone', () => {
     Page.verifyOnPage(ManageContactDetailsPage, 'First Middle Names Last') //
       .clickContactMethodsTab()
@@ -80,11 +101,10 @@ context('Delete Contact Phones', () => {
     Page.verifyOnPage(EditContactMethodsPage, 'First Middle Names Last') //
       .clickDeletePhoneNumberLink('01111 777777')
 
-    Page.verifyOnPage(ConfirmDeletePhonePage) //
+    Page.verifyOnPage(ConfirmDeletePhonePage, 'First Middle Names Last') //
       .hasPhoneNumber('01111 777777')
       .hasType('Home')
       .hasExtension('Not provided')
-      .cancelTo(EditContactMethodsPage, 'First Middle Names Last')
       .cancelTo(ManageContactDetailsPage, 'First Middle Names Last')
       .verifyOnContactsMethodsTab()
 

--- a/integration_tests/pages/confirmDeletePhonePage.ts
+++ b/integration_tests/pages/confirmDeletePhonePage.ts
@@ -1,8 +1,8 @@
 import Page, { PageElement } from './page'
 
 export default class ConfirmDeletePhonePage extends Page {
-  constructor() {
-    super(`Are you sure you want to delete this phone number?`)
+  constructor(contactName: string) {
+    super(`Are you sure you want to delete this phone number for ${contactName}?`)
   }
 
   hasPhoneNumber(value: string): ConfirmDeletePhonePage {

--- a/server/routes/contacts/manage/edit-contact-methods/editContactMethodsController.test.ts
+++ b/server/routes/contacts/manage/edit-contact-methods/editContactMethodsController.test.ts
@@ -45,7 +45,7 @@ describe('GET /contacts/manage/:contactId/relationship/:prisonerContactId/edit-c
 
   it('should audit page view', async () => {
     const response = await request(app).get(
-      `/prisoner/${prisonerNumber}/contacts/manage/1/relationship/99/edit-contact-methods?returnUrl=/foo&returnAnchor=bar`,
+      `/prisoner/${prisonerNumber}/contacts/manage/1/relationship/99/edit-contact-methods`,
     )
     expect(response.status).toEqual(200)
     expect(auditService.logPageView).toHaveBeenCalledWith(Page.EDIT_CONTACT_METHODS_PAGE, {
@@ -57,14 +57,18 @@ describe('GET /contacts/manage/:contactId/relationship/:prisonerContactId/edit-c
 
   it('should have correct navigation', async () => {
     const response = await request(app).get(
-      `/prisoner/${prisonerNumber}/contacts/manage/1/relationship/99/edit-contact-methods?returnUrl=/foo&returnAnchor=bar`,
+      `/prisoner/${prisonerNumber}/contacts/manage/1/relationship/99/edit-contact-methods`,
     )
     const $ = cheerio.load(response.text)
     expect($('.govuk-heading-l').first().text().trim()).toStrictEqual('Edit contact methods for Jones Mason')
     expect($('.govuk-caption-l').first().text().trim()).toStrictEqual('Manage contacts')
     expect($('[data-qa=breadcrumbs]')).toHaveLength(0)
-    expect($('[data-qa=cancel-button]').first().attr('href')).toStrictEqual('/foo#bar')
-    expect($('[data-qa=back-link]').first().attr('href')).toStrictEqual('/foo#bar')
+    expect($('[data-qa=cancel-button]').first().attr('href')).toStrictEqual(
+      '/prisoner/A1234BC/contacts/manage/1/relationship/99#contact-methods',
+    )
+    expect($('[data-qa=back-link]').first().attr('href')).toStrictEqual(
+      '/prisoner/A1234BC/contacts/manage/1/relationship/99#contact-methods',
+    )
   })
 
   describe('Phone numbers summary card', () => {
@@ -80,14 +84,14 @@ describe('GET /contacts/manage/:contactId/relationship/:prisonerContactId/edit-c
       )
 
       const response = await request(app).get(
-        `/prisoner/${prisonerNumber}/contacts/manage/1/relationship/99/edit-contact-methods?returnUrl=/foo&returnAnchor=bar`,
+        `/prisoner/${prisonerNumber}/contacts/manage/1/relationship/99/edit-contact-methods`,
       )
       const $ = cheerio.load(response.text)
 
       const addPhoneNumberLink = $('a:contains("Add phone number")')
       expect(addPhoneNumberLink).toHaveLength(1)
       expect(addPhoneNumberLink.attr('href')).toStrictEqual(
-        '/prisoner/A1234BC/contacts/manage/22/phone/create?returnUrl=%2Fprisoner%2FA1234BC%2Fcontacts%2Fmanage%2F1%2Frelationship%2F99%2Fedit-contact-methods%3FreturnUrl%3D%2Ffoo%26returnAnchor%3Dbar',
+        '/prisoner/A1234BC/contacts/manage/22/phone/create?returnUrl=/prisoner/A1234BC/contacts/manage/1/relationship/99/edit-contact-methods',
       )
 
       const phoneNumbersCard = $('h2:contains("Phone numbers")').first().parent().parent()
@@ -95,27 +99,27 @@ describe('GET /contacts/manage/:contactId/relationship/:prisonerContactId/edit-c
       expectChangeAndDeleteItem(
         $(phoneNumbersCard).find('dt:contains("Business")').first(),
         '1234, ext. 999',
-        '/prisoner/A1234BC/contacts/manage/22/phone/3/edit?returnUrl=%2Fprisoner%2FA1234BC%2Fcontacts%2Fmanage%2F1%2Frelationship%2F99%2Fedit-contact-methods%3FreturnUrl%3D%2Ffoo%26returnAnchor%3Dbar',
+        '/prisoner/A1234BC/contacts/manage/22/phone/3/edit?returnUrl=/prisoner/A1234BC/contacts/manage/1/relationship/99/edit-contact-methods',
         'Change the information about this Business phone number (Phone numbers)',
-        '/prisoner/A1234BC/contacts/manage/22/phone/3/delete?returnUrl=%2Fprisoner%2FA1234BC%2Fcontacts%2Fmanage%2F1%2Frelationship%2F99%2Fedit-contact-methods%3FreturnUrl%3D%2Ffoo%26returnAnchor%3Dbar',
+        '/prisoner/A1234BC/contacts/manage/22/relationship/99/phone/3/delete',
         'Delete the information about this Business phone number (Phone numbers)',
       )
 
       expectChangeAndDeleteItem(
         $(phoneNumbersCard).find('dt:contains("Business")').last(),
         '5555',
-        '/prisoner/A1234BC/contacts/manage/22/phone/2/edit?returnUrl=%2Fprisoner%2FA1234BC%2Fcontacts%2Fmanage%2F1%2Frelationship%2F99%2Fedit-contact-methods%3FreturnUrl%3D%2Ffoo%26returnAnchor%3Dbar',
+        '/prisoner/A1234BC/contacts/manage/22/phone/2/edit?returnUrl=/prisoner/A1234BC/contacts/manage/1/relationship/99/edit-contact-methods',
         'Change the information about this Business phone number (Phone numbers)',
-        '/prisoner/A1234BC/contacts/manage/22/phone/2/delete?returnUrl=%2Fprisoner%2FA1234BC%2Fcontacts%2Fmanage%2F1%2Frelationship%2F99%2Fedit-contact-methods%3FreturnUrl%3D%2Ffoo%26returnAnchor%3Dbar',
+        '/prisoner/A1234BC/contacts/manage/22/relationship/99/phone/2/delete',
         'Delete the information about this Business phone number (Phone numbers)',
       )
 
       expectChangeAndDeleteItem(
         $(phoneNumbersCard).find('dt:contains("Mobile")').first(),
         '4321',
-        '/prisoner/A1234BC/contacts/manage/22/phone/1/edit?returnUrl=%2Fprisoner%2FA1234BC%2Fcontacts%2Fmanage%2F1%2Frelationship%2F99%2Fedit-contact-methods%3FreturnUrl%3D%2Ffoo%26returnAnchor%3Dbar',
+        '/prisoner/A1234BC/contacts/manage/22/phone/1/edit?returnUrl=/prisoner/A1234BC/contacts/manage/1/relationship/99/edit-contact-methods',
         'Change the information about this Mobile phone number (Phone numbers)',
-        '/prisoner/A1234BC/contacts/manage/22/phone/1/delete?returnUrl=%2Fprisoner%2FA1234BC%2Fcontacts%2Fmanage%2F1%2Frelationship%2F99%2Fedit-contact-methods%3FreturnUrl%3D%2Ffoo%26returnAnchor%3Dbar',
+        '/prisoner/A1234BC/contacts/manage/22/relationship/99/phone/1/delete',
         'Delete the information about this Mobile phone number (Phone numbers)',
       )
     })
@@ -128,7 +132,7 @@ describe('GET /contacts/manage/:contactId/relationship/:prisonerContactId/edit-c
       )
 
       const response = await request(app).get(
-        `/prisoner/${prisonerNumber}/contacts/manage/1/relationship/99/edit-contact-methods?returnUrl=/foo&returnAnchor=bar`,
+        `/prisoner/${prisonerNumber}/contacts/manage/1/relationship/99/edit-contact-methods`,
       )
       const $ = cheerio.load(response.text)
 
@@ -139,7 +143,7 @@ describe('GET /contacts/manage/:contactId/relationship/:prisonerContactId/edit-c
       const addPhoneNumberLink = $('a:contains("Add phone number")')
       expect(addPhoneNumberLink).toHaveLength(1)
       expect(addPhoneNumberLink.attr('href')).toStrictEqual(
-        '/prisoner/A1234BC/contacts/manage/22/phone/create?returnUrl=%2Fprisoner%2FA1234BC%2Fcontacts%2Fmanage%2F1%2Frelationship%2F99%2Fedit-contact-methods%3FreturnUrl%3D%2Ffoo%26returnAnchor%3Dbar',
+        '/prisoner/A1234BC/contacts/manage/22/phone/create?returnUrl=/prisoner/A1234BC/contacts/manage/1/relationship/99/edit-contact-methods',
       )
     })
   })
@@ -156,7 +160,7 @@ describe('GET /contacts/manage/:contactId/relationship/:prisonerContactId/edit-c
       )
 
       const response = await request(app).get(
-        `/prisoner/${prisonerNumber}/contacts/manage/1/relationship/99/edit-contact-methods?returnUrl=/foo&returnAnchor=bar`,
+        `/prisoner/${prisonerNumber}/contacts/manage/1/relationship/99/edit-contact-methods`,
       )
       const $ = cheerio.load(response.text)
 
@@ -165,24 +169,24 @@ describe('GET /contacts/manage/:contactId/relationship/:prisonerContactId/edit-c
       expectChangeAndDeleteItem(
         $(emailAddressesCard).find('dt:contains("Email addresses")').first(),
         'test@example.com',
-        '/prisoner/A1234BC/contacts/manage/22/email/2/edit?returnUrl=%2Fprisoner%2FA1234BC%2Fcontacts%2Fmanage%2F1%2Frelationship%2F99%2Fedit-contact-methods%3FreturnUrl%3D%2Ffoo%26returnAnchor%3Dbar',
+        '/prisoner/A1234BC/contacts/manage/22/email/2/edit?returnUrl=/prisoner/A1234BC/contacts/manage/1/relationship/99/edit-contact-methods',
         'Change this email address (Email addresses)',
-        '/prisoner/A1234BC/contacts/manage/22/email/2/delete?returnUrl=%2Fprisoner%2FA1234BC%2Fcontacts%2Fmanage%2F1%2Frelationship%2F99%2Fedit-contact-methods%3FreturnUrl%3D%2Ffoo%26returnAnchor%3Dbar',
+        '/prisoner/A1234BC/contacts/manage/22/email/2/delete?returnUrl=/prisoner/A1234BC/contacts/manage/1/relationship/99/edit-contact-methods',
         'Delete this email address (Email addresses)',
       )
       expectChangeAndDeleteItem(
         $(emailAddressesCard).find('dt:contains("Email addresses")').parent().next().find('dt'),
         'zzz@example.com',
-        '/prisoner/A1234BC/contacts/manage/22/email/1/edit?returnUrl=%2Fprisoner%2FA1234BC%2Fcontacts%2Fmanage%2F1%2Frelationship%2F99%2Fedit-contact-methods%3FreturnUrl%3D%2Ffoo%26returnAnchor%3Dbar',
+        '/prisoner/A1234BC/contacts/manage/22/email/1/edit?returnUrl=/prisoner/A1234BC/contacts/manage/1/relationship/99/edit-contact-methods',
         'Change this email address (Email addresses)',
-        '/prisoner/A1234BC/contacts/manage/22/email/1/delete?returnUrl=%2Fprisoner%2FA1234BC%2Fcontacts%2Fmanage%2F1%2Frelationship%2F99%2Fedit-contact-methods%3FreturnUrl%3D%2Ffoo%26returnAnchor%3Dbar',
+        '/prisoner/A1234BC/contacts/manage/22/email/1/delete?returnUrl=/prisoner/A1234BC/contacts/manage/1/relationship/99/edit-contact-methods',
         'Delete this email address (Email addresses)',
       )
 
       const addEmailAddressLink = $('a:contains("Add email address")')
       expect(addEmailAddressLink).toHaveLength(1)
       expect(addEmailAddressLink.attr('href')).toStrictEqual(
-        '/prisoner/A1234BC/contacts/manage/22/email/create?returnUrl=%2Fprisoner%2FA1234BC%2Fcontacts%2Fmanage%2F1%2Frelationship%2F99%2Fedit-contact-methods%3FreturnUrl%3D%2Ffoo%26returnAnchor%3Dbar',
+        '/prisoner/A1234BC/contacts/manage/22/email/create?returnUrl=/prisoner/A1234BC/contacts/manage/1/relationship/99/edit-contact-methods',
       )
     })
 
@@ -194,7 +198,7 @@ describe('GET /contacts/manage/:contactId/relationship/:prisonerContactId/edit-c
       )
 
       const response = await request(app).get(
-        `/prisoner/${prisonerNumber}/contacts/manage/1/relationship/99/edit-contact-methods?returnUrl=/foo&returnAnchor=bar`,
+        `/prisoner/${prisonerNumber}/contacts/manage/1/relationship/99/edit-contact-methods`,
       )
       const $ = cheerio.load(response.text)
 
@@ -205,7 +209,7 @@ describe('GET /contacts/manage/:contactId/relationship/:prisonerContactId/edit-c
       const addEmailAddressLink = $('a:contains("Add email address")')
       expect(addEmailAddressLink).toHaveLength(1)
       expect(addEmailAddressLink.attr('href')).toStrictEqual(
-        '/prisoner/A1234BC/contacts/manage/22/email/create?returnUrl=%2Fprisoner%2FA1234BC%2Fcontacts%2Fmanage%2F1%2Frelationship%2F99%2Fedit-contact-methods%3FreturnUrl%3D%2Ffoo%26returnAnchor%3Dbar',
+        '/prisoner/A1234BC/contacts/manage/22/email/create?returnUrl=/prisoner/A1234BC/contacts/manage/1/relationship/99/edit-contact-methods',
       )
     })
   })
@@ -260,7 +264,7 @@ describe('GET /contacts/manage/:contactId/relationship/:prisonerContactId/edit-c
         )
 
         const response = await request(app).get(
-          `/prisoner/${prisonerNumber}/contacts/manage/1/relationship/99/edit-contact-methods?returnUrl=/foo&returnAnchor=bar`,
+          `/prisoner/${prisonerNumber}/contacts/manage/1/relationship/99/edit-contact-methods`,
         )
         const $ = cheerio.load(response.text)
 
@@ -274,51 +278,51 @@ describe('GET /contacts/manage/:contactId/relationship/:prisonerContactId/edit-c
           addressCard,
           'Type',
           expectedType,
-          '/prisoner/A1234BC/contacts/manage/22/address/edit/1/start?returnUrl=%2Fprisoner%2FA1234BC%2Fcontacts%2Fmanage%2F1%2Frelationship%2F99%2Fedit-contact-methods%3FreturnUrl%3D%2Ffoo%26returnAnchor%3Dbar',
+          '/prisoner/A1234BC/contacts/manage/22/address/edit/1/start?returnUrl=/prisoner/A1234BC/contacts/manage/1/relationship/99/edit-contact-methods',
           `Change the address type (${expectedTitle})`,
         )
         expectSummaryListItem(
           addressCard,
           'Address',
           'Flat 1a, Property, StreetAreaCityCountyPostcodeEngland',
-          '/prisoner/A1234BC/contacts/manage/22/address/edit/1/start?returnUrl=%2Fprisoner%2FA1234BC%2Fcontacts%2Fmanage%2F1%2Frelationship%2F99%2Fedit-contact-methods%3FreturnUrl%3D%2Ffoo%26returnAnchor%3Dbar',
+          '/prisoner/A1234BC/contacts/manage/22/address/edit/1/start?returnUrl=/prisoner/A1234BC/contacts/manage/1/relationship/99/edit-contact-methods',
           `Change the address (${expectedTitle})`,
         )
         expectSummaryListItem(
           addressCard,
           'Date',
           'From January 2021',
-          '/prisoner/A1234BC/contacts/manage/22/address/edit/1/start?returnUrl=%2Fprisoner%2FA1234BC%2Fcontacts%2Fmanage%2F1%2Frelationship%2F99%2Fedit-contact-methods%3FreturnUrl%3D%2Ffoo%26returnAnchor%3Dbar',
+          '/prisoner/A1234BC/contacts/manage/22/address/edit/1/start?returnUrl=/prisoner/A1234BC/contacts/manage/1/relationship/99/edit-contact-methods',
           `Change the dates for the prisoner’s use of the address (${expectedTitle})`,
         )
         expectSummaryListItem(
           addressCard,
           'Primary or postal address',
           expectedPrimaryOrPostal,
-          '/prisoner/A1234BC/contacts/manage/22/address/edit/1/start?returnUrl=%2Fprisoner%2FA1234BC%2Fcontacts%2Fmanage%2F1%2Frelationship%2F99%2Fedit-contact-methods%3FreturnUrl%3D%2Ffoo%26returnAnchor%3Dbar',
+          '/prisoner/A1234BC/contacts/manage/22/address/edit/1/start?returnUrl=/prisoner/A1234BC/contacts/manage/1/relationship/99/edit-contact-methods',
           `Change if this address is set as the primary or postal address for the contact (${expectedTitle})`,
         )
         expectChangeAndDeleteItem(
           $(addressCard).find('dt:contains("Mobile phone")'),
           '07878 111111, ext. 123',
-          '/prisoner/A1234BC/contacts/manage/22/address/1/phone/123/edit?returnUrl=%2Fprisoner%2FA1234BC%2Fcontacts%2Fmanage%2F1%2Frelationship%2F99%2Fedit-contact-methods%3FreturnUrl%3D%2Ffoo%26returnAnchor%3Dbar',
+          '/prisoner/A1234BC/contacts/manage/22/address/1/phone/123/edit?returnUrl=/prisoner/A1234BC/contacts/manage/1/relationship/99/edit-contact-methods',
           `Change the information about the Mobile phone phone number for this address (${expectedTitle})`,
-          '/prisoner/A1234BC/contacts/manage/22/address/1/phone/123/delete?returnUrl=%2Fprisoner%2FA1234BC%2Fcontacts%2Fmanage%2F1%2Frelationship%2F99%2Fedit-contact-methods%3FreturnUrl%3D%2Ffoo%26returnAnchor%3Dbar',
+          '/prisoner/A1234BC/contacts/manage/22/address/1/phone/123/delete?returnUrl=/prisoner/A1234BC/contacts/manage/1/relationship/99/edit-contact-methods',
           `Delete the information about the Mobile phone phone number for this address (${expectedTitle})`,
         )
         expectChangeAndDeleteItem(
           $(addressCard).find('dt:contains("Business phone")'),
           '999',
-          '/prisoner/A1234BC/contacts/manage/22/address/1/phone/321/edit?returnUrl=%2Fprisoner%2FA1234BC%2Fcontacts%2Fmanage%2F1%2Frelationship%2F99%2Fedit-contact-methods%3FreturnUrl%3D%2Ffoo%26returnAnchor%3Dbar',
+          '/prisoner/A1234BC/contacts/manage/22/address/1/phone/321/edit?returnUrl=/prisoner/A1234BC/contacts/manage/1/relationship/99/edit-contact-methods',
           `Change the information about the Business phone phone number for this address (${expectedTitle})`,
-          '/prisoner/A1234BC/contacts/manage/22/address/1/phone/321/delete?returnUrl=%2Fprisoner%2FA1234BC%2Fcontacts%2Fmanage%2F1%2Frelationship%2F99%2Fedit-contact-methods%3FreturnUrl%3D%2Ffoo%26returnAnchor%3Dbar',
+          '/prisoner/A1234BC/contacts/manage/22/address/1/phone/321/delete?returnUrl=/prisoner/A1234BC/contacts/manage/1/relationship/99/edit-contact-methods',
           `Delete the information about the Business phone phone number for this address (${expectedTitle})`,
         )
         expectSummaryListItem(
           addressCard,
           'Comments on this address',
           'Some comments',
-          '/prisoner/A1234BC/contacts/manage/22/address/edit/1/start?returnUrl=%2Fprisoner%2FA1234BC%2Fcontacts%2Fmanage%2F1%2Frelationship%2F99%2Fedit-contact-methods%3FreturnUrl%3D%2Ffoo%26returnAnchor%3Dbar',
+          '/prisoner/A1234BC/contacts/manage/22/address/edit/1/start?returnUrl=/prisoner/A1234BC/contacts/manage/1/relationship/99/edit-contact-methods',
           `Change the comments on this address (${expectedTitle})`,
         )
       },
@@ -380,7 +384,7 @@ describe('GET /contacts/manage/:contactId/relationship/:prisonerContactId/edit-c
         )
 
         const response = await request(app).get(
-          `/prisoner/${prisonerNumber}/contacts/manage/1/relationship/99/edit-contact-methods?returnUrl=/foo&returnAnchor=bar`,
+          `/prisoner/${prisonerNumber}/contacts/manage/1/relationship/99/edit-contact-methods`,
         )
         const $ = cheerio.load(response.text)
 
@@ -394,51 +398,51 @@ describe('GET /contacts/manage/:contactId/relationship/:prisonerContactId/edit-c
           addressCard,
           'Type',
           expectedType,
-          '/prisoner/A1234BC/contacts/manage/22/address/edit/1/start?returnUrl=%2Fprisoner%2FA1234BC%2Fcontacts%2Fmanage%2F1%2Frelationship%2F99%2Fedit-contact-methods%3FreturnUrl%3D%2Ffoo%26returnAnchor%3Dbar',
+          '/prisoner/A1234BC/contacts/manage/22/address/edit/1/start?returnUrl=/prisoner/A1234BC/contacts/manage/1/relationship/99/edit-contact-methods',
           `Change the address type (${expectedTitle})`,
         )
         expectSummaryListItem(
           addressCard,
           'Address',
           'Flat 1a, Property, StreetAreaCityCountyPostcodeEngland',
-          '/prisoner/A1234BC/contacts/manage/22/address/edit/1/start?returnUrl=%2Fprisoner%2FA1234BC%2Fcontacts%2Fmanage%2F1%2Frelationship%2F99%2Fedit-contact-methods%3FreturnUrl%3D%2Ffoo%26returnAnchor%3Dbar',
+          '/prisoner/A1234BC/contacts/manage/22/address/edit/1/start?returnUrl=/prisoner/A1234BC/contacts/manage/1/relationship/99/edit-contact-methods',
           `Change the address (${expectedTitle})`,
         )
         expectSummaryListItem(
           addressCard,
           'Date',
           'From January 2021 to January 2022',
-          '/prisoner/A1234BC/contacts/manage/22/address/edit/1/start?returnUrl=%2Fprisoner%2FA1234BC%2Fcontacts%2Fmanage%2F1%2Frelationship%2F99%2Fedit-contact-methods%3FreturnUrl%3D%2Ffoo%26returnAnchor%3Dbar',
+          '/prisoner/A1234BC/contacts/manage/22/address/edit/1/start?returnUrl=/prisoner/A1234BC/contacts/manage/1/relationship/99/edit-contact-methods',
           `Change the dates for the prisoner’s use of the address (${expectedTitle})`,
         )
         expectSummaryListItem(
           addressCard,
           'Primary or postal address',
           expectedPrimaryOrPostal,
-          '/prisoner/A1234BC/contacts/manage/22/address/edit/1/start?returnUrl=%2Fprisoner%2FA1234BC%2Fcontacts%2Fmanage%2F1%2Frelationship%2F99%2Fedit-contact-methods%3FreturnUrl%3D%2Ffoo%26returnAnchor%3Dbar',
+          '/prisoner/A1234BC/contacts/manage/22/address/edit/1/start?returnUrl=/prisoner/A1234BC/contacts/manage/1/relationship/99/edit-contact-methods',
           `Change if this address is set as the primary or postal address for the contact (${expectedTitle})`,
         )
         expectChangeAndDeleteItem(
           $(addressCard).find('dt:contains("Mobile phone")'),
           '07878 111111, ext. 123',
-          '/prisoner/A1234BC/contacts/manage/22/address/1/phone/123/edit?returnUrl=%2Fprisoner%2FA1234BC%2Fcontacts%2Fmanage%2F1%2Frelationship%2F99%2Fedit-contact-methods%3FreturnUrl%3D%2Ffoo%26returnAnchor%3Dbar',
+          '/prisoner/A1234BC/contacts/manage/22/address/1/phone/123/edit?returnUrl=/prisoner/A1234BC/contacts/manage/1/relationship/99/edit-contact-methods',
           `Change the information about the Mobile phone phone number for this address (${expectedTitle})`,
-          '/prisoner/A1234BC/contacts/manage/22/address/1/phone/123/delete?returnUrl=%2Fprisoner%2FA1234BC%2Fcontacts%2Fmanage%2F1%2Frelationship%2F99%2Fedit-contact-methods%3FreturnUrl%3D%2Ffoo%26returnAnchor%3Dbar',
+          '/prisoner/A1234BC/contacts/manage/22/address/1/phone/123/delete?returnUrl=/prisoner/A1234BC/contacts/manage/1/relationship/99/edit-contact-methods',
           `Delete the information about the Mobile phone phone number for this address (${expectedTitle})`,
         )
         expectChangeAndDeleteItem(
           $(addressCard).find('dt:contains("Business phone")'),
           '999',
-          '/prisoner/A1234BC/contacts/manage/22/address/1/phone/321/edit?returnUrl=%2Fprisoner%2FA1234BC%2Fcontacts%2Fmanage%2F1%2Frelationship%2F99%2Fedit-contact-methods%3FreturnUrl%3D%2Ffoo%26returnAnchor%3Dbar',
+          '/prisoner/A1234BC/contacts/manage/22/address/1/phone/321/edit?returnUrl=/prisoner/A1234BC/contacts/manage/1/relationship/99/edit-contact-methods',
           `Change the information about the Business phone phone number for this address (${expectedTitle})`,
-          '/prisoner/A1234BC/contacts/manage/22/address/1/phone/321/delete?returnUrl=%2Fprisoner%2FA1234BC%2Fcontacts%2Fmanage%2F1%2Frelationship%2F99%2Fedit-contact-methods%3FreturnUrl%3D%2Ffoo%26returnAnchor%3Dbar',
+          '/prisoner/A1234BC/contacts/manage/22/address/1/phone/321/delete?returnUrl=/prisoner/A1234BC/contacts/manage/1/relationship/99/edit-contact-methods',
           `Delete the information about the Business phone phone number for this address (${expectedTitle})`,
         )
         expectSummaryListItem(
           addressCard,
           'Comments on this address',
           'Some comments',
-          '/prisoner/A1234BC/contacts/manage/22/address/edit/1/start?returnUrl=%2Fprisoner%2FA1234BC%2Fcontacts%2Fmanage%2F1%2Frelationship%2F99%2Fedit-contact-methods%3FreturnUrl%3D%2Ffoo%26returnAnchor%3Dbar',
+          '/prisoner/A1234BC/contacts/manage/22/address/edit/1/start?returnUrl=/prisoner/A1234BC/contacts/manage/1/relationship/99/edit-contact-methods',
           `Change the comments on this address (${expectedTitle})`,
         )
       },
@@ -482,7 +486,7 @@ describe('GET /contacts/manage/:contactId/relationship/:prisonerContactId/edit-c
       )
 
       const response = await request(app).get(
-        `/prisoner/${prisonerNumber}/contacts/manage/1/relationship/99/edit-contact-methods?returnUrl=/foo&returnAnchor=bar`,
+        `/prisoner/${prisonerNumber}/contacts/manage/1/relationship/99/edit-contact-methods`,
       )
       const $ = cheerio.load(response.text)
 
@@ -494,42 +498,42 @@ describe('GET /contacts/manage/:contactId/relationship/:prisonerContactId/edit-c
         addressCard,
         'Type',
         'Not provided',
-        '/prisoner/A1234BC/contacts/manage/22/address/edit/1/start?returnUrl=%2Fprisoner%2FA1234BC%2Fcontacts%2Fmanage%2F1%2Frelationship%2F99%2Fedit-contact-methods%3FreturnUrl%3D%2Ffoo%26returnAnchor%3Dbar',
+        '/prisoner/A1234BC/contacts/manage/22/address/edit/1/start?returnUrl=/prisoner/A1234BC/contacts/manage/1/relationship/99/edit-contact-methods',
         `Change the address type (Address)`,
       )
       expectSummaryListItem(
         addressCard,
         'Address',
         'No fixed addressEngland',
-        '/prisoner/A1234BC/contacts/manage/22/address/edit/1/start?returnUrl=%2Fprisoner%2FA1234BC%2Fcontacts%2Fmanage%2F1%2Frelationship%2F99%2Fedit-contact-methods%3FreturnUrl%3D%2Ffoo%26returnAnchor%3Dbar',
+        '/prisoner/A1234BC/contacts/manage/22/address/edit/1/start?returnUrl=/prisoner/A1234BC/contacts/manage/1/relationship/99/edit-contact-methods',
         `Change the address (Address)`,
       )
       expectSummaryListItem(
         addressCard,
         'Date',
         'Not provided',
-        '/prisoner/A1234BC/contacts/manage/22/address/edit/1/start?returnUrl=%2Fprisoner%2FA1234BC%2Fcontacts%2Fmanage%2F1%2Frelationship%2F99%2Fedit-contact-methods%3FreturnUrl%3D%2Ffoo%26returnAnchor%3Dbar',
+        '/prisoner/A1234BC/contacts/manage/22/address/edit/1/start?returnUrl=/prisoner/A1234BC/contacts/manage/1/relationship/99/edit-contact-methods',
         `Change the dates for the prisoner’s use of the address (Address)`,
       )
       expectSummaryListItem(
         addressCard,
         'Primary or postal address',
         'No',
-        '/prisoner/A1234BC/contacts/manage/22/address/edit/1/start?returnUrl=%2Fprisoner%2FA1234BC%2Fcontacts%2Fmanage%2F1%2Frelationship%2F99%2Fedit-contact-methods%3FreturnUrl%3D%2Ffoo%26returnAnchor%3Dbar',
+        '/prisoner/A1234BC/contacts/manage/22/address/edit/1/start?returnUrl=/prisoner/A1234BC/contacts/manage/1/relationship/99/edit-contact-methods',
         `Change if this address is set as the primary or postal address for the contact (Address)`,
       )
       expectSummaryListItem(
         addressCard,
         'Address phone numbers',
         'Not provided',
-        '/prisoner/A1234BC/contacts/manage/22/address/1/phone/create?returnUrl=%2Fprisoner%2FA1234BC%2Fcontacts%2Fmanage%2F1%2Frelationship%2F99%2Fedit-contact-methods%3FreturnUrl%3D%2Ffoo%26returnAnchor%3Dbar',
+        '/prisoner/A1234BC/contacts/manage/22/address/1/phone/create?returnUrl=/prisoner/A1234BC/contacts/manage/1/relationship/99/edit-contact-methods',
         `Change the information about the phone number for this address (Address)`,
       )
       expectSummaryListItem(
         addressCard,
         'Comments on this address',
         'Not provided',
-        '/prisoner/A1234BC/contacts/manage/22/address/edit/1/start?returnUrl=%2Fprisoner%2FA1234BC%2Fcontacts%2Fmanage%2F1%2Frelationship%2F99%2Fedit-contact-methods%3FreturnUrl%3D%2Ffoo%26returnAnchor%3Dbar',
+        '/prisoner/A1234BC/contacts/manage/22/address/edit/1/start?returnUrl=/prisoner/A1234BC/contacts/manage/1/relationship/99/edit-contact-methods',
         `Change the comments on this address (Address)`,
       )
     })
@@ -542,7 +546,7 @@ describe('GET /contacts/manage/:contactId/relationship/:prisonerContactId/edit-c
       )
 
       const response = await request(app).get(
-        `/prisoner/${prisonerNumber}/contacts/manage/1/relationship/99/edit-contact-methods?returnUrl=/foo&returnAnchor=bar`,
+        `/prisoner/${prisonerNumber}/contacts/manage/1/relationship/99/edit-contact-methods`,
       )
       const $ = cheerio.load(response.text)
       expect($('h2:contains("Addresses")').first().parent().parent().next().text()).toMatch(/No addresses provided./)
@@ -584,7 +588,7 @@ describe('GET /contacts/manage/:contactId/relationship/:prisonerContactId/edit-c
     const addAddressLink = $(`h2:contains("Addresses")`).first().parent().next().find('a').first()
     expect(addAddressLink.text()).toStrictEqual('Add address')
     expect(addAddressLink.attr('href')).toStrictEqual(
-      '/prisoner/A1234BC/contacts/manage/1/address/add/start?returnUrl=%2Fprisoner%2FA1234BC%2Fcontacts%2Fmanage%2F1%2Frelationship%2F99%2Fedit-contact-methods%3FreturnUrl%3D%2Ffoo%26returnAnchor%3Dbar',
+      '/prisoner/A1234BC/contacts/manage/1/address/add/start?returnUrl=/prisoner/A1234BC/contacts/manage/1/relationship/99/edit-contact-methods',
     )
   }
 })

--- a/server/routes/contacts/manage/edit-contact-methods/editContactMethodsController.ts
+++ b/server/routes/contacts/manage/edit-contact-methods/editContactMethodsController.ts
@@ -4,6 +4,7 @@ import { Page } from '../../../../services/auditService'
 import { ContactsService } from '../../../../services'
 import { Navigation } from '../../common/navigation'
 import ContactDetails = contactsApiClientTypes.ContactDetails
+import Urls from '../../../urls'
 
 export default class EditContactMethodsController implements PageHandler {
   constructor(private readonly contactsService: ContactsService) {}
@@ -11,16 +12,13 @@ export default class EditContactMethodsController implements PageHandler {
   public PAGE_NAME = Page.EDIT_CONTACT_METHODS_PAGE
 
   GET = async (
-    req: Request<{ prisonerNumber: string; contactId: string; prisonerContactId?: string }, unknown, unknown>,
+    req: Request<{ prisonerNumber: string; contactId: string; prisonerContactId: string }, unknown, unknown>,
     res: Response,
   ): Promise<void> => {
     const { prisonerNumber, contactId, prisonerContactId } = req.params
-    const { user, journey } = res.locals
+    const { user } = res.locals
     const contact: ContactDetails = await this.contactsService.getContact(Number(contactId), user)
-    let returnUrlWithAnchor = journey.returnPoint.url
-    if (journey.returnPoint.anchor) {
-      returnUrlWithAnchor += `#${journey.returnPoint.anchor}`
-    }
+    const returnUrlWithAnchor = Urls.contactDetails(prisonerNumber, contactId, prisonerContactId, 'contact-methods')
     const navigation: Navigation = {
       backLink: returnUrlWithAnchor,
       cancelButton: returnUrlWithAnchor,
@@ -32,7 +30,6 @@ export default class EditContactMethodsController implements PageHandler {
       contactId,
       prisonerContactId,
       navigation,
-      returnPoint: journey.returnPoint,
     })
   }
 }

--- a/server/routes/contacts/manage/manageContactsRoutes.ts
+++ b/server/routes/contacts/manage/manageContactsRoutes.ts
@@ -242,8 +242,8 @@ const ManageContactsRoutes = (
     schema: phoneNumberSchema,
   })
 
-  standAloneJourneyRoute({
-    path: '/prisoner/:prisonerNumber/contacts/manage/:contactId/phone/:contactPhoneId/delete',
+  standAloneRoute({
+    path: '/prisoner/:prisonerNumber/contacts/manage/:contactId/relationship/:prisonerContactId/phone/:contactPhoneId/delete',
     controller: new ManageContactDeletePhoneController(contactsService),
     noValidation: true,
   })
@@ -449,7 +449,6 @@ const ManageContactsRoutes = (
   get(
     '/prisoner/:prisonerNumber/contacts/manage/:contactId/relationship/:prisonerContactId/edit-contact-methods',
     new EditContactMethodsController(contactsService),
-    prepareStandaloneManageContactJourney,
   )
 
   return router

--- a/server/routes/contacts/manage/name/changeTitleOrMiddleNamesController.test.ts
+++ b/server/routes/contacts/manage/name/changeTitleOrMiddleNamesController.test.ts
@@ -8,6 +8,7 @@ import TestData from '../../../testutils/testData'
 import PatchContactRequest = contactsApiClientTypes.PatchContactRequest
 import { MockedService } from '../../../../testutils/mockedServices'
 import PatchContactResponse = contactsApiClientTypes.PatchContactResponse
+import { FLASH_KEY__SUCCESS_BANNER } from '../../../../middleware/setUpSuccessNotificationBanner'
 
 jest.mock('../../../../services/auditService')
 jest.mock('../../../../services/referenceDataService')
@@ -216,7 +217,7 @@ describe('POST /prisoner/:prisonerNumber/contacts/manage/:contactId/relationship
 
     expect(contactsService.updateContactById).toHaveBeenCalledWith(contactId, expectedRequest, user)
     expect(flashProvider).toHaveBeenCalledWith(
-      'successNotificationBanner',
+      FLASH_KEY__SUCCESS_BANNER,
       'You’ve updated the personal information for First Mid Last.',
     )
   })

--- a/server/routes/contacts/manage/name/changeTitleOrMiddleNamesController.ts
+++ b/server/routes/contacts/manage/name/changeTitleOrMiddleNamesController.ts
@@ -10,6 +10,7 @@ import { formatNameFirstNameFirst } from '../../../../utils/formatName'
 import Urls from '../../../urls'
 import ReferenceCode = contactsApiClientTypes.ReferenceCode
 import PatchContactRequest = contactsApiClientTypes.PatchContactRequest
+import { FLASH_KEY__SUCCESS_BANNER } from '../../../../middleware/setUpSuccessNotificationBanner'
 
 export default class ChangeTitleOrMiddleNamesController implements PageHandler {
   constructor(
@@ -75,7 +76,7 @@ export default class ChangeTitleOrMiddleNamesController implements PageHandler {
       .updateContactById(Number(contactId), request, user)
       .then(response =>
         req.flash(
-          'successNotificationBanner',
+          FLASH_KEY__SUCCESS_BANNER,
           `You’ve updated the personal information for ${formatNameFirstNameFirst(response)}.`,
         ),
       )

--- a/server/routes/urls.ts
+++ b/server/routes/urls.ts
@@ -3,7 +3,7 @@ export default class Urls {
     prisonerNumber: string,
     contactId: string | number,
     prisonerContactId: string | number,
-    tab?: string | undefined,
+    tab?: 'contact-details' | 'contact-methods' | undefined,
   ) => {
     return `/prisoner/${prisonerNumber}/contacts/manage/${contactId}/relationship/${prisonerContactId}${tab ? `#${tab}` : ''}`
   }
@@ -14,5 +14,13 @@ export default class Urls {
     prisonerContactId: string | number,
   ) => {
     return `/prisoner/${prisonerNumber}/contacts/manage/${contactId}/relationship/${prisonerContactId}/edit-contact-details`
+  }
+
+  static editContactMethods = (
+    prisonerNumber: string,
+    contactId: string | number,
+    prisonerContactId: string | number,
+  ) => {
+    return `/prisoner/${prisonerNumber}/contacts/manage/${contactId}/relationship/${prisonerContactId}/edit-contact-methods`
   }
 }

--- a/server/views/pages/contacts/manage/confirmDeletePhone.njk
+++ b/server/views/pages/contacts/manage/confirmDeletePhone.njk
@@ -4,21 +4,30 @@
 {% from "govuk/components/summary-list/macro.njk" import govukSummaryList %}
 
 {% set pageTitle = applicationName + " - Delete contact phone number" %}
-{% set title = "Are you sure you want to delete this phone number?" %}
+{% set title = "Are you sure you want to delete this phone number for " + (contact | formatNameFirstNameFirst) + "?" %}
 {% set mainClasses = "app-container govuk-body" %}
 
 {% block content %}
 
     {% include '../../../partials/navigation.njk' %}
     {{ miniProfile(prisonerDetails) }}
-    <span class="govuk-caption-l">Contacts</span>
-    <h1 class="govuk-heading-l" data-qa="main-heading">{{ title }}</h1>
     <div class="govuk-grid-row">
-        <div class="govuk-grid-column-three-quarters">
+        <div class="govuk-grid-column-two-thirds">
+            <span class="govuk-caption-l">Edit contact methods</span>
+            <h1 class="govuk-heading-l" data-qa="main-heading">{{ title }}</h1>
             <form method='POST'>
                 <input type="hidden" name="_csrf" value="{{ csrfToken }}" />
                 {{ govukSummaryList({
                     rows: [
+                      {
+                        key: {
+                          text: "Type"
+                        },
+                          value: {
+                            html: phone.phoneTypeDescription,
+                            classes: 'type-value'
+                          }
+                        },
                         {
                             key: {
                                 text: "Phone number"
@@ -26,15 +35,6 @@
                             value: {
                                 html: phone.phoneNumber,
                                 classes: 'phone-number-value'
-                            }
-                        },
-                        {
-                            key: {
-                                text: "Type"
-                            },
-                            value: {
-                                html: phone.phoneTypeDescription,
-                                classes: 'type-value'
                             }
                         },
                         {
@@ -62,7 +62,7 @@
                         type: "button",
                         classes: 'govuk-!-margin-top-6 govuk-button--secondary',
                         attributes: {"data-qa": "cancel-button"},
-                        href: journey.returnPoint.url,
+                        href: navigation.cancelButton,
                         preventDoubleClick: true
                     }) }}
                 </div>

--- a/server/views/pages/contacts/manage/contactDetails/details/contactMethodsTab.njk
+++ b/server/views/pages/contacts/manage/contactDetails/details/contactMethodsTab.njk
@@ -13,7 +13,7 @@
       </div>
       <div class="moj-page-header-actions__actions">
         <div class="moj-button-group moj-button-group--inline">
-          <a class="govuk-link govuk-link--no-visited-state" data-qa="edit-contact-methods-link" href="/prisoner/{{ prisonerNumber }}/contacts/manage/{{ contactId }}/relationship/{{ prisonerContactId }}/edit-contact-methods?returnUrl={{  manageContactRelationshipUrl }}&returnAnchor=contact-methods">Edit contact methods</a>
+          <a class="govuk-link govuk-link--no-visited-state" data-qa="edit-contact-methods-link" href="/prisoner/{{ prisonerNumber }}/contacts/manage/{{ contactId }}/relationship/{{ prisonerContactId }}/edit-contact-methods">Edit contact methods</a>
         </div>
       </div>
     </div>

--- a/server/views/pages/contacts/manage/contactDetails/details/editContactMethods.njk
+++ b/server/views/pages/contacts/manage/contactDetails/details/editContactMethods.njk
@@ -12,23 +12,21 @@
 
 {% block content %}
   {% include 'partials/navigation.njk' %}
-  {% include 'partials/successNotificationBanner.njk' %}
   {{ miniProfile(prisonerDetails) }}
+  {# TODO can be removed once all journies return to contact details page directly #}
+  {% include 'partials/successNotificationBanner.njk' %}
   <div class="govuk-grid-row govuk-!-static-margin-bottom-5">
     <div class="govuk-grid-column-two-thirds">
       <div class="govuk-!-static-margin-bottom-7">
         <span class="govuk-caption-l">Manage contacts</span>
         <h1 class="govuk-heading-l">Edit contact methods for {{ contact | formatNameFirstNameFirst }}</h1>
       </div>
-      {% set returnUrl = '/prisoner/' + prisonerNumber + '/contacts/manage/' + contactId + '/relationship/' + prisonerContactId + '/edit-contact-methods?returnUrl=' + returnPoint.url %}
-      {% if returnPoint.anchor %}
-        {% set returnUrl = returnUrl + '&returnAnchor=' + returnPoint.anchor %}
-      {% endif %}
-      {% set returnUrl = returnUrl | urlencode %}
+      {% set returnUrl = '/prisoner/' + prisonerNumber + '/contacts/manage/' + contactId + '/relationship/' + prisonerContactId + '/edit-contact-methods' %}
 
       {{ phoneNumbersCard({
           contact: contact,
           prisonerNumber: prisonerNumber,
+          prisonerContactId: prisonerContactId,
           returnUrl: returnUrl,
           showActions: true
         })

--- a/server/views/partials/contactMethods/phoneNumbersCard.njk
+++ b/server/views/partials/contactMethods/phoneNumbersCard.njk
@@ -6,6 +6,7 @@
   {% set showActions = opts.showActions %}
   {% set returnUrl = opts.returnUrl %}
   {% set prisonerNumber = opts.prisonerNumber %}
+  {% set prisonerContactId = opts.prisonerContactId %}
 
   {% set phoneNumbers = [] %}
   {% if contact.phoneNumbers and contact.phoneNumbers.length > 0 %}
@@ -27,7 +28,7 @@
               classes: "govuk-link--no-visited-state"
             },
             {
-              href: "/prisoner/" + prisonerNumber + "/contacts/manage/" + contact.id + "/phone/" + item.contactPhoneId + "/delete?returnUrl=" + returnUrl,
+              href: "/prisoner/" + prisonerNumber + "/contacts/manage/" + contact.id + "/relationship/" + prisonerContactId + "/phone/" + item.contactPhoneId + "/delete",
               text: "Delete",
               visuallyHiddenText: "the information about this " + item.phoneTypeDescription + " phone number",
               attributes: {"data-qa": "delete-phone-number-" + item.contactPhoneId},


### PR DESCRIPTION
Some minor text tweaks plus now returns directly to contact details on cancel or success. Made edit contact methods not require a return URL either.