### PR TITLE
PRC-451: Edit identity documents

### DIFF
--- a/integration_tests/e2e/createContactIdentity.cy.ts
+++ b/integration_tests/e2e/createContactIdentity.cy.ts
@@ -1,6 +1,6 @@
 import Page from '../pages/page'
 import TestData from '../../server/routes/testutils/testData'
-import EnterIdentityPage from '../pages/enterIdentityPage'
+import ChangeIdentityDocumentPage from '../pages/changeIdentityDocumentPage'
 import ManageContactDetailsPage from '../pages/manageContactDetails'
 import { StubIdentityDetails } from '../mockApis/contactsApi'
 import EditContactDetailsPage from '../pages/editContactDetailsPage'
@@ -64,7 +64,7 @@ context('Create Contact Identity', () => {
     Page.verifyOnPage(EditContactDetailsPage, 'First Middle Names Last') //
       .clickAddIdentityDocumentLink()
 
-    Page.verifyOnPage(EnterIdentityPage, 'First Middle Names Last') //
+    Page.verifyOnPage(ChangeIdentityDocumentPage, 'First Middle Names Last') //
       .enterIdentity('425362965')
       .selectType('PASS')
       .clickContinue()
@@ -103,7 +103,7 @@ context('Create Contact Identity', () => {
     Page.verifyOnPage(EditContactDetailsPage, 'First Middle Names Last') //
       .clickAddIdentityDocumentLink()
 
-    Page.verifyOnPage(EnterIdentityPage, 'First Middle Names Last') //
+    Page.verifyOnPage(ChangeIdentityDocumentPage, 'First Middle Names Last') //
       .enterIdentity('425362965')
       .enterIssuingAuthority('000')
       .selectType('NINO')
@@ -127,10 +127,10 @@ context('Create Contact Identity', () => {
     Page.verifyOnPage(EditContactDetailsPage, 'First Middle Names Last') //
       .clickAddIdentityDocumentLink()
 
-    const enterIdentityPage = Page.verifyOnPage(EnterIdentityPage, 'First Middle Names Last') //
+    const enterIdentityPage = Page.verifyOnPage(ChangeIdentityDocumentPage, 'First Middle Names Last') //
       .enterIdentity('425362965')
     enterIdentityPage.clickContinue()
-    enterIdentityPage.hasFieldInError('type', 'Select the type of identity number')
+    enterIdentityPage.hasFieldInError('type', 'Select the document type')
   })
 
   it('Should require identity number', () => {
@@ -140,10 +140,10 @@ context('Create Contact Identity', () => {
     Page.verifyOnPage(EditContactDetailsPage, 'First Middle Names Last') //
       .clickAddIdentityDocumentLink()
 
-    const enterIdentityPage = Page.verifyOnPage(EnterIdentityPage, 'First Middle Names Last') //
+    const enterIdentityPage = Page.verifyOnPage(ChangeIdentityDocumentPage, 'First Middle Names Last') //
       .selectType('NINO')
     enterIdentityPage.clickContinue()
-    enterIdentityPage.hasFieldInError('identity', 'Enter the identity number')
+    enterIdentityPage.hasFieldInError('identity', 'Enter the document number')
   })
 
   it('Should require identity number is 20 chars or fewer', () => {
@@ -153,11 +153,11 @@ context('Create Contact Identity', () => {
     Page.verifyOnPage(EditContactDetailsPage, 'First Middle Names Last') //
       .clickAddIdentityDocumentLink()
 
-    const enterIdentityPage = Page.verifyOnPage(EnterIdentityPage, 'First Middle Names Last') //
+    const enterIdentityPage = Page.verifyOnPage(ChangeIdentityDocumentPage, 'First Middle Names Last') //
       .selectType('NINO')
       .enterIdentity(''.padEnd(21, '0'))
     enterIdentityPage.clickContinue()
-    enterIdentityPage.hasFieldInError('identity', 'Identity number should be 20 characters or fewer')
+    enterIdentityPage.hasFieldInError('identity', 'Document number must be 20 characters or less')
   })
 
   it('Should require Issuing authority is 40 chars or fewer', () => {
@@ -167,13 +167,13 @@ context('Create Contact Identity', () => {
     Page.verifyOnPage(EditContactDetailsPage, 'First Middle Names Last') //
       .clickAddIdentityDocumentLink()
 
-    const enterIdentityPage = Page.verifyOnPage(EnterIdentityPage, 'First Middle Names Last') //
+    const enterIdentityPage = Page.verifyOnPage(ChangeIdentityDocumentPage, 'First Middle Names Last') //
       .selectType('NINO')
       .enterIdentity('0123')
       .enterIssuingAuthority(''.padEnd(41, '0'))
 
     enterIdentityPage.clickContinue()
-    enterIdentityPage.hasFieldInError('issuingAuthority', 'Issuing authority should be 40 characters or fewer')
+    enterIdentityPage.hasFieldInError('issuingAuthority', 'Issuing authority must be 40 characters or less')
   })
 
   it('Back link goes to manage contacts', () => {
@@ -183,7 +183,7 @@ context('Create Contact Identity', () => {
     Page.verifyOnPage(EditContactDetailsPage, 'First Middle Names Last') //
       .clickAddIdentityDocumentLink()
 
-    Page.verifyOnPage(EnterIdentityPage, 'First Middle Names Last') //
+    Page.verifyOnPage(ChangeIdentityDocumentPage, 'First Middle Names Last') //
       .backTo(EditContactDetailsPage, 'First Middle Names Last')
       .backTo(ManageContactDetailsPage, 'First Middle Names Last')
   })
@@ -195,7 +195,7 @@ context('Create Contact Identity', () => {
     Page.verifyOnPage(EditContactDetailsPage, 'First Middle Names Last') //
       .clickAddIdentityDocumentLink()
 
-    Page.verifyOnPage(EnterIdentityPage, 'First Middle Names Last') //
+    Page.verifyOnPage(ChangeIdentityDocumentPage, 'First Middle Names Last') //
       .cancelTo(EditContactDetailsPage, 'First Middle Names Last')
       .cancelTo(ManageContactDetailsPage, 'First Middle Names Last')
   })

--- a/integration_tests/e2e/editContactIdentity.cy.ts
+++ b/integration_tests/e2e/editContactIdentity.cy.ts
@@ -1,6 +1,6 @@
 import Page from '../pages/page'
 import TestData from '../../server/routes/testutils/testData'
-import EnterIdentityPage from '../pages/enterIdentityPage'
+import ChangeIdentityDocumentPage from '../pages/changeIdentityDocumentPage'
 import ManageContactDetailsPage from '../pages/manageContactDetails'
 import { StubIdentityDetails } from '../mockApis/contactsApi'
 import EditContactDetailsPage from '../pages/editContactDetailsPage'
@@ -39,6 +39,7 @@ context('Edit Contact Identities', () => {
         contactGlobalRestrictions: [],
       },
     })
+    cy.task('stubGetContactNameById', contact)
     cy.signIn()
     const { prisonerNumber } = TestData.prisoner()
     cy.visit(`/prisoner/${prisonerNumber}/contacts/manage/${contactId}/relationship/${prisonerContactId}`)
@@ -67,7 +68,7 @@ context('Edit Contact Identities', () => {
     Page.verifyOnPage(EditContactDetailsPage, 'First Middle Names Last') //
       .clickEditIdentityLink('LAST-8773671M')
 
-    Page.verifyOnPage(EnterIdentityPage, 'First Middle Names Last') // without issuing authority
+    Page.verifyOnPage(ChangeIdentityDocumentPage, 'First Middle Names Last') // without issuing authority
       .hasIdentity('LAST-8773671M')
       .enterIdentity('123434')
       .hasType('DL')
@@ -76,7 +77,8 @@ context('Edit Contact Identities', () => {
       .clearIssuingAuthority()
       .clickContinue()
 
-    Page.verifyOnPage(EditContactDetailsPage, 'First Middle Names Last')
+    Page.verifyOnPage(ManageContactDetailsPage, 'First Middle Names Last') //
+      .hasSuccessBanner('You’ve updated the identity documentation for First Middle Names Last.')
 
     cy.verifyLastAPICall(
       {
@@ -108,7 +110,7 @@ context('Edit Contact Identities', () => {
     Page.verifyOnPage(EditContactDetailsPage, 'First Middle Names Last') //
       .clickEditIdentityLink('LAST-8773671M')
 
-    Page.verifyOnPage(EnterIdentityPage, 'First Middle Names Last') //
+    Page.verifyOnPage(ChangeIdentityDocumentPage, 'First Middle Names Last') //
       .hasIdentity('LAST-8773671M')
       .enterIdentity('987654321')
       .hasIssuingAuthority('UK')
@@ -117,7 +119,8 @@ context('Edit Contact Identities', () => {
       .selectType('NINO')
       .clickContinue()
 
-    Page.verifyOnPage(EditContactDetailsPage, 'First Middle Names Last')
+    Page.verifyOnPage(ManageContactDetailsPage, 'First Middle Names Last') //
+      .hasSuccessBanner('You’ve updated the identity documentation for First Middle Names Last.')
 
     cy.verifyLastAPICall(
       {
@@ -135,11 +138,11 @@ context('Edit Contact Identities', () => {
     Page.verifyOnPage(EditContactDetailsPage, 'First Middle Names Last') //
       .clickEditIdentityLink('LAST-8773671M')
 
-    const enterIdentityPage = Page.verifyOnPage(EnterIdentityPage, 'First Middle Names Last') //
+    const enterIdentityPage = Page.verifyOnPage(ChangeIdentityDocumentPage, 'First Middle Names Last') //
       .selectType('')
       .enterIdentity('425362965')
     enterIdentityPage.clickContinue()
-    enterIdentityPage.hasFieldInError('type', 'Select the type of identity number')
+    enterIdentityPage.hasFieldInError('type', 'Select the document type')
   })
 
   it('Should require identity number', () => {
@@ -149,10 +152,10 @@ context('Edit Contact Identities', () => {
     Page.verifyOnPage(EditContactDetailsPage, 'First Middle Names Last') //
       .clickEditIdentityLink('LAST-8773671M')
 
-    const enterIdentityPage = Page.verifyOnPage(EnterIdentityPage, 'First Middle Names Last') //
+    const enterIdentityPage = Page.verifyOnPage(ChangeIdentityDocumentPage, 'First Middle Names Last') //
       .clearIdentity()
     enterIdentityPage.clickContinue()
-    enterIdentityPage.hasFieldInError('identity', 'Enter the identity number')
+    enterIdentityPage.hasFieldInError('identity', 'Enter the document number')
   })
 
   it('Should require identity is 20 chars or fewer', () => {
@@ -162,10 +165,10 @@ context('Edit Contact Identities', () => {
     Page.verifyOnPage(EditContactDetailsPage, 'First Middle Names Last') //
       .clickEditIdentityLink('LAST-8773671M')
 
-    const enterIdentityPage = Page.verifyOnPage(EnterIdentityPage, 'First Middle Names Last') //
+    const enterIdentityPage = Page.verifyOnPage(ChangeIdentityDocumentPage, 'First Middle Names Last') //
       .enterIdentity(''.padEnd(21, '0'))
     enterIdentityPage.clickContinue()
-    enterIdentityPage.hasFieldInError('identity', 'Identity number should be 20 characters or fewer')
+    enterIdentityPage.hasFieldInError('identity', 'Document number must be 20 characters or less')
   })
 
   it('Should require issuing authority is 7 chars or fewer', () => {
@@ -175,36 +178,35 @@ context('Edit Contact Identities', () => {
     Page.verifyOnPage(EditContactDetailsPage, 'First Middle Names Last') //
       .clickEditIdentityLink('LAST-8773671M')
 
-    const enterIdentityPage = Page.verifyOnPage(EnterIdentityPage, 'First Middle Names Last') //
+    const enterIdentityPage = Page.verifyOnPage(ChangeIdentityDocumentPage, 'First Middle Names Last') //
       .selectType('PASS')
       .enterIdentity('0123')
       .enterIssuingAuthority(''.padEnd(41, '0'))
 
     enterIdentityPage.clickContinue()
-    enterIdentityPage.hasFieldInError('issuingAuthority', 'Issuing authority should be 40 characters or fewer')
+    enterIdentityPage.hasFieldInError('issuingAuthority', 'Issuing authority must be 40 characters or less')
   })
 
-  it('Back link goes to manage contacts', () => {
+  it('Back link goes to edit contact details then contact details', () => {
     Page.verifyOnPage(ManageContactDetailsPage, 'First Middle Names Last') //
       .clickEditContactDetailsLink()
 
     Page.verifyOnPage(EditContactDetailsPage, 'First Middle Names Last') //
       .clickEditIdentityLink('LAST-8773671M')
 
-    Page.verifyOnPage(EnterIdentityPage, 'First Middle Names Last') //
+    Page.verifyOnPage(ChangeIdentityDocumentPage, 'First Middle Names Last') //
       .backTo(EditContactDetailsPage, 'First Middle Names Last')
       .backTo(ManageContactDetailsPage, 'First Middle Names Last')
   })
 
-  it('Cancel goes to manage contacts', () => {
+  it('Cancel goes to contact details', () => {
     Page.verifyOnPage(ManageContactDetailsPage, 'First Middle Names Last') //
       .clickEditContactDetailsLink()
 
     Page.verifyOnPage(EditContactDetailsPage, 'First Middle Names Last') //
       .clickEditIdentityLink('LAST-8773671M')
 
-    Page.verifyOnPage(EnterIdentityPage, 'First Middle Names Last') //
-      .cancelTo(EditContactDetailsPage, 'First Middle Names Last')
+    Page.verifyOnPage(ChangeIdentityDocumentPage, 'First Middle Names Last') //
       .cancelTo(ManageContactDetailsPage, 'First Middle Names Last')
   })
 })

--- a/integration_tests/mockApis/contactsApi.ts
+++ b/integration_tests/mockApis/contactsApi.ts
@@ -109,6 +109,33 @@ export default {
     })
   },
 
+  stubGetContactNameById: (contact: {
+    id: number
+    titleCode?: string | undefined
+    titleDescription?: string | undefined
+    lastName?: string | undefined
+    firstName?: string | undefined
+    middleNames?: string | undefined
+  }): SuperAgentRequest => {
+    return stubFor({
+      request: {
+        method: 'GET',
+        urlPath: `/contact/${contact.id}/name`,
+      },
+      response: {
+        status: 200,
+        headers: { 'Content-Type': 'application/json;charset=UTF-8' },
+        jsonBody: {
+          titleCode: contact.titleCode,
+          titleDescription: contact.titleDescription,
+          lastName: contact.lastName,
+          firstName: contact.firstName,
+          middleNames: contact.middleNames,
+        },
+      },
+    })
+  },
+
   stubGetGlobalRestrictions: (globalRestrictions: ContactRestrictionDetails[]): SuperAgentRequest => {
     return stubFor({
       request: {

--- a/integration_tests/pages/changeIdentityDocumentPage.ts
+++ b/integration_tests/pages/changeIdentityDocumentPage.ts
@@ -1,46 +1,46 @@
 import Page, { PageElement } from './page'
 
-export default class EnterIdentityPage extends Page {
+export default class ChangeIdentityDocumentPage extends Page {
   constructor(name: string) {
-    super(`What is the identity number for ${name}?`)
+    super(`Update an identity document for ${name}`)
   }
 
-  hasIdentity(value: string): EnterIdentityPage {
+  hasIdentity(value: string): ChangeIdentityDocumentPage {
     this.identityTextBox().should('have.value', value)
     return this
   }
 
-  enterIdentity(value: string): EnterIdentityPage {
+  enterIdentity(value: string): ChangeIdentityDocumentPage {
     this.identityTextBox().clear().type(value, { delay: 0 })
     return this
   }
 
-  clearIdentity(): EnterIdentityPage {
+  clearIdentity(): ChangeIdentityDocumentPage {
     this.identityTextBox().clear()
     return this
   }
 
-  selectType(value: string): EnterIdentityPage {
+  selectType(value: string): ChangeIdentityDocumentPage {
     this.typeSelect().select(value)
     return this
   }
 
-  hasType(value: string): EnterIdentityPage {
+  hasType(value: string): ChangeIdentityDocumentPage {
     this.typeSelect().should('have.value', value)
     return this
   }
 
-  enterIssuingAuthority(value: string): EnterIdentityPage {
+  enterIssuingAuthority(value: string): ChangeIdentityDocumentPage {
     this.issuingAuthorityTextBox().clear().type(value, { delay: 0 })
     return this
   }
 
-  hasIssuingAuthority(value: string): EnterIdentityPage {
+  hasIssuingAuthority(value: string): ChangeIdentityDocumentPage {
     this.issuingAuthorityTextBox().should('have.value', value)
     return this
   }
 
-  clearIssuingAuthority(): EnterIdentityPage {
+  clearIssuingAuthority(): ChangeIdentityDocumentPage {
     this.issuingAuthorityTextBox().clear()
     return this
   }

--- a/server/data/contactsApiClient.ts
+++ b/server/data/contactsApiClient.ts
@@ -42,6 +42,7 @@ type UpdateEmailRequest = components['schemas']['UpdateEmailRequest']
 type ContactEmailDetails = components['schemas']['ContactEmailDetails']
 type AddContactRelationshipRequest = components['schemas']['AddContactRelationshipRequest']
 type CreateContactRequest = components['schemas']['CreateContactRequest']
+type ContactNameDetails = components['schemas']['ContactNameDetails']
 
 export default class ContactsApiClient extends RestClient {
   constructor() {
@@ -120,6 +121,10 @@ export default class ContactsApiClient extends RestClient {
 
   async getContact(contactId: number, user: Express.User): Promise<ContactDetails> {
     return this.get<ContactDetails>({ path: `/contact/${contactId}` }, user)
+  }
+
+  async getContactName(contactId: number, user: Express.User): Promise<ContactNameDetails> {
+    return this.get<ContactNameDetails>({ path: `/contact/${contactId}/name` }, user)
   }
 
   async getPrisonerContactRelationship(

--- a/server/routes/contacts/manage/edit-contact-details/editContactDetailsController.test.ts
+++ b/server/routes/contacts/manage/edit-contact-details/editContactDetailsController.test.ts
@@ -398,7 +398,7 @@ describe('GET /contacts/manage/:contactId/relationship/:prisonerContactId/edit-c
         'Change the information about this Passport number (Identity documentation)',
       )
       expect(firstPassportHeading.next().next().find('a').first().attr('href')).toStrictEqual(
-        '/prisoner/A1234BC/contacts/manage/22/identity/3/edit?returnUrl=/prisoner/A1234BC/contacts/manage/1/relationship/99/edit-contact-details',
+        '/prisoner/A1234BC/contacts/manage/22/relationship/99/identity/3/edit',
       )
       expect(firstPassportHeading.next().next().find('a').last().text()).toStrictEqual(
         'Delete the information about this Passport number (Identity documentation)',
@@ -414,7 +414,7 @@ describe('GET /contacts/manage/:contactId/relationship/:prisonerContactId/edit-c
         'Change the information about this Passport number (Identity documentation)',
       )
       expect(secondPassportHeading.next().next().find('a').first().attr('href')).toStrictEqual(
-        '/prisoner/A1234BC/contacts/manage/22/identity/2/edit?returnUrl=/prisoner/A1234BC/contacts/manage/1/relationship/99/edit-contact-details',
+        '/prisoner/A1234BC/contacts/manage/22/relationship/99/identity/2/edit',
       )
       expect(secondPassportHeading.next().next().find('a').last().text()).toStrictEqual(
         'Delete the information about this Passport number (Identity documentation)',

--- a/server/routes/contacts/manage/identities/IdentitySchemas.test.ts
+++ b/server/routes/contacts/manage/identities/IdentitySchemas.test.ts
@@ -23,7 +23,7 @@ describe('identitySchemaFactory', () => {
       // Then
       expect(result.success).toStrictEqual(false)
       const deduplicatedFieldErrors = deduplicateFieldErrors(result.error!)
-      expect(deduplicatedFieldErrors).toStrictEqual({ type: ['Select the type of identity number'] })
+      expect(deduplicatedFieldErrors).toStrictEqual({ type: ['Select the document type'] })
     })
 
     it('should require identity number', async () => {
@@ -36,7 +36,7 @@ describe('identitySchemaFactory', () => {
       // Then
       expect(result.success).toStrictEqual(false)
       const deduplicatedFieldErrors = deduplicateFieldErrors(result.error!)
-      expect(deduplicatedFieldErrors).toStrictEqual({ identity: ['Enter the identity number'] })
+      expect(deduplicatedFieldErrors).toStrictEqual({ identity: ['Enter the document number'] })
     })
 
     it('identity number should be limited to 20 chars', async () => {
@@ -54,7 +54,7 @@ describe('identitySchemaFactory', () => {
       expect(result.success).toStrictEqual(false)
       const deduplicatedFieldErrors = deduplicateFieldErrors(result.error!)
       expect(deduplicatedFieldErrors).toStrictEqual({
-        identity: ['Identity number should be 20 characters or fewer'],
+        identity: ['Document number must be 20 characters or less'],
       })
     })
 
@@ -73,7 +73,7 @@ describe('identitySchemaFactory', () => {
       expect(result.success).toStrictEqual(false)
       const deduplicatedFieldErrors = deduplicateFieldErrors(result.error!)
       expect(deduplicatedFieldErrors).toStrictEqual({
-        issuingAuthority: ['Issuing authority should be 40 characters or fewer'],
+        issuingAuthority: ['Issuing authority must be 40 characters or less'],
       })
     })
 
@@ -87,7 +87,9 @@ describe('identitySchemaFactory', () => {
       // Then
       expect(result.success).toStrictEqual(false)
       const deduplicatedFieldErrors = deduplicateFieldErrors(result.error!)
-      expect(deduplicatedFieldErrors).toStrictEqual({ identity: ['Enter a PNC number in the correct format'] })
+      expect(deduplicatedFieldErrors).toStrictEqual({
+        identity: ['Enter a PNC number in the correct format – for example, ‘22/1234567A’'],
+      })
     })
 
     it('should accept PNC numbers in required format', async () => {
@@ -117,9 +119,9 @@ describe('identitySchemaFactory', () => {
       const deduplicatedFieldErrors = deduplicateFieldErrors(result.error!)
       expect(JSON.stringify(deduplicatedFieldErrors)).toBe(
         JSON.stringify({
-          identity: ['Enter the identity number'],
-          type: ['Select the type of identity number'],
-          issuingAuthority: ['Issuing authority should be 40 characters or fewer'],
+          type: ['Select the document type'],
+          identity: ['Enter the document number'],
+          issuingAuthority: ['Issuing authority must be 40 characters or less'],
         }),
       )
     })

--- a/server/routes/contacts/manage/identities/IdentitySchemas.ts
+++ b/server/routes/contacts/manage/identities/IdentitySchemas.ts
@@ -2,23 +2,23 @@ import { z } from 'zod'
 import { createSchema } from '../../../../middleware/validationMiddleware'
 import isValidPNC from '../../../../utils/pncValidation'
 
-const TYPE_REQUIRED_MESSAGE = 'Select the type of identity number'
+const TYPE_REQUIRED_MESSAGE = 'Select the document type'
 
-const IDENTITY_NUMBER_REQUIRED_MESSAGE = 'Enter the identity number'
-const IDENTITY_NUMBER_TOO_LONG_ERROR_MSG = 'Identity number should be 20 characters or fewer'
+const IDENTITY_NUMBER_REQUIRED_MESSAGE = 'Enter the document number'
+const IDENTITY_NUMBER_TOO_LONG_ERROR_MSG = 'Document number must be 20 characters or less'
 
-const ISSUING_AUTHORITY_TOO_LONG_ERROR_MSG = 'Issuing authority should be 40 characters or fewer'
+const ISSUING_AUTHORITY_TOO_LONG_ERROR_MSG = 'Issuing authority must be 40 characters or less'
 
-const PNC_INVALID_MSG = 'Enter a PNC number in the correct format'
+const PNC_INVALID_MSG = 'Enter a PNC number in the correct format – for example, ‘22/1234567A’'
 
 export const identitySchema = createSchema({
+  type: z
+    .string({ message: TYPE_REQUIRED_MESSAGE })
+    .refine(val => val?.trim().length > 0, { message: TYPE_REQUIRED_MESSAGE }),
   identity: z
     .string({ message: IDENTITY_NUMBER_REQUIRED_MESSAGE })
     .max(20, IDENTITY_NUMBER_TOO_LONG_ERROR_MSG)
     .refine(val => val?.trim().length > 0, { message: IDENTITY_NUMBER_REQUIRED_MESSAGE }),
-  type: z
-    .string({ message: TYPE_REQUIRED_MESSAGE })
-    .refine(val => val?.trim().length > 0, { message: TYPE_REQUIRED_MESSAGE }),
   issuingAuthority: z
     .string()
     .max(40, ISSUING_AUTHORITY_TOO_LONG_ERROR_MSG)

--- a/server/routes/contacts/manage/identities/add/manageContactAddIdentityController.test.ts
+++ b/server/routes/contacts/manage/identities/add/manageContactAddIdentityController.test.ts
@@ -62,7 +62,7 @@ describe('GET /prisoner/:prisonerNumber/contacts/manage/:contactId/identity/crea
 
     const $ = cheerio.load(response.text)
     expect($('[data-qa=main-heading]').first().text().trim()).toStrictEqual(
-      'What is the identity number for First Middle Last?',
+      'Update an identity document for First Middle Last',
     )
     expect($('[data-qa=cancel-button]').first().attr('href')).toStrictEqual('/foo-bar')
     expect($('[data-qa=back-link]').first().attr('href')).toStrictEqual('/foo-bar')

--- a/server/routes/contacts/manage/identities/add/manageContactAddIdentityController.ts
+++ b/server/routes/contacts/manage/identities/add/manageContactAddIdentityController.ts
@@ -5,9 +5,9 @@ import ReferenceCodeType from '../../../../../enumeration/referenceCodeType'
 import ReferenceDataService from '../../../../../services/referenceDataService'
 import { IdentitySchemaType } from '../IdentitySchemas'
 import { ContactsService } from '../../../../../services'
-import ReferenceCode = contactsApiClientTypes.ReferenceCode
-import ContactDetails = contactsApiClientTypes.ContactDetails
 import { Navigation } from '../../../common/navigation'
+import { referenceCodesToOptions } from '../../../../../utils/utils'
+import ContactDetails = contactsApiClientTypes.ContactDetails
 
 export default class ManageContactAddIdentityController implements PageHandler {
   constructor(
@@ -23,8 +23,8 @@ export default class ManageContactAddIdentityController implements PageHandler {
     const contact: ContactDetails = await this.contactsService.getContact(parseInt(contactId, 10), user)
     const typeOptions = await this.referenceDataService
       .getReferenceData(ReferenceCodeType.ID_TYPE, user)
-      .then(val => this.getSelectedOptions(val, res.locals?.formResponses?.['type']))
-    const navigation: Navigation = { backLink: journey.returnPoint.url }
+      .then(val => referenceCodesToOptions(val, res.locals?.formResponses?.['type'], 'Select document type'))
+    const navigation: Navigation = { backLink: journey.returnPoint.url, cancelButton: journey.returnPoint.url }
     const viewModel = {
       typeOptions,
       identity: res.locals?.formResponses?.['identity'],
@@ -33,7 +33,7 @@ export default class ManageContactAddIdentityController implements PageHandler {
       contact,
       navigation,
     }
-    res.render('pages/contacts/manage/addEditIdentity', viewModel)
+    res.render('pages/contacts/manage/editIdentity', viewModel)
   }
 
   POST = async (
@@ -46,23 +46,5 @@ export default class ManageContactAddIdentityController implements PageHandler {
     const { identity, type, issuingAuthority } = req.body
     await this.contactsService.createContactIdentity(parseInt(contactId, 10), user, type, identity, issuingAuthority)
     res.redirect(journey.returnPoint.url)
-  }
-
-  private getSelectedOptions(
-    options: ReferenceCode[],
-    selectedType?: string,
-  ): Array<{
-    value: string
-    text: string
-    selected?: boolean
-  }> {
-    const mappedOptions = options.map((referenceCode: ReferenceCode) => {
-      return {
-        text: referenceCode.description,
-        value: referenceCode.code,
-        selected: referenceCode.code === selectedType,
-      }
-    })
-    return [{ text: '', value: '' }, ...mappedOptions]
   }
 }

--- a/server/routes/contacts/manage/manageContactsRoutes.ts
+++ b/server/routes/contacts/manage/manageContactsRoutes.ts
@@ -279,8 +279,8 @@ const ManageContactsRoutes = (
     schema: identitySchema,
   })
 
-  standAloneJourneyRoute({
-    path: '/prisoner/:prisonerNumber/contacts/manage/:contactId/identity/:contactIdentityId/edit',
+  standAloneRoute({
+    path: '/prisoner/:prisonerNumber/contacts/manage/:contactId/relationship/:prisonerContactId/identity/:contactIdentityId/edit',
     controller: new ManageContactEditIdentityController(contactsService, referenceDataService),
     schema: identitySchema,
   })

--- a/server/routes/testutils/testData.ts
+++ b/server/routes/testutils/testData.ts
@@ -3,6 +3,7 @@ import { components } from '../../@types/contactsApi'
 
 type ContactSearchResultItem = components['schemas']['ContactSearchResultItem']
 type ContactDetails = components['schemas']['ContactDetails']
+type ContactNameDetails = components['schemas']['ContactNameDetails']
 type ContactAddressDetails = components['schemas']['ContactAddressDetails']
 type ContactPhoneDetails = components['schemas']['ContactPhoneDetails']
 type ContactPhoneNumberDetails = components['schemas']['ContactPhoneDetails']
@@ -339,6 +340,21 @@ export default class TestData {
       domesticStatusDescription,
       employments,
     }) as ContactDetails
+
+  static contactName = ({
+    titleCode = 'MR',
+    titleDescription = 'Mr',
+    lastName = 'Mason',
+    firstName = 'Jones',
+    middleNames = undefined,
+  }: Partial<ContactNameDetails> = {}): ContactNameDetails =>
+    ({
+      titleCode,
+      titleDescription,
+      lastName,
+      firstName,
+      middleNames,
+    }) as ContactNameDetails
 
   static prisonerContactRelationship = ({
     prisonerContactId = 99,

--- a/server/services/contactsService.ts
+++ b/server/services/contactsService.ts
@@ -30,6 +30,7 @@ type CreateEmailRequest = components['schemas']['CreateEmailRequest']
 type ContactEmailDetails = components['schemas']['ContactEmailDetails']
 type CreateContactRequest = components['schemas']['CreateContactRequest']
 type AddContactRelationshipRequest = components['schemas']['AddContactRelationshipRequest']
+type ContactNameDetails = components['schemas']['ContactNameDetails']
 
 export default class ContactsService {
   constructor(private readonly contactsApiClient: ContactsApiClient) {}
@@ -107,6 +108,10 @@ export default class ContactsService {
 
   async getContact(contactId: number, user: Express.User): Promise<ContactDetails> {
     return this.contactsApiClient.getContact(contactId, user)
+  }
+
+  async getContactName(contactId: number, user: Express.User): Promise<ContactNameDetails> {
+    return this.contactsApiClient.getContactName(contactId, user)
   }
 
   async getPrisonerContactRelationship(

--- a/server/utils/utils.ts
+++ b/server/utils/utils.ts
@@ -1,5 +1,6 @@
 import { format, isValid, parseISO } from 'date-fns'
 import DateOfBirth = journeys.DateOfBirth
+import ReferenceCode = contactsApiClientTypes.ReferenceCode
 
 const isBlank = (str?: string): boolean => !str || /^\s*$/.test(str)
 
@@ -143,4 +144,23 @@ export const isDateAndInThePast = (date?: string): boolean => {
     return expirationDate.getTime() < new Date().getTime()
   }
   return false
+}
+
+export const referenceCodesToOptions = (
+  options: ReferenceCode[],
+  selectedType?: string | undefined,
+  defaultLabel?: string | undefined,
+): Array<{
+  value: string
+  text: string
+  selected?: boolean
+}> => {
+  const mappedOptions = options.map((referenceCode: ReferenceCode) => {
+    return {
+      text: referenceCode.description,
+      value: referenceCode.code,
+      selected: referenceCode.code === selectedType,
+    }
+  })
+  return [{ text: defaultLabel ?? '', value: '' }, ...mappedOptions]
 }

--- a/server/views/pages/contacts/manage/editIdentity.njk
+++ b/server/views/pages/contacts/manage/editIdentity.njk
@@ -5,7 +5,7 @@
 {% from "govuk/components/button/macro.njk" import govukButton %}
 
 {% set pageTitle = applicationName + " - Create Identity number" %}
-{% set title = "What is the identity number for " + (contact | formatNameFirstNameFirst) + "?" %}
+{% set title = "Update an identity document for " + (contact | formatNameFirstNameFirst) %}
 {% set mainClasses = "app-container govuk-body" %}
 
 {% block content %}
@@ -13,38 +13,38 @@
     {% include '../../../partials/navigation.njk' %}
     {{ miniProfile(prisonerDetails) }}
     {% include '../../../partials/formErrorSummary.njk' %}
-    <span class="govuk-caption-l">Contacts</span>
+    <span class="govuk-caption-l">Edit identity documentation for a contact</span>
     <h1 class="govuk-heading-l" data-qa="main-heading">{{ title }}</h1>
     <div class="govuk-grid-row">
         <div class="govuk-grid-column-three-quarters">
             <form method='POST'>
                 <input type="hidden" name="_csrf" value="{{ csrfToken }}" />
 
+              {{ govukSelect({
+                id: "type",
+                name: "type",
+                label: {
+                  text: "Document type"
+                },
+                classes: 'govuk-!-width-one-quarter',
+                items: typeOptions,
+                errorMessage: validationErrors | findError('type')
+              }) }}
+
                 {{ govukInput({
                     id: "identity",
                     name: "identity",
-                    label: { text: "Identity number" },
+                    label: { text: "Document number" },
                     classes: 'govuk-!-width-one-third',
                     errorMessage: validationErrors | findError('identity'),
                     value: identity
                 }) }}
 
-                {{ govukSelect({
-                    id: "type",
-                    name: "type",
-                    label: {
-                        text: "Type"
-                    },
-                    items: typeOptions,
-                    errorMessage: validationErrors | findError('type')
-                }) }}
-
-
                 {{ govukInput({
                     id: "issuingAuthority",
                     name: "issuingAuthority",
-                    label: { text: "Issuing authority" },
-                    classes: 'govuk-!-width-one-third',
+                    label: { text: "Issuing authority (optional)" },
+                    classes: 'govuk-!-width-one-half',
                     errorMessage: validationErrors | findError('issuingAuthority'),
                     value: issuingAuthority
                 }) }}
@@ -57,7 +57,9 @@
                         attributes: {"data-qa": "continue-button"},
                         preventDoubleClick: true
                     }) }}
-                    <a class="govuk-link govuk-link--no-visited-state govuk-!-font-size-19" href="{{ journey.returnPoint.url }}" data-qa="cancel-button">Cancel</a>
+                    {% if navigation.cancelButton %}
+                    <a class="govuk-link govuk-link--no-visited-state govuk-!-font-size-19" href="{{ navigation.cancelButton }}" data-qa="cancel-button">Cancel</a>
+                    {% endif %}
                 </div>
             </form>
 

--- a/server/views/partials/contactDetails/identityDocumentationCard.njk
+++ b/server/views/partials/contactDetails/identityDocumentationCard.njk
@@ -14,7 +14,7 @@
       {% set actions = [] %}
       {% if item.identityTypeIsActive == true %}
         {% set actions = actions.concat([{
-          href: "/prisoner/" + prisonerNumber + "/contacts/manage/" + contact.id + "/identity/" + item.contactIdentityId + "/edit?returnUrl=" + returnUrl,
+          href: "/prisoner/" + prisonerNumber + "/contacts/manage/" + contact.id + "/relationship/" + prisonerContactId + "/identity/" + item.contactIdentityId + "/edit",
           text: "Change",
           visuallyHiddenText: "the information about this " + item.identityTypeDescription,
           attributes: {"data-qa": "edit-identity-number-" + item.contactIdentityId},


### PR DESCRIPTION
Updated design of edit identity documents. New errors, caption and heading plus re-order the fields.

Add identity document temporarily sharing the edit njk until next PR.

![Screenshot 2025-03-03 at 11 18 45](https://github.com/user-attachments/assets/4e4af388-d322-40df-99ae-9d533fcb7625)

![Screenshot 2025-03-03 at 11 19 11](https://github.com/user-attachments/assets/3294c302-1725-4f71-8d66-5124d9fc9646)
