### PR TITLE
PRC-281: Linked prisoners tab

### DIFF
--- a/integration_tests/e2e/addAddress.cy.ts
+++ b/integration_tests/e2e/addAddress.cy.ts
@@ -42,6 +42,7 @@ context('Add Address', () => {
         contactGlobalRestrictions: [],
       },
     })
+    cy.task('stubGetLinkedPrisoners', { contactId, linkedPrisoners: [] })
     cy.signIn()
     cy.visit(`/prisoner/${prisonerNumber}/contacts/manage/${contactId}/relationship/${prisonerContactId}`)
 

--- a/integration_tests/e2e/changeContactDateOfBirth.cy.ts
+++ b/integration_tests/e2e/changeContactDateOfBirth.cy.ts
@@ -23,6 +23,7 @@ context('Change Contact Date Of Birth', () => {
         contactGlobalRestrictions: [],
       },
     })
+    cy.task('stubGetLinkedPrisoners', { contactId, linkedPrisoners: [] })
     cy.signIn()
   })
 

--- a/integration_tests/e2e/changeContactTitleOrMiddleNames.cy.ts
+++ b/integration_tests/e2e/changeContactTitleOrMiddleNames.cy.ts
@@ -23,6 +23,7 @@ context('Change Contact Title Or Middle Names', () => {
         contactGlobalRestrictions: [],
       },
     })
+    cy.task('stubGetLinkedPrisoners', { contactId, linkedPrisoners: [] })
     cy.signIn()
   })
 

--- a/integration_tests/e2e/changeDateOfDeath.cy.ts
+++ b/integration_tests/e2e/changeDateOfDeath.cy.ts
@@ -37,6 +37,7 @@ context('Change date of death', () => {
         contactGlobalRestrictions: [],
       },
     })
+    cy.task('stubGetLinkedPrisoners', { contactId, linkedPrisoners: [] })
     cy.signIn()
     const { prisonerNumber } = TestData.prisoner()
     cy.visit(`/prisoner/${prisonerNumber}/contacts/manage/${contactId}/relationship/${prisonerContactId}`)

--- a/integration_tests/e2e/changeRelationshipToPrisoner.cy.ts
+++ b/integration_tests/e2e/changeRelationshipToPrisoner.cy.ts
@@ -33,7 +33,7 @@ context('Change Relationship To Prisoner', () => {
         contactGlobalRestrictions: [],
       },
     })
-
+    cy.task('stubGetLinkedPrisoners', { contactId, linkedPrisoners: [] })
     cy.signIn()
   })
 

--- a/integration_tests/e2e/changeRelationshipType.cy.ts
+++ b/integration_tests/e2e/changeRelationshipType.cy.ts
@@ -34,7 +34,7 @@ context('Change Relationship Type', () => {
         contactGlobalRestrictions: [],
       },
     })
-
+    cy.task('stubGetLinkedPrisoners', { contactId, linkedPrisoners: [] })
     cy.signIn()
   })
 

--- a/integration_tests/e2e/createAddressPhone.cy.ts
+++ b/integration_tests/e2e/createAddressPhone.cy.ts
@@ -44,6 +44,7 @@ context('Create Address Phones', () => {
         contactGlobalRestrictions: [],
       },
     })
+    cy.task('stubGetLinkedPrisoners', { contactId, linkedPrisoners: [] })
     cy.signIn()
     const { prisonerNumber } = TestData.prisoner()
     cy.visit(`/prisoner/${prisonerNumber}/contacts/manage/${contactId}/relationship/${prisonerContactId}`)

--- a/integration_tests/e2e/createContactGlobalRestriction.cy.ts
+++ b/integration_tests/e2e/createContactGlobalRestriction.cy.ts
@@ -37,7 +37,7 @@ context('Create Contact Global Restriction', () => {
         contactGlobalRestrictions: [],
       },
     })
-
+    cy.task('stubGetLinkedPrisoners', { contactId, linkedPrisoners: [] })
     cy.signIn()
 
     cy.visit(`/prisoner/${prisonerNumber}/contacts/manage/${contactId}/relationship/${prisonerContactId}`)

--- a/integration_tests/e2e/createContactIdentity.cy.ts
+++ b/integration_tests/e2e/createContactIdentity.cy.ts
@@ -40,6 +40,7 @@ context('Create Contact Identity', () => {
         contactGlobalRestrictions: [],
       },
     })
+    cy.task('stubGetLinkedPrisoners', { contactId, linkedPrisoners: [] })
     cy.signIn()
     const { prisonerNumber } = TestData.prisoner()
     cy.visit(`/prisoner/${prisonerNumber}/contacts/manage/${contactId}/relationship/${prisonerContactId}`)

--- a/integration_tests/e2e/createContactPhone.cy.ts
+++ b/integration_tests/e2e/createContactPhone.cy.ts
@@ -38,6 +38,7 @@ context('Create Contact Phones', () => {
         contactGlobalRestrictions: [],
       },
     })
+    cy.task('stubGetLinkedPrisoners', { contactId, linkedPrisoners: [] })
     cy.signIn()
     const { prisonerNumber } = TestData.prisoner()
     cy.visit(`/prisoner/${prisonerNumber}/contacts/manage/${contactId}/relationship/${prisonerContactId}`)

--- a/integration_tests/e2e/createContacts.cy.ts
+++ b/integration_tests/e2e/createContacts.cy.ts
@@ -61,7 +61,7 @@ context('Create Contacts', () => {
         contactGlobalRestrictions: [],
       },
     })
-
+    cy.task('stubGetLinkedPrisoners', { contactId, linkedPrisoners: [] })
     cy.signIn()
     const { prisonerNumber } = TestData.prisoner()
     cy.visit(`/prisoner/${prisonerNumber}/contacts/list`)

--- a/integration_tests/e2e/createEmail.cy.ts
+++ b/integration_tests/e2e/createEmail.cy.ts
@@ -27,6 +27,7 @@ context('Create Email Address', () => {
         contactGlobalRestrictions: [],
       },
     })
+    cy.task('stubGetLinkedPrisoners', { contactId, linkedPrisoners: [] })
     cy.signIn()
     const { prisonerNumber } = TestData.prisoner()
     cy.visit(`/prisoner/${prisonerNumber}/contacts/manage/${contactId}/relationship/${prisonerContactId}`)

--- a/integration_tests/e2e/createPrisonerContactRestriction.cy.ts
+++ b/integration_tests/e2e/createPrisonerContactRestriction.cy.ts
@@ -38,7 +38,7 @@ context('Create Prisoner Contact Restriction', () => {
         contactGlobalRestrictions: [],
       },
     })
-
+    cy.task('stubGetLinkedPrisoners', { contactId, linkedPrisoners: [] })
     cy.signIn()
 
     cy.visit(`/prisoner/${prisonerNumber}/contacts/manage/${contactId}/relationship/${prisonerContactId}`)

--- a/integration_tests/e2e/deleteAddressPhone.cy.ts
+++ b/integration_tests/e2e/deleteAddressPhone.cy.ts
@@ -59,6 +59,7 @@ context('Delete Address Phones', () => {
         contactGlobalRestrictions: [],
       },
     })
+    cy.task('stubGetLinkedPrisoners', { contactId, linkedPrisoners: [] })
     cy.signIn()
     const { prisonerNumber } = TestData.prisoner()
     cy.visit(`/prisoner/${prisonerNumber}/contacts/manage/${contactId}/relationship/${prisonerContactId}`)

--- a/integration_tests/e2e/deleteContactEmail.cy.ts
+++ b/integration_tests/e2e/deleteContactEmail.cy.ts
@@ -36,6 +36,7 @@ context('Delete Contact Email', () => {
         contactGlobalRestrictions: [],
       },
     })
+    cy.task('stubGetLinkedPrisoners', { contactId, linkedPrisoners: [] })
     cy.signIn()
     const { prisonerNumber } = TestData.prisoner()
     cy.visit(`/prisoner/${prisonerNumber}/contacts/manage/${contactId}/relationship/${prisonerContactId}`)

--- a/integration_tests/e2e/deleteContactIdentity.cy.ts
+++ b/integration_tests/e2e/deleteContactIdentity.cy.ts
@@ -38,6 +38,7 @@ context('Delete Contact Identity', () => {
         contactGlobalRestrictions: [],
       },
     })
+    cy.task('stubGetLinkedPrisoners', { contactId, linkedPrisoners: [] })
     cy.signIn()
     const { prisonerNumber } = TestData.prisoner()
     cy.visit(`/prisoner/${prisonerNumber}/contacts/manage/${contactId}/relationship/${prisonerContactId}`)

--- a/integration_tests/e2e/deleteContactPhone.cy.ts
+++ b/integration_tests/e2e/deleteContactPhone.cy.ts
@@ -38,6 +38,7 @@ context('Delete Contact Phones', () => {
         contactGlobalRestrictions: [],
       },
     })
+    cy.task('stubGetLinkedPrisoners', { contactId, linkedPrisoners: [] })
     cy.signIn()
     const { prisonerNumber } = TestData.prisoner()
     cy.visit(`/prisoner/${prisonerNumber}/contacts/manage/${contactId}/relationship/${prisonerContactId}`)

--- a/integration_tests/e2e/deleteDateOfDeath.cy.ts
+++ b/integration_tests/e2e/deleteDateOfDeath.cy.ts
@@ -37,6 +37,7 @@ context('Delete date of death', () => {
         contactGlobalRestrictions: [],
       },
     })
+    cy.task('stubGetLinkedPrisoners', { contactId, linkedPrisoners: [] })
     cy.signIn()
     const { prisonerNumber } = TestData.prisoner()
     cy.visit(`/prisoner/${prisonerNumber}/contacts/manage/${contactId}/relationship/${prisonerContactId}`)

--- a/integration_tests/e2e/editAddress.cy.ts
+++ b/integration_tests/e2e/editAddress.cy.ts
@@ -33,6 +33,7 @@ context('Edit Address', () => {
         contactGlobalRestrictions: [],
       },
     })
+    cy.task('stubGetLinkedPrisoners', { contactId, linkedPrisoners: [] })
     cy.signIn()
   })
 

--- a/integration_tests/e2e/editAddressPhone.cy.ts
+++ b/integration_tests/e2e/editAddressPhone.cy.ts
@@ -60,6 +60,7 @@ context('Edit Address Phones', () => {
         contactGlobalRestrictions: [],
       },
     })
+    cy.task('stubGetLinkedPrisoners', { contactId, linkedPrisoners: [] })
     cy.signIn()
     const { prisonerNumber } = TestData.prisoner()
     cy.visit(`/prisoner/${prisonerNumber}/contacts/manage/${contactId}/relationship/${prisonerContactId}`)

--- a/integration_tests/e2e/editContactIdentity.cy.ts
+++ b/integration_tests/e2e/editContactIdentity.cy.ts
@@ -39,6 +39,7 @@ context('Edit Contact Identities', () => {
         contactGlobalRestrictions: [],
       },
     })
+    cy.task('stubGetLinkedPrisoners', { contactId, linkedPrisoners: [] })
     cy.task('stubGetContactNameById', contact)
     cy.signIn()
     const { prisonerNumber } = TestData.prisoner()

--- a/integration_tests/e2e/editContactPhone.cy.ts
+++ b/integration_tests/e2e/editContactPhone.cy.ts
@@ -38,6 +38,7 @@ context('Edit Contact Phones', () => {
         contactGlobalRestrictions: [],
       },
     })
+    cy.task('stubGetLinkedPrisoners', { contactId, linkedPrisoners: [] })
     cy.signIn()
     const { prisonerNumber } = TestData.prisoner()
     cy.visit(`/prisoner/${prisonerNumber}/contacts/manage/${contactId}/relationship/${prisonerContactId}`)

--- a/integration_tests/e2e/editEmail.cy.ts
+++ b/integration_tests/e2e/editEmail.cy.ts
@@ -35,6 +35,7 @@ context('Edit Email Address', () => {
         contactGlobalRestrictions: [],
       },
     })
+    cy.task('stubGetLinkedPrisoners', { contactId, linkedPrisoners: [] })
     cy.signIn()
     const { prisonerNumber } = TestData.prisoner()
     cy.visit(`/prisoner/${prisonerNumber}/contacts/manage/${contactId}/relationship/${prisonerContactId}`)

--- a/integration_tests/e2e/manageContactsRestrictions.cy.ts
+++ b/integration_tests/e2e/manageContactsRestrictions.cy.ts
@@ -30,7 +30,7 @@ context('Manage contacts restrictions', () => {
     })
     cy.task('stubPrisonerById', TestData.prisoner())
     cy.task('stubContactList', 'A1234BC')
-
+    cy.task('stubGetLinkedPrisoners', { contactId: contact.id, linkedPrisoners: [] })
     cy.task('stubGetContactById', contact)
     cy.task('stubGetPrisonerContactRelationshipById', { id: 31, response: TestData.prisonerContactRelationship() })
   })

--- a/integration_tests/e2e/manageEmergencyContactOrNextOfKin.cy.ts
+++ b/integration_tests/e2e/manageEmergencyContactOrNextOfKin.cy.ts
@@ -29,6 +29,7 @@ context('Manage contact update emergency contact', () => {
         isNextOfKin: true,
       }),
     })
+    cy.task('stubGetLinkedPrisoners', { contactId, linkedPrisoners: [] })
     cy.task('stubUpdateContactRelationshipById', {
       prisonerContactId,
     })

--- a/integration_tests/e2e/manageRelationshipComments.cy.ts
+++ b/integration_tests/e2e/manageRelationshipComments.cy.ts
@@ -38,7 +38,7 @@ context('Manage contact update comments for a contact', () => {
         contactGlobalRestrictions: [],
       },
     })
-
+    cy.task('stubGetLinkedPrisoners', { contactId, linkedPrisoners: [] })
     cy.signIn()
     const { prisonerNumber } = TestData.prisoner()
     cy.visit(`/prisoner/${prisonerNumber}/contacts/manage/${contactId}/relationship/${prisonerContactId}`)

--- a/integration_tests/e2e/manageRelationshipStatus.cy.ts
+++ b/integration_tests/e2e/manageRelationshipStatus.cy.ts
@@ -36,7 +36,7 @@ context('Manage contact update relationship status active', () => {
         contactGlobalRestrictions: [],
       },
     })
-
+    cy.task('stubGetLinkedPrisoners', { contactId, linkedPrisoners: [] })
     cy.signIn()
     const { prisonerNumber } = TestData.prisoner()
     cy.visit(`/prisoner/${prisonerNumber}/contacts/manage/${contactId}/relationship/${prisonerContactId}`)

--- a/integration_tests/e2e/recordDateOfDeath.cy.ts
+++ b/integration_tests/e2e/recordDateOfDeath.cy.ts
@@ -36,6 +36,7 @@ context('Record date of death', () => {
         contactGlobalRestrictions: [],
       },
     })
+    cy.task('stubGetLinkedPrisoners', { contactId, linkedPrisoners: [] })
     cy.signIn()
     const { prisonerNumber } = TestData.prisoner()
     cy.visit(`/prisoner/${prisonerNumber}/contacts/manage/${contactId}/relationship/${prisonerContactId}`)

--- a/integration_tests/e2e/selectApprovedVisitor.cy.ts
+++ b/integration_tests/e2e/selectApprovedVisitor.cy.ts
@@ -39,7 +39,7 @@ context('Manage contact update approved visitor contact', () => {
         contactGlobalRestrictions: [],
       },
     })
-
+    cy.task('stubGetLinkedPrisoners', { contactId, linkedPrisoners: [] })
     cy.signIn()
     const { prisonerNumber } = TestData.prisoner()
     cy.visit(`/prisoner/${prisonerNumber}/contacts/manage/${contactId}/relationship/${prisonerContactId}`)

--- a/integration_tests/e2e/selectDomesticStatus.cy.ts
+++ b/integration_tests/e2e/selectDomesticStatus.cy.ts
@@ -35,6 +35,7 @@ context('Select Domestic Status', () => {
         contactGlobalRestrictions: [],
       },
     })
+    cy.task('stubGetLinkedPrisoners', { contactId, linkedPrisoners: [] })
     cy.signIn()
   })
 

--- a/integration_tests/e2e/selectGender.cy.ts
+++ b/integration_tests/e2e/selectGender.cy.ts
@@ -30,7 +30,7 @@ context('Select Gender', () => {
         contactGlobalRestrictions: [],
       },
     })
-
+    cy.task('stubGetLinkedPrisoners', { contactId, linkedPrisoners: [] })
     cy.signIn()
     const { prisonerNumber } = TestData.prisoner()
     cy.visit(`/prisoner/${prisonerNumber}/contacts/manage/${contactId}/relationship/${prisonerContactId}`)

--- a/integration_tests/e2e/selectLanguageAndInterpretationRequirements.cy.ts
+++ b/integration_tests/e2e/selectLanguageAndInterpretationRequirements.cy.ts
@@ -26,6 +26,7 @@ context('Select Language and interpretation requirements', () => {
         contactGlobalRestrictions: [],
       },
     })
+    cy.task('stubGetLinkedPrisoners', { contactId, linkedPrisoners: [] })
     cy.task('stubLanguagesReferenceData')
     cy.task('stubTitlesReferenceData')
     cy.signIn()

--- a/integration_tests/e2e/selectStaffStatus.cy.ts
+++ b/integration_tests/e2e/selectStaffStatus.cy.ts
@@ -31,6 +31,7 @@ context('Select Staff Status', () => {
         contactGlobalRestrictions: [],
       },
     })
+    cy.task('stubGetLinkedPrisoners', { contactId, linkedPrisoners: [] })
     cy.signIn()
   })
 

--- a/integration_tests/e2e/updateContactGlobalRestriction.cy.ts
+++ b/integration_tests/e2e/updateContactGlobalRestriction.cy.ts
@@ -46,7 +46,7 @@ context('Update Contact Global Restriction', () => {
         contactGlobalRestrictions: [globalRestriction],
       },
     })
-
+    cy.task('stubGetLinkedPrisoners', { contactId, linkedPrisoners: [] })
     cy.signIn()
 
     cy.visit(`/prisoner/${prisonerNumber}/contacts/manage/${contactId}/relationship/${prisonerContactId}`)

--- a/integration_tests/e2e/updatePrisonerContactEmployments.cy.ts
+++ b/integration_tests/e2e/updatePrisonerContactEmployments.cy.ts
@@ -67,6 +67,7 @@ context('Update Prisoner Contact Employments', () => {
         contactGlobalRestrictions: [],
       },
     })
+    cy.task('stubGetLinkedPrisoners', { contactId, linkedPrisoners: [] })
     cy.task('stubOrganisationSearch')
     cy.task('stubGetOrganisation', {
       organisationId: 201,

--- a/integration_tests/e2e/updatePrisonerContactRestriction.cy.ts
+++ b/integration_tests/e2e/updatePrisonerContactRestriction.cy.ts
@@ -45,6 +45,7 @@ context('Update Prisoner Contact Restriction', () => {
         contactGlobalRestrictions: [],
       },
     })
+    cy.task('stubGetLinkedPrisoners', { contactId, linkedPrisoners: [] })
     cy.signIn()
 
     cy.visit(`/prisoner/${prisonerNumber}/contacts/manage/${contactId}/relationship/${prisonerContactId}`)

--- a/scripts/generate-hmpps-contacts-api-types.sh
+++ b/scripts/generate-hmpps-contacts-api-types.sh
@@ -1,2 +1,2 @@
-npx -y openapi-typescript http://localhost:8080/v3/api-docs | sed "s/\"/'/g" | sed "s/;//g" > ../server/@types/contactsApi/index.d.ts
+npx -y openapi-typescript https://personal-relationships-api-dev.hmpps.service.justice.gov.uk/v3/api-docs | sed "s/\"/'/g" | sed "s/;//g" > ../server/@types/contactsApi/index.d.ts
 eslint --fix "../server/@types/contactsApi/index.d.ts"

--- a/server/@types/contactsApi/index.d.ts
+++ b/server/@types/contactsApi/index.d.ts
@@ -425,6 +425,42 @@ export interface paths {
     patch?: never
     trace?: never
   }
+  '/prisoner/{prisonerNumber}/number-of-children': {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    /** Get prisoner number of children */
+    get: operations['getNumberOfChildren']
+    /** Create or update prisoner number of children */
+    put: operations['createOrUpdateNumberOfChildren']
+    post?: never
+    delete?: never
+    options?: never
+    head?: never
+    patch?: never
+    trace?: never
+  }
+  '/prisoner/{prisonerNumber}/domestic-status': {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    /** Get prisoner domestic status */
+    get: operations['getDomesticStatus']
+    /** Create or update prisoner domestic status */
+    put: operations['createOrUpdateDomesticStatus']
+    post?: never
+    delete?: never
+    options?: never
+    head?: never
+    patch?: never
+    trace?: never
+  }
   '/prisoner-contact/{prisonerContactId}/restriction/{prisonerContactRestrictionId}': {
     parameters: {
       query?: never
@@ -3024,6 +3060,75 @@ export interface components {
        * @example 2023-09-24T12:00:00
        */
       updatedTime?: string
+    }
+    /** @description Request to update prisoner number of children */
+    CreateOrUpdatePrisonerNumberOfChildrenRequest: {
+      /**
+       * Format: int32
+       * @description The number of children
+       * @example 1
+       */
+      numberOfChildren?: number
+      /**
+       * @description User who requesting to create or update
+       * @example admin
+       */
+      requestedBy: string
+    }
+    /** @description Response object containing prisoner number of children information */
+    PrisonerNumberOfChildrenResponse: {
+      /**
+       * Format: int64
+       * @description The unique identifier of the number of children
+       * @example 1
+       */
+      id: number
+      /** @description The number of children of the prisoner */
+      numberOfChildren?: string
+      /** @description Is this the active number of children of the prisoner */
+      active: boolean
+      /**
+       * Format: date-time
+       * @description Creation date and time
+       */
+      createdTime?: string
+      /** @description Username of the creator */
+      createdBy?: string
+    }
+    /** @description Request to create or update prisoner domestic status */
+    CreateOrUpdatePrisonerDomesticStatusRequest: {
+      /**
+       * @description The domestic status code for DOMESTIC_STS group code
+       * @example M
+       */
+      domesticStatusCode?: string
+      /**
+       * @description User who requesting to create or update
+       * @example admin
+       */
+      requestedBy: string
+    }
+    /** @description Response object containing prisoner domestic status information */
+    PrisonerDomesticStatusResponse: {
+      /**
+       * Format: int64
+       * @description The unique identifier of the domestic status
+       * @example 1
+       */
+      id: number
+      /** @description The domestic status code of the prisoner */
+      domesticStatusCode?: string
+      /** @description The domestic status description of the prisoner */
+      domesticStatusDescription?: string
+      /** @description Is this the active domestic status code of the prisoner */
+      active: boolean
+      /**
+       * Format: date-time
+       * @description Creation date and time
+       */
+      createdTime?: string
+      /** @description Username of the creator */
+      createdBy?: string
     }
     /** @description Request to update an existing new restriction between a prisoner and a contact */
     UpdatePrisonerContactRestrictionRequest: {
@@ -6183,11 +6288,11 @@ export interface components {
       /** Format: int64 */
       offset?: number
       sort?: components['schemas']['SortObject']
+      /** Format: int32 */
+      pageSize?: number
       paged?: boolean
       /** Format: int32 */
       pageNumber?: number
-      /** Format: int32 */
-      pageSize?: number
       unpaged?: boolean
     }
     /** @description Describes the details of a prisoner's contact */
@@ -6376,10 +6481,10 @@ export interface components {
       /** Format: int64 */
       total?: number
       last?: boolean
-      /** Format: int32 */
-      totalPages?: number
       /** Format: int64 */
       totalElements?: number
+      /** Format: int32 */
+      totalPages?: number
       first?: boolean
       /** Format: int32 */
       size?: number
@@ -6392,8 +6497,8 @@ export interface components {
     }
     SortObject: {
       empty?: boolean
-      unsorted?: boolean
       sorted?: boolean
+      unsorted?: boolean
     }
     /** @description Restriction related to a specific relationship between a prisoner and contact */
     PrisonerContactRestrictionsResponse: {
@@ -6566,6 +6671,16 @@ export interface components {
        * @example William
        */
       middleNames?: string
+      /**
+       * @description The id of the prisoners current prison
+       * @example BXI
+       */
+      prisonId?: string
+      /**
+       * @description The name of the prisoners current prison
+       * @example Brixton (HMP)
+       */
+      prisonName?: string
       /** @description All the relationships between the prisoner and contact. At least one will be present. */
       relationships: components['schemas']['LinkedPrisonerRelationshipDetails'][]
     }
@@ -6755,10 +6870,10 @@ export interface components {
       /** Format: int64 */
       total?: number
       last?: boolean
-      /** Format: int32 */
-      totalPages?: number
       /** Format: int64 */
       totalElements?: number
+      /** Format: int32 */
+      totalPages?: number
       first?: boolean
       /** Format: int32 */
       size?: number
@@ -8289,6 +8404,210 @@ export interface operations {
         }
         content: {
           'application/json': components['schemas']['SyncContactAddressPhone']
+        }
+      }
+    }
+  }
+  getNumberOfChildren: {
+    parameters: {
+      query?: never
+      header?: never
+      path: {
+        prisonerNumber: string
+      }
+      cookie?: never
+    }
+    requestBody?: never
+    responses: {
+      /** @description Prisoner number of children retrieved successfully */
+      200: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['PrisonerNumberOfChildrenResponse']
+        }
+      }
+      /** @description Unauthorised, requires a valid Oauth2 token */
+      401: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['ErrorResponse']
+        }
+      }
+      /** @description Forbidden, requires an appropriate role */
+      403: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['ErrorResponse']
+        }
+      }
+      /** @description Prisoner not found */
+      404: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['ErrorResponse']
+        }
+      }
+    }
+  }
+  createOrUpdateNumberOfChildren: {
+    parameters: {
+      query?: never
+      header?: never
+      path: {
+        prisonerNumber: string
+      }
+      cookie?: never
+    }
+    requestBody: {
+      content: {
+        'application/json': components['schemas']['CreateOrUpdatePrisonerNumberOfChildrenRequest']
+      }
+    }
+    responses: {
+      /** @description Prisoner number of children created/updated successfully */
+      200: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['PrisonerNumberOfChildrenResponse']
+        }
+      }
+      /** @description Unauthorised, requires a valid Oauth2 token */
+      401: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['ErrorResponse']
+        }
+      }
+      /** @description Forbidden, requires an appropriate role */
+      403: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['ErrorResponse']
+        }
+      }
+      /** @description Prisoner not found */
+      404: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['ErrorResponse']
+        }
+      }
+    }
+  }
+  getDomesticStatus: {
+    parameters: {
+      query?: never
+      header?: never
+      path: {
+        prisonerNumber: string
+      }
+      cookie?: never
+    }
+    requestBody?: never
+    responses: {
+      /** @description Prisoner domestic status retrieved successfully */
+      200: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['PrisonerDomesticStatusResponse']
+        }
+      }
+      /** @description Unauthorised, requires a valid Oauth2 token */
+      401: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['ErrorResponse']
+        }
+      }
+      /** @description Forbidden, requires an appropriate role */
+      403: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['ErrorResponse']
+        }
+      }
+      /** @description Prisoner not found */
+      404: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['ErrorResponse']
+        }
+      }
+    }
+  }
+  createOrUpdateDomesticStatus: {
+    parameters: {
+      query?: never
+      header?: never
+      path: {
+        prisonerNumber: string
+      }
+      cookie?: never
+    }
+    requestBody: {
+      content: {
+        'application/json': components['schemas']['CreateOrUpdatePrisonerDomesticStatusRequest']
+      }
+    }
+    responses: {
+      /** @description Prisoner domestic status created/updated successfully */
+      200: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['PrisonerDomesticStatusResponse']
+        }
+      }
+      /** @description Unauthorised, requires a valid Oauth2 token */
+      401: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['ErrorResponse']
+        }
+      }
+      /** @description Forbidden, requires an appropriate role */
+      403: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['ErrorResponse']
+        }
+      }
+      /** @description Prisoner not found */
+      404: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['ErrorResponse']
         }
       }
     }

--- a/server/@types/contactsApiClient/index.d.ts
+++ b/server/@types/contactsApiClient/index.d.ts
@@ -32,7 +32,6 @@ declare namespace contactsApiClientTypes {
   export type CreateContactAddressPhoneRequest = components['schemas']['CreateContactAddressPhoneRequest']
   export type UpdateContactAddressPhoneRequest = components['schemas']['UpdateContactAddressPhoneRequest']
   export type ContactAddressPhoneDetails = components['schemas']['ContactAddressPhoneDetails']
-  export type LinkedPrisonerDetails = components['schemas']['LinkedPrisonerDetails']
   export type OrganisationSummary = components['schemas']['OrganisationSummary']
   export type OrganisationSummaryResultItemPage = components['schemas']['OrganisationSummaryResultItemPage']
   export type PatchEmploymentsRequest = components['schemas']['PatchEmploymentsRequest']

--- a/server/data/contactsApiClient.ts
+++ b/server/data/contactsApiClient.ts
@@ -32,7 +32,6 @@ import UpdateContactAddressRequest = contactsApiClientTypes.UpdateContactAddress
 import CreateContactAddressPhoneRequest = contactsApiClientTypes.CreateContactAddressPhoneRequest
 import ContactAddressPhoneDetails = contactsApiClientTypes.ContactAddressPhoneDetails
 import UpdateContactAddressPhoneRequest = contactsApiClientTypes.UpdateContactAddressPhoneRequest
-import LinkedPrisonerDetails = contactsApiClientTypes.LinkedPrisonerDetails
 import PatchEmploymentsRequest = contactsApiClientTypes.PatchEmploymentsRequest
 
 type PageableObject = components['schemas']['PageableObject']
@@ -43,6 +42,7 @@ type AddContactRelationshipRequest = components['schemas']['AddContactRelationsh
 type CreateContactRequest = components['schemas']['CreateContactRequest']
 type ContactNameDetails = components['schemas']['ContactNameDetails']
 type CreateMultipleIdentitiesRequest = components['schemas']['CreateMultipleIdentitiesRequest']
+type LinkedPrisonerDetails = components['schemas']['LinkedPrisonerDetails']
 
 export default class ContactsApiClient extends RestClient {
   constructor() {

--- a/server/routes/contacts/manage/contact-details/contactDetailsController.ts
+++ b/server/routes/contacts/manage/contact-details/contactDetailsController.ts
@@ -32,6 +32,8 @@ export default class ContactDetailsController implements PageHandler {
       user,
     )
 
+    const linkedPrisoners = await this.contactsService.getLinkedPrisoners(contact.id, user)
+
     contact.employments = contact.employments.sort(employmentSorter)
 
     return res.render('pages/contacts/manage/contactDetails/details/index', {
@@ -44,6 +46,8 @@ export default class ContactDetailsController implements PageHandler {
       prisonerContactRelationship,
       manageContactRelationshipUrl: `/prisoner/${prisonerNumber}/contacts/manage/${contactId}/relationship/${prisonerContactId}`,
       navigation,
+      linkedPrisoners,
+      linkedPrisonerCount: linkedPrisoners.flatMap(linkedPrisoner => linkedPrisoner.relationships).length,
     })
   }
 }

--- a/server/services/contactsService.ts
+++ b/server/services/contactsService.ts
@@ -20,7 +20,6 @@ import CreateContactAddressRequest = contactsApiClientTypes.CreateContactAddress
 import UpdateContactAddressRequest = contactsApiClientTypes.UpdateContactAddressRequest
 import CreateContactAddressPhoneRequest = contactsApiClientTypes.CreateContactAddressPhoneRequest
 import UpdateContactAddressPhoneRequest = contactsApiClientTypes.UpdateContactAddressPhoneRequest
-import LinkedPrisonerDetails = contactsApiClientTypes.LinkedPrisonerDetails
 import PatchEmploymentsRequest = contactsApiClientTypes.PatchEmploymentsRequest
 
 type PageableObject = components['schemas']['PageableObject']
@@ -32,6 +31,7 @@ type AddContactRelationshipRequest = components['schemas']['AddContactRelationsh
 type ContactNameDetails = components['schemas']['ContactNameDetails']
 type CreateMultipleIdentitiesRequest = components['schemas']['CreateMultipleIdentitiesRequest']
 type IdentityDocument = components['schemas']['IdentityDocument']
+type LinkedPrisonerDetails = components['schemas']['LinkedPrisonerDetails']
 
 export default class ContactsService {
   constructor(private readonly contactsApiClient: ContactsApiClient) {}

--- a/server/views/pages/contacts/manage/contactDetails/details/index.njk
+++ b/server/views/pages/contacts/manage/contactDetails/details/index.njk
@@ -1,6 +1,7 @@
 {% extends "partials/layout.njk" %}
 {% from "partials/miniProfile/macro.njk" import miniProfile %}
 {% from "govuk/components/back-link/macro.njk" import govukBackLink %}
+{% from "partials/linkedPrisonersTable.njk" import linkedPrisonersTable %}
 {% block content %}
 {% include 'partials/navigation.njk' %}
 {{ miniProfile(prisonerDetails) }}
@@ -35,7 +36,13 @@
                             Restrictions ({{ globalRestrictions.length + prisonerContactRestrictions.length }})
                         </a>
                     </li>
+                    <li class="govuk-tabs__list-item">
+                      <a class="govuk-tabs__tab linked-prisoners-tab-title" href="#linked-prisoners">
+                        Linked prisoners ({{ linkedPrisonerCount }})
+                      </a>
+                    </li>
                 </ul>
+
                <div class="govuk-tabs__panel govuk-!-static-padding-top-7" id="contact-details">
                   {%- include "./contactDetailsTab.njk" -%}
                </div>
@@ -47,6 +54,9 @@
                </div>
                 <div class="govuk-tabs__panel govuk-!-static-padding-top-7 govuk-tabs__panel--hidden" data-qa="restrictions-result-message" id="restrictions">
                   {%- include "./restrictionsTab.njk" -%}
+                </div>
+                <div class="govuk-tabs__panel govuk-!-static-padding-top-7 govuk-tabs__panel--hidden" data-qa="linked-prisoner-tab-message" id="linked-prisoners">
+                    {{ linkedPrisonersTable({ linkedPrisoners: linkedPrisoners, contact: contact }) }}
                 </div>
              </div>
     </div>

--- a/server/views/partials/linkedPrisonersTable.njk
+++ b/server/views/partials/linkedPrisonersTable.njk
@@ -1,0 +1,44 @@
+{% from "govuk/components/table/macro.njk" import govukTable %}
+
+{% macro linkedPrisonersTable(opts) %}
+
+    {% set linkedPrisoners = opts.linkedPrisoners %}
+    {% set contact = opts.contact %}
+
+    {% set rows = [] %}
+    {% for linkedPrisoner in linkedPrisoners %}
+      {% for relationship in linkedPrisoner.relationships %}
+        {% set prisonerNameAndNumberHtml %}
+          <a class="govuk-link--no-visited-state" href="{{ DPS_HOME_PAGE_URL }}/prisoner/{{ linkedPrisoner.prisonerNumber }}" target="_blank" data-qa="linked-prisoner-profile-link-{{ relationship.prisonerContactId }}">{{ linkedPrisoner | formatNameLastNameFirst }}</a><br/>
+          {{ linkedPrisoner.prisonerNumber }}
+        {% endset %}
+        {% set rows = (rows.push([
+          { html: prisonerNameAndNumberHtml },
+          { text: linkedPrisoner.prisonName },
+          { text: relationship.relationshipTypeDescription },
+          { text: relationship.relationshipToPrisonerDescription }
+        ]), rows) %}
+      {% endfor %}
+    {% endfor %}
+
+    {{ govukTable({
+      caption: "Prisoners linked to contact " + (contact | formatNameFirstNameFirst),
+      captionClasses: "govuk-table__caption--l govuk-!-margin-bottom-6",
+      firstCellIsHeader: false,
+      head: [
+        {
+          text: "Name and prison number"
+        },
+        {
+          text: "Establishment"
+        },
+        {
+          text: "Relationship type"
+        },
+        {
+          text: "Contact’s relationship to the prisoner"
+        }
+      ],
+      rows: rows
+    }) }}
+{% endmacro %}


### PR DESCRIPTION
Initial version of linked prisoners tab & table. This will eventually replace the linked prisoner card but it's still used in the link existing prisoner journey.

Currently has no empty state as it'll show all relationships which there must be one in the context of a contact record but may be needed for link existing contact later.

Also fixed the generator script for personal relationship API which I must've broken at some point...

![Screenshot 2025-03-06 at 08 13 48](https://github.com/user-attachments/assets/e21b2993-c117-48a0-b706-7bef45737c22)
