### PR TITLE
PRC-553: Back link tweaks

### DIFF
--- a/integration_tests/e2e/createContactWithEmployments.cy.ts
+++ b/integration_tests/e2e/createContactWithEmployments.cy.ts
@@ -134,7 +134,7 @@ context('Create Contact With Addresses', () => {
       .clickLinkTo('Employers', UpdateEmploymentsPage, true)
       .clickButtonTo('Continue', AddContactAdditionalInfoPage, 'First Last')
       .clickLinkTo('Employers', UpdateEmploymentsPage, true)
-      .clickLink('Back')
+      .clickLink('Back to additional information options')
 
     // Can enter some employment records
     Page.verifyOnPage(AddContactAdditionalInfoPage, 'First Last') //

--- a/server/routes/contacts/add/addContactFlowControl.test.ts
+++ b/server/routes/contacts/add/addContactFlowControl.test.ts
@@ -42,6 +42,12 @@ describe('addContactFlowControl', () => {
           undefined,
         ],
         [
+          Page.ENTER_ADDITIONAL_INFORMATION_PAGE,
+          `/prisoner/A1234BC/contacts/create/approved-to-visit/${journeyId}`,
+          undefined,
+          `Back to visits approval`,
+        ],
+        [
           Page.ENTER_RELATIONSHIP_COMMENTS,
           `/prisoner/A1234BC/contacts/add/enter-additional-info/${journeyId}`,
           undefined,
@@ -95,6 +101,18 @@ describe('addContactFlowControl', () => {
           undefined,
           undefined,
         ],
+        [
+          Page.ADD_EMPLOYMENTS,
+          `/prisoner/A1234BC/contacts/add/enter-additional-info/${journeyId}`,
+          undefined,
+          'Back to additional information options',
+        ],
+        [
+          Page.ADD_ADDRESSES,
+          `/prisoner/A1234BC/contacts/add/enter-additional-info/${journeyId}`,
+          undefined,
+          'Back to additional information options',
+        ],
       ])(
         'Should go back to previous page: from %s to %s',
         (page: Page, expectedBackUrl?: string, expectedCancelButton?: string, expectedBackLabel?: string) => {
@@ -125,45 +143,50 @@ describe('addContactFlowControl', () => {
       )
 
       it.each([
-        [Page.CREATE_CONTACT_NAME_PAGE, undefined],
-        [Page.CREATE_CONTACT_DOB_PAGE, undefined],
-        [Page.SELECT_RELATIONSHIP_TYPE, undefined],
-        [Page.SELECT_CONTACT_RELATIONSHIP, undefined],
-        [Page.SELECT_EMERGENCY_CONTACT_OR_NEXT_OF_KIN, undefined],
-        [Page.ADD_CONTACT_APPROVED_TO_VISIT_PAGE, undefined],
-        [Page.ENTER_RELATIONSHIP_COMMENTS, undefined],
-        [Page.ADD_CONTACT_CANCEL_PAGE, undefined],
-        [Page.ADD_CONTACT_ADD_PHONE_PAGE, undefined],
-        [Page.ADD_CONTACT_DELETE_PHONE_PAGE, `/prisoner/A1234BC/contacts/create/check-answers/${journeyId}`],
-        [Page.ADD_CONTACT_ENTER_GENDER_PAGE, undefined],
-        [Page.ADD_CONTACT_IS_STAFF_PAGE, undefined],
-        [Page.ADD_CONTACT_LANGUAGE_INTERPRETER_PAGE, undefined],
-        [Page.ADD_CONTACT_DOMESTIC_STATUS_PAGE, undefined],
-      ])('Should go back to check answers from %s', (page: Page, cancelButton) => {
-        const journey: AddContactJourney = {
-          id: journeyId,
-          lastTouched: new Date().toISOString(),
-          prisonerNumber: 'A1234BC',
-          returnPoint: {
-            url: '/foo',
-          },
-          mode: 'NEW',
-          isCheckingAnswers: true,
-          dateOfBirth: {
-            isKnown: 'NO',
-          },
-        }
-        const expected: Navigation = {
-          backLink: `/prisoner/A1234BC/contacts/create/check-answers/${journeyId}`,
-          backLinkLabel: undefined,
-          breadcrumbs: undefined,
-          cancelButton,
-        }
+        [Page.CREATE_CONTACT_NAME_PAGE, undefined, undefined],
+        [Page.CREATE_CONTACT_DOB_PAGE, undefined, undefined],
+        [Page.SELECT_RELATIONSHIP_TYPE, undefined, undefined],
+        [Page.SELECT_CONTACT_RELATIONSHIP, undefined, undefined],
+        [Page.SELECT_EMERGENCY_CONTACT_OR_NEXT_OF_KIN, undefined, undefined],
+        [Page.ADD_CONTACT_APPROVED_TO_VISIT_PAGE, undefined, undefined],
+        [Page.ENTER_RELATIONSHIP_COMMENTS, undefined, undefined],
+        [Page.ADD_CONTACT_CANCEL_PAGE, undefined, undefined],
+        [Page.ADD_CONTACT_ADD_PHONE_PAGE, undefined, undefined],
+        [Page.ADD_CONTACT_DELETE_PHONE_PAGE, `/prisoner/A1234BC/contacts/create/check-answers/${journeyId}`, undefined],
+        [Page.ADD_CONTACT_ENTER_GENDER_PAGE, undefined, undefined],
+        [Page.ADD_CONTACT_IS_STAFF_PAGE, undefined, undefined],
+        [Page.ADD_CONTACT_LANGUAGE_INTERPRETER_PAGE, undefined, undefined],
+        [Page.ADD_CONTACT_DOMESTIC_STATUS_PAGE, undefined, undefined],
+        [Page.ADD_ADDRESSES, undefined, 'Back'],
+        [Page.ADD_EMPLOYMENTS, undefined, 'Back'],
+      ])(
+        'Should go back to check answers from %s',
+        (page: Page, cancelButton?: string | undefined, backLinkLabel?: string | undefined) => {
+          const journey: AddContactJourney = {
+            id: journeyId,
+            lastTouched: new Date().toISOString(),
+            prisonerNumber: 'A1234BC',
+            returnPoint: {
+              url: '/foo',
+            },
+            mode: 'NEW',
+            isCheckingAnswers: true,
+            dateOfBirth: {
+              isKnown: 'NO',
+            },
+          }
+          const expected: Navigation = {
+            backLink: `/prisoner/A1234BC/contacts/create/check-answers/${journeyId}`,
+            backLinkLabel,
+            breadcrumbs: undefined,
+            cancelButton,
+          }
 
-        const nav = navigationForAddContactJourney(page, journey)
+          const nav = navigationForAddContactJourney(page, journey)
 
-        expect(nav).toStrictEqual(expected)
-      })
+          expect(nav).toStrictEqual(expected)
+        },
+      )
     })
 
     describe('getNextPageForAddContactJourney', () => {
@@ -307,37 +330,57 @@ describe('addContactFlowControl', () => {
     describe('getNavigationForAddContactJourney', () => {
       const journeyId = uuidv4()
       it.each([
-        [Page.CONTACT_MATCH_PAGE, `/prisoner/A1234BC/contacts/search/${journeyId}`, undefined],
-        [Page.SELECT_RELATIONSHIP_TYPE, `/prisoner/A1234BC/contacts/add/match/12346789/${journeyId}`, undefined],
+        [
+          Page.CONTACT_MATCH_PAGE,
+          `/prisoner/A1234BC/contacts/search/${journeyId}`,
+          undefined,
+          'Back to contact search',
+        ],
+        [
+          Page.SELECT_RELATIONSHIP_TYPE,
+          `/prisoner/A1234BC/contacts/add/match/12346789/${journeyId}`,
+          undefined,
+          undefined,
+        ],
         [
           Page.SELECT_CONTACT_RELATIONSHIP,
           `/prisoner/A1234BC/contacts/create/select-relationship-type/${journeyId}`,
+          undefined,
           undefined,
         ],
         [
           Page.SELECT_EMERGENCY_CONTACT_OR_NEXT_OF_KIN,
           `/prisoner/A1234BC/contacts/create/select-relationship-to-prisoner/${journeyId}`,
           undefined,
+          undefined,
         ],
         [
           Page.ADD_CONTACT_APPROVED_TO_VISIT_PAGE,
           `/prisoner/A1234BC/contacts/create/emergency-contact-or-next-of-kin/${journeyId}`,
+          undefined,
           undefined,
         ],
         [
           Page.ENTER_RELATIONSHIP_COMMENTS,
           `/prisoner/A1234BC/contacts/create/approved-to-visit/${journeyId}`,
           undefined,
+          undefined,
         ],
         [
           Page.CREATE_CONTACT_CHECK_ANSWERS_PAGE,
           `/prisoner/A1234BC/contacts/create/enter-relationship-comments/${journeyId}`,
           `/prisoner/A1234BC/contacts/add/cancel/${journeyId}`,
+          undefined,
         ],
-        [Page.ADD_CONTACT_CANCEL_PAGE, `/prisoner/A1234BC/contacts/create/check-answers/${journeyId}`, undefined],
+        [
+          Page.ADD_CONTACT_CANCEL_PAGE,
+          `/prisoner/A1234BC/contacts/create/check-answers/${journeyId}`,
+          undefined,
+          undefined,
+        ],
       ])(
         'Should go back to previous page: from %s to %s',
-        (page: Page, expectedBackUrl?: string, expectedCancelButton?: string) => {
+        (page: Page, expectedBackUrl?: string, expectedCancelButton?: string, expectedBackLinkLabel?: string) => {
           const journey: AddContactJourney = {
             id: journeyId,
             lastTouched: new Date().toISOString(),
@@ -351,7 +394,7 @@ describe('addContactFlowControl', () => {
           }
           const expected: Navigation = {
             backLink: expectedBackUrl,
-            backLinkLabel: undefined,
+            backLinkLabel: expectedBackLinkLabel,
             breadcrumbs: undefined,
             cancelButton: expectedCancelButton,
           }
@@ -507,12 +550,14 @@ describe('addContactFlowControl', () => {
       )
     })
   })
+
   describe('should work correctly before mode set', () => {
     const journeyId = uuidv4()
     it.each([
-      [Page.CREATE_CONTACT_START_PAGE, undefined],
-      [Page.CONTACT_SEARCH_PAGE, ['DPS_HOME', 'DPS_PROFILE', 'PRISONER_CONTACTS']],
-    ])('Should have no back for initial pages', (page: Page, breadcrumbs) => {
+      [Page.CREATE_CONTACT_START_PAGE, undefined, undefined, undefined],
+      [Page.CONTACT_SEARCH_PAGE, ['DPS_HOME', 'DPS_PROFILE', 'PRISONER_CONTACTS'], undefined, undefined],
+      [Page.CONTACT_MATCH_PAGE, undefined, `/prisoner/A1234BC/contacts/search/${journeyId}`, 'Back to contact search'],
+    ])('Should have no back for initial pages', (page: Page, breadcrumbs, backLink, backLinkLabel) => {
       const journey: AddContactJourney = {
         id: journeyId,
         lastTouched: new Date().toISOString(),
@@ -523,8 +568,8 @@ describe('addContactFlowControl', () => {
         isCheckingAnswers: false,
       }
       const expected: Navigation = {
-        backLink: undefined,
-        backLinkLabel: undefined,
+        backLink,
+        backLinkLabel,
         breadcrumbs: breadcrumbs as BreadcrumbType[] | undefined,
         cancelButton: undefined,
       }
@@ -535,9 +580,11 @@ describe('addContactFlowControl', () => {
     })
 
     it.each([
-      [Page.CREATE_CONTACT_START_PAGE, `/prisoner/A1234BC/contacts/search/${journeyId}`],
-      [Page.CONTACT_SEARCH_PAGE, `/prisoner/A1234BC/contacts/search/${journeyId}`],
-    ])('Should go to next page if mode not set: from %s to %s', (page: Page, expectedNextUrl?: string) => {
+      [Page.CREATE_CONTACT_START_PAGE, `/prisoner/A1234BC/contacts/search/${journeyId}`, undefined],
+      [Page.CONTACT_SEARCH_PAGE, `/prisoner/A1234BC/contacts/search/${journeyId}`, undefined],
+      [Page.CONTACT_MATCH_PAGE, `/prisoner/A1234BC/contacts/add/mode/NEW/${journeyId}`, 'NEW'],
+      [Page.CONTACT_MATCH_PAGE, `/prisoner/A1234BC/contacts/add/mode/EXISTING/${journeyId}`, 'EXISTING'],
+    ])('Should go to next page if mode not set: from %s to %s', (page: Page, expectedNextUrl: string, mode) => {
       const journey: AddContactJourney = {
         id: journeyId,
         lastTouched: new Date().toISOString(),
@@ -547,6 +594,7 @@ describe('addContactFlowControl', () => {
         },
         isCheckingAnswers: false,
       }
+      if (mode) journey.mode = mode as 'NEW' | 'EXISTING'
 
       const nav = nextPageForAddContactJourney(page, journey)
 

--- a/server/routes/contacts/add/addContactFlowControl.ts
+++ b/server/routes/contacts/add/addContactFlowControl.ts
@@ -150,6 +150,7 @@ const PRE_MODE_SPEC: Record<PreModePages, Spec> = {
   [Page.CONTACT_SEARCH_PAGE]: { previousUrl: _ => undefined, nextUrl: PAGES.CONTACT_SEARCH_PAGE.url },
   [Page.CONTACT_MATCH_PAGE]: {
     previousUrl: PAGES.CONTACT_SEARCH_PAGE.url,
+    previousUrlLabel: _ => 'Back to contact search',
     nextUrl: journey => PAGES.ADD_CONTACT_MODE_PAGE.url(journey),
   },
 }
@@ -159,6 +160,7 @@ const CREATE_CONTACT_SPEC: Record<CreateContactPages, Spec> = {
   [Page.CONTACT_SEARCH_PAGE]: { previousUrl: _ => undefined, nextUrl: PAGES.CONTACT_SEARCH_PAGE.url },
   [Page.CONTACT_MATCH_PAGE]: {
     previousUrl: PAGES.CONTACT_SEARCH_PAGE.url,
+    previousUrlLabel: _ => 'Back to contact search',
     nextUrl: journey => PAGES.ADD_CONTACT_MODE_PAGE.url(journey),
   },
   [Page.ADD_CONTACT_MODE_PAGE]: { previousUrl: _ => undefined, nextUrl: PAGES.CREATE_CONTACT_NAME_PAGE.url },
@@ -188,6 +190,7 @@ const CREATE_CONTACT_SPEC: Record<CreateContactPages, Spec> = {
   },
   [Page.ENTER_ADDITIONAL_INFORMATION_PAGE]: {
     previousUrl: checkAnswersOr(PAGES.ADD_CONTACT_APPROVED_TO_VISIT_PAGE.url),
+    previousUrlLabel: _ => 'Back to visits approval',
     nextUrl: PAGES.CREATE_CONTACT_CHECK_ANSWERS_PAGE.url,
   },
   [Page.ENTER_RELATIONSHIP_COMMENTS]: {
@@ -219,11 +222,12 @@ const CREATE_CONTACT_SPEC: Record<CreateContactPages, Spec> = {
   },
   [Page.ADD_EMPLOYMENTS]: {
     previousUrl: checkAnswersOr(PAGES.ENTER_ADDITIONAL_INFORMATION_PAGE.url),
+    previousUrlLabel: backIfCheckAnswersOr(_ => 'Back to additional information options'),
     nextUrl: checkAnswersOr(PAGES.ENTER_ADDITIONAL_INFORMATION_PAGE.url),
   },
   [Page.ADD_ADDRESSES]: {
     previousUrl: checkAnswersOr(PAGES.ENTER_ADDITIONAL_INFORMATION_PAGE.url),
-    previousUrlLabel: _ => 'Back to additional information options',
+    previousUrlLabel: backIfCheckAnswersOr(_ => 'Back to additional information options'),
     nextUrl: checkAnswersOr(PAGES.ENTER_ADDITIONAL_INFORMATION_PAGE.url),
   },
   [Page.ADD_CONTACT_ENTER_GENDER_PAGE]: {
@@ -267,6 +271,7 @@ const EXISTING_CONTACT_SPEC: Record<ExistingContactPages, Spec> = {
   [Page.CONTACT_SEARCH_PAGE]: { previousUrl: _ => undefined, nextUrl: PAGES.CONTACT_SEARCH_PAGE.url },
   [Page.CONTACT_MATCH_PAGE]: {
     previousUrl: PAGES.CONTACT_SEARCH_PAGE.url,
+    previousUrlLabel: _ => 'Back to contact search',
     nextUrl: PAGES.ADD_CONTACT_MODE_PAGE.url,
   },
   [Page.ADD_CONTACT_MODE_PAGE]: {
@@ -310,6 +315,10 @@ const EXISTING_CONTACT_SPEC: Record<ExistingContactPages, Spec> = {
 
 function checkAnswersOr(other: JourneyUrlProvider): JourneyUrlProvider {
   return journey => (journey.isCheckingAnswers ? PAGES.CREATE_CONTACT_CHECK_ANSWERS_PAGE.url(journey) : other(journey))
+}
+
+function backIfCheckAnswersOr(other: JourneyUrlProvider): JourneyUrlProvider {
+  return journey => (journey.isCheckingAnswers ? `Back` : other(journey))
 }
 
 function forwardToRelationshipToPrisonerOrCheckAnswers(): JourneyUrlProvider {


### PR DESCRIPTION
Added some missing custom back link labels and restored the behaviour of back links on employments and address interstitial pages.

Also added a bunch of missing back link tests