### PR TITLE
PRC-615: Add audit event details for security

### DIFF
--- a/server/data/contactsApiClient.ts
+++ b/server/data/contactsApiClient.ts
@@ -76,23 +76,6 @@ export default class ContactsApiClient extends RestClient {
     )
   }
 
-  async getPrisonerContacts(
-    prisonerNumber: string,
-    activeOnly: boolean,
-    user: Express.User,
-    pagination?: PrisonerContactPagination,
-  ): Promise<PagedModelPrisonerContactSummary> {
-    const paginationParameters = pagination ?? { page: 0, size: config.apis.contactsApi.pageSize || 10 }
-
-    return this.get<PagedModelPrisonerContactSummary>(
-      {
-        path: `/prisoner/${prisonerNumber}/contact`,
-        query: { active: activeOnly, ...paginationParameters },
-      },
-      user,
-    )
-  }
-
   async filterPrisonerContacts(
     prisonerNumber: string,
     filter: PrisonerContactFilter,

--- a/server/services/contactsService.ts
+++ b/server/services/contactsService.ts
@@ -140,6 +140,7 @@ export default class ContactsService extends AuditedService {
       subjectType: 'CONTACT',
       details: {
         prisonNumber: journey.prisonerNumber,
+        isApprovedVisitor: request.relationship?.isApprovedVisitor ?? false,
       },
       correlationId,
     })
@@ -172,22 +173,10 @@ export default class ContactsService extends AuditedService {
       details: {
         contactId: journey.contactId,
         prisonNumber: journey.prisonerNumber,
+        isApprovedVisitor: request.relationship.isApprovedVisitor,
       },
       correlationId,
     })
-  }
-
-  async getPrisonerContacts(
-    prisonerNumber: string,
-    active: boolean,
-    user: Express.User,
-    pagination: {
-      page: number
-      size: number
-      sort?: string[]
-    },
-  ): Promise<PagedModelPrisonerContactSummary> {
-    return this.contactsApiClient.getPrisonerContacts(prisonerNumber, active, user, pagination)
   }
 
   async filterPrisonerContacts(
@@ -360,6 +349,7 @@ export default class ContactsService extends AuditedService {
     user: Express.User,
     correlationId: string,
   ): Promise<void> {
+    const { comments, updatedBy, ...detailsToAudit } = request
     return this.handleAuditEvent(
       this.contactsApiClient.updateContactRelationshipById(prisonerContactId, request, user),
       {
@@ -368,6 +358,7 @@ export default class ContactsService extends AuditedService {
         subjectType: 'CONTACT_RELATIONSHIP',
         subjectId: String(prisonerContactId),
         correlationId,
+        details: { prisonerContactId, ...detailsToAudit },
       },
     )
   }

--- a/server/services/restrictionsService.test.ts
+++ b/server/services/restrictionsService.test.ts
@@ -3,6 +3,7 @@ import { v4 as uuidv4 } from 'uuid'
 import ContactsApiClient from '../data/contactsApiClient'
 import RestrictionsService from './restrictionsService'
 import { RestrictionSchemaType } from '../routes/restrictions/schema/restrictionSchema'
+import { MockedService } from '../testutils/mockedServices'
 import AddRestrictionJourney = journeys.AddRestrictionJourney
 import ContactRestrictionDetails = contactsApiClientTypes.ContactRestrictionDetails
 import CreateContactRestrictionRequest = contactsApiClientTypes.CreateContactRestrictionRequest
@@ -10,7 +11,6 @@ import PrisonerContactRestrictionDetails = contactsApiClientTypes.PrisonerContac
 import CreatePrisonerContactRestrictionRequest = contactsApiClientTypes.CreatePrisonerContactRestrictionRequest
 import UpdateContactRestrictionRequest = contactsApiClientTypes.UpdateContactRestrictionRequest
 import ContactDetails = contactsApiClientTypes.ContactDetails
-import { MockedService } from '../testutils/mockedServices'
 
 jest.mock('../data/contactsApiClient')
 jest.mock('../services/auditService')
@@ -65,7 +65,7 @@ describe('restrictionsService', () => {
         who: 'user1',
         subjectType: 'CONTACT_RESTRICTION',
         correlationId: 'correlationId',
-        details: { contactId: 99 },
+        details: { contactId: 99, type: 'BAN', startDate: '2009-02-01', expiryDate: null },
       })
     })
 
@@ -89,6 +89,13 @@ describe('restrictionsService', () => {
       }
       expect(created).toStrictEqual(expectedResponse)
       expect(apiClient.createContactGlobalRestriction).toHaveBeenCalledWith(99, expectedRequest, user)
+      expect(auditService.logAuditEvent).toHaveBeenCalledWith({
+        what: 'API_POST_CONTACT_RESTRICTION',
+        who: 'user1',
+        subjectType: 'CONTACT_RESTRICTION',
+        correlationId: 'correlationId',
+        details: { contactId: 99, type: 'BAN', startDate: '2009-02-01', expiryDate: '2020-03-02' },
+      })
     })
 
     it('should handle a bad request creating global restriction', async () => {
@@ -101,7 +108,7 @@ describe('restrictionsService', () => {
         who: 'user1',
         subjectType: 'CONTACT_RESTRICTION',
         correlationId: 'correlationId',
-        details: { contactId: 99, statusCode: 400 },
+        details: { contactId: 99, statusCode: 400, type: 'BAN', startDate: '2009-02-01', expiryDate: null },
       })
     })
 
@@ -130,7 +137,14 @@ describe('restrictionsService', () => {
         who: 'user1',
         subjectType: 'CONTACT_RELATIONSHIP_RESTRICTION',
         correlationId: 'correlationId',
-        details: { prisonNumber: 'A1234BC', contactId: 99, prisonerContactId: 66 },
+        details: {
+          prisonNumber: 'A1234BC',
+          contactId: 99,
+          prisonerContactId: 66,
+          type: 'BAN',
+          startDate: '2009-02-01',
+          expiryDate: null,
+        },
       })
     })
 
@@ -154,6 +168,20 @@ describe('restrictionsService', () => {
       }
       expect(created).toStrictEqual(expectedResponse)
       expect(apiClient.createPrisonerContactRestriction).toHaveBeenCalledWith(66, expectedRequest, user)
+      expect(auditService.logAuditEvent).toHaveBeenCalledWith({
+        what: 'API_POST_CONTACT_RELATIONSHIP_RESTRICTION',
+        who: 'user1',
+        subjectType: 'CONTACT_RELATIONSHIP_RESTRICTION',
+        correlationId: 'correlationId',
+        details: {
+          prisonNumber: 'A1234BC',
+          contactId: 99,
+          prisonerContactId: 66,
+          type: 'BAN',
+          startDate: '2009-02-01',
+          expiryDate: '2020-03-02',
+        },
+      })
     })
 
     it('should handle a bad request creating prisoner-contact restriction', async () => {
@@ -166,7 +194,15 @@ describe('restrictionsService', () => {
         who: 'user1',
         subjectType: 'CONTACT_RELATIONSHIP_RESTRICTION',
         correlationId: 'correlationId',
-        details: { prisonNumber: 'A1234BC', contactId: 99, prisonerContactId: 66, statusCode: 400 },
+        details: {
+          prisonNumber: 'A1234BC',
+          contactId: 99,
+          prisonerContactId: 66,
+          statusCode: 400,
+          type: 'BAN',
+          startDate: '2009-02-01',
+          expiryDate: null,
+        },
       })
     })
   })
@@ -215,7 +251,12 @@ describe('restrictionsService', () => {
         subjectType: 'CONTACT_RESTRICTION',
         subjectId: '555',
         correlationId: 'correlationId',
-        details: { contactId: 999 },
+        details: {
+          contactId: 999,
+          type: 'BAN',
+          startDate: '1999-02-01',
+          expiryDate: null,
+        },
       })
     })
 
@@ -254,6 +295,19 @@ describe('restrictionsService', () => {
         expectedRequest,
         user,
       )
+      expect(auditService.logAuditEvent).toHaveBeenCalledWith({
+        what: 'API_PUT_CONTACT_RESTRICTION',
+        who: 'user1',
+        subjectType: 'CONTACT_RESTRICTION',
+        subjectId: '555',
+        correlationId: 'correlationId',
+        details: {
+          contactId: 999,
+          type: 'BAN',
+          startDate: '1999-02-01',
+          expiryDate: '2099-03-02',
+        },
+      })
     })
 
     it('should handle a bad request updating global restriction', async () => {
@@ -274,7 +328,13 @@ describe('restrictionsService', () => {
         subjectType: 'CONTACT_RESTRICTION',
         subjectId: '555',
         correlationId: 'correlationId',
-        details: { contactId: 999, statusCode: 400 },
+        details: {
+          contactId: 999,
+          statusCode: 400,
+          type: 'BAN',
+          startDate: '1999-02-01',
+          expiryDate: null,
+        },
       })
     })
   })
@@ -323,7 +383,12 @@ describe('restrictionsService', () => {
         subjectType: 'CONTACT_RELATIONSHIP_RESTRICTION',
         subjectId: '555',
         correlationId: 'correlationId',
-        details: { prisonerContactId: 999 },
+        details: {
+          prisonerContactId: 999,
+          type: 'BAN',
+          startDate: '1999-02-01',
+          expiryDate: null,
+        },
       })
     })
 
@@ -362,6 +427,19 @@ describe('restrictionsService', () => {
         expectedRequest,
         user,
       )
+      expect(auditService.logAuditEvent).toHaveBeenCalledWith({
+        what: 'API_PUT_CONTACT_RELATIONSHIP_RESTRICTION',
+        who: 'user1',
+        subjectType: 'CONTACT_RELATIONSHIP_RESTRICTION',
+        subjectId: '555',
+        correlationId: 'correlationId',
+        details: {
+          prisonerContactId: 999,
+          type: 'BAN',
+          startDate: '1999-02-01',
+          expiryDate: '2099-03-02',
+        },
+      })
     })
 
     it('should handle a bad request creating global restriction', async () => {
@@ -382,7 +460,13 @@ describe('restrictionsService', () => {
         subjectType: 'CONTACT_RELATIONSHIP_RESTRICTION',
         subjectId: '555',
         correlationId: 'correlationId',
-        details: { prisonerContactId: 999, statusCode: 400 },
+        details: {
+          prisonerContactId: 999,
+          statusCode: 400,
+          type: 'BAN',
+          startDate: '1999-02-01',
+          expiryDate: null,
+        },
       })
     })
   })

--- a/server/services/restrictionsService.ts
+++ b/server/services/restrictionsService.ts
@@ -27,15 +27,18 @@ export default class RestrictionsService extends AuditedService {
     correlationId: string,
   ): Promise<ContactRestrictionDetails | PrisonerContactRestrictionDetails> {
     const { type, startDate, expiryDate, comments } = journey.restriction!
+    const parsedStartDate = formatISO(parse(startDate!, 'dd/MM/yyyy', new Date()), { representation: 'date' })
+    const parsedExpiryDate = expiryDate
+      ? formatISO(parse(expiryDate, 'dd/MM/yyyy', new Date()), { representation: 'date' })
+      : undefined
     const request: CreatePrisonerContactRestrictionRequest & CreateContactRestrictionRequest = {
       restrictionType: type,
-      startDate: formatISO(parse(startDate!, 'dd/MM/yyyy', new Date()), { representation: 'date' }),
-      expiryDate: expiryDate
-        ? formatISO(parse(expiryDate, 'dd/MM/yyyy', new Date()), { representation: 'date' })
-        : undefined,
+      startDate: parsedStartDate,
+      expiryDate: parsedExpiryDate,
       comments,
       createdBy: user.username,
     }
+
     switch (journey.restrictionClass) {
       case 'CONTACT_GLOBAL':
         return this.handleAuditEvent(
@@ -44,7 +47,12 @@ export default class RestrictionsService extends AuditedService {
             what: 'API_POST_CONTACT_RESTRICTION',
             who: user.username,
             subjectType: 'CONTACT_RESTRICTION',
-            details: { contactId: journey.contactId },
+            details: {
+              contactId: journey.contactId,
+              type,
+              startDate: parsedStartDate,
+              expiryDate: parsedExpiryDate ?? null,
+            },
             correlationId,
           },
         )
@@ -59,6 +67,9 @@ export default class RestrictionsService extends AuditedService {
               contactId: journey.contactId,
               prisonNumber: journey.prisonerNumber,
               prisonerContactId: journey.prisonerContactId,
+              type,
+              startDate: parsedStartDate,
+              expiryDate: parsedExpiryDate ?? null,
             },
             correlationId,
           },
@@ -76,12 +87,14 @@ export default class RestrictionsService extends AuditedService {
     correlationId: string,
   ): Promise<ContactRestrictionDetails> {
     const { type, startDate, expiryDate, comments } = form
+    const parsedStartDate = formatISO(parse(startDate, 'dd/MM/yyyy', new Date()), { representation: 'date' })
+    const parsedExpiryDate = expiryDate
+      ? formatISO(parse(expiryDate, 'dd/MM/yyyy', new Date()), { representation: 'date' })
+      : undefined
     const request: UpdateContactRestrictionRequest = {
       restrictionType: type,
-      startDate: formatISO(parse(startDate, 'dd/MM/yyyy', new Date()), { representation: 'date' }),
-      expiryDate: expiryDate
-        ? formatISO(parse(expiryDate, 'dd/MM/yyyy', new Date()), { representation: 'date' })
-        : undefined,
+      startDate: parsedStartDate,
+      expiryDate: parsedExpiryDate,
       comments,
       updatedBy: user.username,
     }
@@ -92,7 +105,7 @@ export default class RestrictionsService extends AuditedService {
         who: user.username,
         subjectType: 'CONTACT_RESTRICTION',
         subjectId: String(contactRestrictionId),
-        details: { contactId },
+        details: { contactId, type, startDate: parsedStartDate, expiryDate: parsedExpiryDate ?? null },
         correlationId,
       },
     )
@@ -106,12 +119,14 @@ export default class RestrictionsService extends AuditedService {
     correlationId: string,
   ): Promise<PrisonerContactRestrictionDetails> {
     const { type, startDate, expiryDate, comments } = form
+    const parsedStartDate = formatISO(parse(startDate, 'dd/MM/yyyy', new Date()), { representation: 'date' })
+    const parsedExpiryDate = expiryDate
+      ? formatISO(parse(expiryDate, 'dd/MM/yyyy', new Date()), { representation: 'date' })
+      : undefined
     const request: UpdatePrisonerContactRestrictionRequest = {
       restrictionType: type,
-      startDate: formatISO(parse(startDate, 'dd/MM/yyyy', new Date()), { representation: 'date' }),
-      expiryDate: expiryDate
-        ? formatISO(parse(expiryDate, 'dd/MM/yyyy', new Date()), { representation: 'date' })
-        : undefined,
+      startDate: parsedStartDate,
+      expiryDate: parsedExpiryDate,
       comments,
       updatedBy: user.username,
     }
@@ -127,7 +142,7 @@ export default class RestrictionsService extends AuditedService {
         who: user.username,
         subjectType: 'CONTACT_RELATIONSHIP_RESTRICTION',
         subjectId: String(prisonerContactRestrictionId),
-        details: { prisonerContactId },
+        details: { prisonerContactId, type, startDate: parsedStartDate, expiryDate: parsedExpiryDate ?? null },
         correlationId,
       },
     )


### PR DESCRIPTION
For potentially security related modifications we now include the details of the action in the audit event. This includes anywhere that sets isApprovedVisitor or adds or changes a restriction.

This would allow the audit team to see who approved or unapproved a visitor or set restrictions even if they have since been modified again.