### PR TITLE
PRC-653: Don't focus element on error

### DIFF
--- a/server/middleware/validationMiddleware.test.ts
+++ b/server/middleware/validationMiddleware.test.ts
@@ -64,14 +64,13 @@ describe('validationMiddleware', () => {
 
       await validate(schema)(req, res, next)
 
-      expect(res.redirect).toHaveBeenCalledWith('/url-being-validated')
       expect(req.flash).toHaveBeenCalledWith(
         'validationErrors',
         JSON.stringify({ information: [DESCRIPTION_OF_INFORMATION] }),
       )
       expect(req.flash).toHaveBeenCalledWith('formResponses', JSON.stringify(req.body))
     })
-    it('should redirect to original url', async () => {
+    it('should redirect to original url with a default fragment to ensure correct focus', async () => {
       const next = jest.fn()
       req = {
         params: {},
@@ -86,12 +85,7 @@ describe('validationMiddleware', () => {
 
       await validate(schema)(req, res, next)
 
-      expect(res.redirect).toHaveBeenCalledWith('/url-being-validated')
-      expect(req.flash).toHaveBeenCalledWith(
-        'validationErrors',
-        JSON.stringify({ information: [DESCRIPTION_OF_INFORMATION] }),
-      )
-      expect(req.flash).toHaveBeenCalledWith('formResponses', JSON.stringify(req.body))
+      expect(res.redirect).toHaveBeenCalledWith('/url-being-validated#')
     })
 
     it('should return flash responses for other info', async () => {
@@ -109,7 +103,6 @@ describe('validationMiddleware', () => {
 
       await validate(schema)(req, res, next)
 
-      expect(res.redirect).toHaveBeenCalledWith('/url-being-validated')
       expect(req.flash).toHaveBeenCalledWith(
         'validationErrors',
         JSON.stringify({ otherInformation: [DESCRIPTION_OF_OTHER_INFORMATION] }),
@@ -132,7 +125,6 @@ describe('validationMiddleware', () => {
 
       await validate(schema)(req, res, next)
 
-      expect(res.redirect).toHaveBeenCalledWith('/url-being-validated')
       expect(req.flash).toHaveBeenCalledWith(
         'validationErrors',
         JSON.stringify({

--- a/server/middleware/validationMiddleware.ts
+++ b/server/middleware/validationMiddleware.ts
@@ -45,7 +45,8 @@ export const validate = <P extends { [key: string]: string }>(schema: z.ZodTypeA
     const deduplicatedFieldErrors = deduplicateFieldErrors(result.error)
 
     req.flash('validationErrors', JSON.stringify(deduplicatedFieldErrors))
-    return res.redirect(req.originalUrl)
+    const urlWithDefaultFragmentSoAnyFieldFocusIsRemoved = `${req.originalUrl}#`
+    return res.redirect(urlWithDefaultFragmentSoAnyFieldFocusIsRemoved)
   }
 }
 

--- a/server/routes/contacts/add/addresses/add-address-phone/createContactAddressPhoneController.test.ts
+++ b/server/routes/contacts/add/addresses/add-address-phone/createContactAddressPhoneController.test.ts
@@ -335,7 +335,7 @@ describe(`POST /prisoner/:prisonerNumber/contacts/create/addresses/:addressIndex
       .type('form')
       .send({})
       .expect(302)
-      .expect('Location', `/prisoner/${prisonerNumber}/contacts/create/addresses/new/phone/create/${journeyId}`)
+      .expect('Location', `/prisoner/${prisonerNumber}/contacts/create/addresses/new/phone/create/${journeyId}#`)
     expect(session.addContactJourneys![journeyId]!.newAddress!.phoneNumbers).toBeUndefined()
   })
 

--- a/server/routes/contacts/add/addresses/comments/createContactAddressCommentsController.test.ts
+++ b/server/routes/contacts/add/addresses/comments/createContactAddressCommentsController.test.ts
@@ -249,7 +249,7 @@ describe('POST /prisoner/:prisonerNumber/contacts/create/addresses/:addressIndex
       .type('form')
       .send({ comments: 'a'.repeat(300) })
       .expect(302)
-      .expect('Location', `/prisoner/${prisonerNumber}/contacts/create/addresses/new/comments/${journeyId}`)
+      .expect('Location', `/prisoner/${prisonerNumber}/contacts/create/addresses/new/comments/${journeyId}#`)
   })
 
   it('should return not found page if index is out of range', async () => {

--- a/server/routes/contacts/add/addresses/dates/createContactAddressDatesController.test.ts
+++ b/server/routes/contacts/add/addresses/dates/createContactAddressDatesController.test.ts
@@ -285,7 +285,7 @@ describe('POST /prisoner/:prisonerNumber/contacts/create/addresses/:addressIndex
       .type('form')
       .send({ fromMonth: 'a'.repeat(300) })
       .expect(302)
-      .expect('Location', `/prisoner/${prisonerNumber}/contacts/create/addresses/new/dates/${journeyId}`)
+      .expect('Location', `/prisoner/${prisonerNumber}/contacts/create/addresses/new/dates/${journeyId}#`)
   })
 
   it('should return not found page if index is out of range', async () => {

--- a/server/routes/contacts/add/addresses/enter-address/createContactEnterAddressController.test.ts
+++ b/server/routes/contacts/add/addresses/enter-address/createContactEnterAddressController.test.ts
@@ -287,7 +287,7 @@ describe('POST /prisoner/:prisonerNumber/contacts/create/addresses/:addressIndex
       .type('form')
       .send({})
       .expect(302)
-      .expect('Location', `/prisoner/${prisonerNumber}/contacts/create/addresses/new/enter-address/${journeyId}`)
+      .expect('Location', `/prisoner/${prisonerNumber}/contacts/create/addresses/new/enter-address/${journeyId}#`)
   })
 
   it('should return not found page if index is out of range', async () => {

--- a/server/routes/contacts/add/contact-match/contactMatchController.test.ts
+++ b/server/routes/contacts/add/contact-match/contactMatchController.test.ts
@@ -1025,7 +1025,7 @@ describe('POST /prisoner/:prisonerNumber/contacts/add/match/22/:journeyId?contac
       .type('form')
       .send({ isContactMatched: '' })
       .expect(302)
-      .expect('Location', `/prisoner/${prisonerNumber}/contacts/add/match/22/${journeyId}`)
+      .expect('Location', `/prisoner/${prisonerNumber}/contacts/add/match/22/${journeyId}#`)
 
     // Then
     expect(session.addContactJourneys![journeyId]!.isContactMatched).toStrictEqual(undefined)

--- a/server/routes/contacts/add/contact-search/contactSearchController.test.ts
+++ b/server/routes/contacts/add/contact-search/contactSearchController.test.ts
@@ -197,7 +197,7 @@ describe('POST /prisoner/:prisonerNumber/contacts/search/:journeyId', () => {
       .type('form')
       .send({ day: '01', month: '', year: '' })
       .expect(302)
-      .expect('Location', `/prisoner/${prisonerNumber}/contacts/search/${journeyId}`)
+      .expect('Location', `/prisoner/${prisonerNumber}/contacts/search/${journeyId}#`)
 
     expect(session.addContactJourneys![journeyId]!.searchContact!.dateOfBirth).toBeUndefined()
   })
@@ -210,7 +210,7 @@ describe('POST /prisoner/:prisonerNumber/contacts/search/:journeyId', () => {
       .type('form')
       .send({ day: '01', month: '12', year: '' })
       .expect(302)
-      .expect('Location', `/prisoner/${prisonerNumber}/contacts/search/${journeyId}`)
+      .expect('Location', `/prisoner/${prisonerNumber}/contacts/search/${journeyId}#`)
 
     expect(session.addContactJourneys![journeyId]!.searchContact!.dateOfBirth).toBeUndefined()
   })
@@ -227,7 +227,7 @@ describe('POST /prisoner/:prisonerNumber/contacts/search/:journeyId', () => {
         year: date.setDate(date.getDate() + 1),
       })
       .expect(302)
-      .expect('Location', `/prisoner/${prisonerNumber}/contacts/search/${journeyId}`)
+      .expect('Location', `/prisoner/${prisonerNumber}/contacts/search/${journeyId}#`)
 
     expect(session.addContactJourneys![journeyId]!.searchContact!.dateOfBirth).toBeUndefined()
   })

--- a/server/routes/contacts/add/emails/addContactAddEmailsController.test.ts
+++ b/server/routes/contacts/add/emails/addContactAddEmailsController.test.ts
@@ -221,7 +221,7 @@ describe('POST /prisoner/:prisonerNumber/contacts/create/emails/:journeyId', () 
       .type('form')
       .send({ save: '', emails: [{ emailAddress: '' }, { emailAddress: '123' }] })
       .expect(302)
-      .expect('Location', `/prisoner/${prisonerNumber}/contacts/create/emails/${journeyId}`)
+      .expect('Location', `/prisoner/${prisonerNumber}/contacts/create/emails/${journeyId}#`)
   })
 
   it('should return to start if no journey in session', async () => {

--- a/server/routes/contacts/add/enter-dob/createContactEnterDobController.test.ts
+++ b/server/routes/contacts/add/enter-dob/createContactEnterDobController.test.ts
@@ -213,7 +213,7 @@ describe('POST /prisoner/:prisonerNumber/contacts/create/enter-name', () => {
       .type('form')
       .send({ day: ' ' })
       .expect(302)
-      .expect('Location', `/prisoner/${prisonerNumber}/contacts/create/enter-dob/${journeyId}`)
+      .expect('Location', `/prisoner/${prisonerNumber}/contacts/create/enter-dob/${journeyId}#`)
   })
 
   it('should return to start if no journey in session', async () => {

--- a/server/routes/contacts/add/enter-name/createContactEnterNameController.test.ts
+++ b/server/routes/contacts/add/enter-name/createContactEnterNameController.test.ts
@@ -221,7 +221,7 @@ describe('POST /prisoner/:prisonerNumber/contacts/create/enter-name/:journeyId',
       .type('form')
       .send({ firstName: 'first' })
       .expect(302)
-      .expect('Location', `/prisoner/${prisonerNumber}/contacts/create/enter-name/${journeyId}`)
+      .expect('Location', `/prisoner/${prisonerNumber}/contacts/create/enter-name/${journeyId}#`)
   })
 
   it('should return to start if no journey in session', async () => {

--- a/server/routes/contacts/add/identities/addContactAddIdentitiesController.test.ts
+++ b/server/routes/contacts/add/identities/addContactAddIdentitiesController.test.ts
@@ -259,7 +259,7 @@ describe('POST /prisoner/:prisonerNumber/contacts/create/identities/:journeyId',
       .type('form')
       .send({ save: '', identities: [{ identityType: '', identityValue: '0123' }] })
       .expect(302)
-      .expect('Location', `/prisoner/${prisonerNumber}/contacts/create/identities/${journeyId}`)
+      .expect('Location', `/prisoner/${prisonerNumber}/contacts/create/identities/${journeyId}#`)
   })
 
   it('should return to start if no journey in session', async () => {

--- a/server/routes/contacts/add/phone/addContactAddPhoneController.test.ts
+++ b/server/routes/contacts/add/phone/addContactAddPhoneController.test.ts
@@ -276,7 +276,7 @@ describe('POST /prisoner/:prisonerNumber/contacts/create/add-phone-numbers/:jour
       .type('form')
       .send({ save: '', phones: [{ type: '', phoneNumber: '0123', extension: '' }] })
       .expect(302)
-      .expect('Location', `/prisoner/${prisonerNumber}/contacts/create/add-phone-numbers/${journeyId}`)
+      .expect('Location', `/prisoner/${prisonerNumber}/contacts/create/add-phone-numbers/${journeyId}#`)
   })
 
   it('should return to start if no journey in session', async () => {

--- a/server/routes/contacts/add/relationship-comments/enterRelationshipCommentsController.test.ts
+++ b/server/routes/contacts/add/relationship-comments/enterRelationshipCommentsController.test.ts
@@ -245,7 +245,7 @@ describe('POST /prisoner/:prisonerNumber/contacts/create/enter-relationship-comm
       .type('form')
       .send({ comments: ''.padEnd(241) })
       .expect(302)
-      .expect('Location', `/prisoner/${prisonerNumber}/contacts/create/enter-relationship-comments/${journeyId}`)
+      .expect('Location', `/prisoner/${prisonerNumber}/contacts/create/enter-relationship-comments/${journeyId}#`)
   })
 
   it('should return to start if no journey in session', async () => {

--- a/server/routes/contacts/add/relationship-to-prisoner/selectRelationshipToPrisonerController.test.ts
+++ b/server/routes/contacts/add/relationship-to-prisoner/selectRelationshipToPrisonerController.test.ts
@@ -304,7 +304,7 @@ describe('POST /prisoner/:prisonerNumber/contacts/create/select-relationship-to-
       .type('form')
       .send({})
       .expect(302)
-      .expect('Location', `/prisoner/${prisonerNumber}/contacts/create/select-relationship-to-prisoner/${journeyId}`)
+      .expect('Location', `/prisoner/${prisonerNumber}/contacts/create/select-relationship-to-prisoner/${journeyId}#`)
   })
 
   it('should return to start if no journey in session', async () => {

--- a/server/routes/contacts/add/relationship-type/relationshipTypeController.test.ts
+++ b/server/routes/contacts/add/relationship-type/relationshipTypeController.test.ts
@@ -246,7 +246,7 @@ describe('POST /prisoner/:prisonerNumber/contacts/create/select-relationship-typ
       .type('form')
       .send({})
       .expect(302)
-      .expect('Location', `/prisoner/${prisonerNumber}/contacts/create/select-relationship-type/${journeyId}`)
+      .expect('Location', `/prisoner/${prisonerNumber}/contacts/create/select-relationship-type/${journeyId}#`)
   })
 
   it('should return to start if no journey in session', async () => {

--- a/server/routes/contacts/manage/additional-information/domestic-status/manageDomesticStatusController.test.ts
+++ b/server/routes/contacts/manage/additional-information/domestic-status/manageDomesticStatusController.test.ts
@@ -136,7 +136,7 @@ describe('POST /prisoner/:prisonerNumber/contacts/manage/:contactId/relationship
       .expect(302)
       .expect(
         'Location',
-        `/prisoner/${prisonerNumber}/contacts/manage/${contactId}/relationship/${prisonerContactId}/domestic-status`,
+        `/prisoner/${prisonerNumber}/contacts/manage/${contactId}/relationship/${prisonerContactId}/domestic-status#`,
       )
 
     expect(contactsService.updateContactById).not.toHaveBeenCalled()

--- a/server/routes/contacts/manage/additional-information/language-and-interpreter/manageLanguageAndInterpreterController.test.ts
+++ b/server/routes/contacts/manage/additional-information/language-and-interpreter/manageLanguageAndInterpreterController.test.ts
@@ -119,7 +119,7 @@ describe('POST /prisoner/:prisonerNumber/contacts/manage/:contactId/relationship
       .expect(302)
       .expect(
         'Location',
-        `/prisoner/${prisonerNumber}/contacts/manage/${contactId}/relationship/${prisonerContactId}/language-and-interpreter`,
+        `/prisoner/${prisonerNumber}/contacts/manage/${contactId}/relationship/${prisonerContactId}/language-and-interpreter#`,
       )
 
     expect(contactsService.updateContactById).not.toHaveBeenCalled()

--- a/server/routes/contacts/manage/addresses/add-address-phone/addressPhoneController.test.ts
+++ b/server/routes/contacts/manage/addresses/add-address-phone/addressPhoneController.test.ts
@@ -268,7 +268,7 @@ describe(`POST /prisoner/:prisonerNumber/contacts/manage/:contactId/relationship
       .expect(302)
       .expect(
         'Location',
-        `/prisoner/${prisonerNumber}/contacts/manage/${contactId}/relationship/${prisonerContactId}/address/phone/${journeyId}`,
+        `/prisoner/${prisonerNumber}/contacts/manage/${contactId}/relationship/${prisonerContactId}/address/phone/${journeyId}#`,
       )
     expect(session.addressJourneys![journeyId]!.phoneNumbers).toBeUndefined()
   })

--- a/server/routes/contacts/manage/addresses/add-address-phone/manageContactAddAddressPhoneController.test.ts
+++ b/server/routes/contacts/manage/addresses/add-address-phone/manageContactAddAddressPhoneController.test.ts
@@ -178,7 +178,7 @@ describe('POST /prisoner/:prisonerNumber/contacts/manage/:contactId/relationship
       .expect(302)
       .expect(
         'Location',
-        `/prisoner/${prisonerNumber}/contacts/manage/${contactId}/relationship/${prisonerContactId}/address/${contactAddressId}/phone/create`,
+        `/prisoner/${prisonerNumber}/contacts/manage/${contactId}/relationship/${prisonerContactId}/address/${contactAddressId}/phone/create#`,
       )
     expect(contactsService.createContactAddressPhones).not.toHaveBeenCalled()
   })

--- a/server/routes/contacts/manage/addresses/address-type/changeAddressTypeController.test.ts
+++ b/server/routes/contacts/manage/addresses/address-type/changeAddressTypeController.test.ts
@@ -188,7 +188,7 @@ describe('POST /prisoner/:prisonerNumber/contacts/manage/:contactId/relationship
       .expect(302)
       .expect(
         'Location',
-        `/prisoner/${prisonerNumber}/contacts/manage/${contactId}/relationship/${prisonerContactId}/address/${contactAddressId}/select-type`,
+        `/prisoner/${prisonerNumber}/contacts/manage/${contactId}/relationship/${prisonerContactId}/address/${contactAddressId}/select-type#`,
       )
   })
 })

--- a/server/routes/contacts/manage/addresses/comments/addressCommentsController.test.ts
+++ b/server/routes/contacts/manage/addresses/comments/addressCommentsController.test.ts
@@ -194,7 +194,7 @@ describe('POST /prisoner/:prisonerNumber/contacts/manage/:contactId/relationship
       .expect(302)
       .expect(
         'Location',
-        `/prisoner/${prisonerNumber}/contacts/manage/${contactId}/relationship/${prisonerContactId}/address/comments/${journeyId}`,
+        `/prisoner/${prisonerNumber}/contacts/manage/${contactId}/relationship/${prisonerContactId}/address/comments/${journeyId}#`,
       )
   })
 

--- a/server/routes/contacts/manage/addresses/comments/changeAddressCommentsController.test.ts
+++ b/server/routes/contacts/manage/addresses/comments/changeAddressCommentsController.test.ts
@@ -240,7 +240,7 @@ describe('POST /prisoner/:prisonerNumber/contacts/manage/:contactId/relationship
       .expect(302)
       .expect(
         'Location',
-        `/prisoner/${prisonerNumber}/contacts/manage/${contactId}/relationship/${prisonerContactId}/address/${contactAddressId}/comments`,
+        `/prisoner/${prisonerNumber}/contacts/manage/${contactId}/relationship/${prisonerContactId}/address/${contactAddressId}/comments#`,
       )
   })
 })

--- a/server/routes/contacts/manage/addresses/dates/addressDatesController.test.ts
+++ b/server/routes/contacts/manage/addresses/dates/addressDatesController.test.ts
@@ -251,7 +251,7 @@ describe('POST /prisoner/:prisonerNumber/contacts/manage/:contactId/relationship
         .expect(302)
         .expect(
           'Location',
-          `/prisoner/${prisonerNumber}/contacts/manage/${contactId}/relationship/${prisonerContactId}/address/dates/${journeyId}`,
+          `/prisoner/${prisonerNumber}/contacts/manage/${contactId}/relationship/${prisonerContactId}/address/dates/${journeyId}#`,
         )
     },
   )

--- a/server/routes/contacts/manage/addresses/dates/changeAddressDatesController.test.ts
+++ b/server/routes/contacts/manage/addresses/dates/changeAddressDatesController.test.ts
@@ -204,7 +204,7 @@ describe('POST /prisoner/:prisonerNumber/contacts/manage/:contactId/relationship
       .expect(302)
       .expect(
         'Location',
-        `/prisoner/${prisonerNumber}/contacts/manage/${contactId}/relationship/${prisonerContactId}/address/${contactAddressId}/dates`,
+        `/prisoner/${prisonerNumber}/contacts/manage/${contactId}/relationship/${prisonerContactId}/address/${contactAddressId}/dates#`,
       )
   })
 })

--- a/server/routes/contacts/manage/addresses/edit-address-phone/manageContactEditAddressPhoneController.test.ts
+++ b/server/routes/contacts/manage/addresses/edit-address-phone/manageContactEditAddressPhoneController.test.ts
@@ -214,7 +214,7 @@ describe(`POST /prisoner/:prisonerNumber/contacts/manage/:contactId/relationship
       .expect(302)
       .expect(
         'Location',
-        `/prisoner/${prisonerNumber}/contacts/manage/${contactId}/relationship/${prisonerContactId}/address/${contactAddressId}/phone/999/edit`,
+        `/prisoner/${prisonerNumber}/contacts/manage/${contactId}/relationship/${prisonerContactId}/address/${contactAddressId}/phone/999/edit#`,
       )
     expect(contactsService.updateContactAddressPhone).not.toHaveBeenCalled()
   })

--- a/server/routes/contacts/manage/addresses/enter-address/changeAddressLinesController.test.ts
+++ b/server/routes/contacts/manage/addresses/enter-address/changeAddressLinesController.test.ts
@@ -207,7 +207,7 @@ describe('POST /prisoner/:prisonerNumber/contacts/manage/:contactId/relationship
       .expect(302)
       .expect(
         'Location',
-        `/prisoner/${prisonerNumber}/contacts/manage/${contactId}/relationship/${prisonerContactId}/address/${contactAddressId}/enter-address`,
+        `/prisoner/${prisonerNumber}/contacts/manage/${contactId}/relationship/${prisonerContactId}/address/${contactAddressId}/enter-address#`,
       )
   })
 })

--- a/server/routes/contacts/manage/addresses/enter-address/enterAddressController.test.ts
+++ b/server/routes/contacts/manage/addresses/enter-address/enterAddressController.test.ts
@@ -309,7 +309,7 @@ describe('POST /prisoner/:prisonerNumber/contacts/manage/:contactId/relationship
       .expect(302)
       .expect(
         'Location',
-        `/prisoner/${prisonerNumber}/contacts/manage/${contactId}/relationship/${prisonerContactId}/address/enter-address/${journeyId}`,
+        `/prisoner/${prisonerNumber}/contacts/manage/${contactId}/relationship/${prisonerContactId}/address/enter-address/${journeyId}#`,
       )
   })
 

--- a/server/routes/contacts/manage/addresses/primary-or-postal/changeAddressFlagsController.test.ts
+++ b/server/routes/contacts/manage/addresses/primary-or-postal/changeAddressFlagsController.test.ts
@@ -177,7 +177,7 @@ describe('POST /prisoner/:prisonerNumber/contacts/manage/:contactId/relationship
       .expect(302)
       .expect(
         'Location',
-        `/prisoner/${prisonerNumber}/contacts/manage/${contactId}/relationship/${prisonerContactId}/address/${contactAddressId}/primary-or-postal`,
+        `/prisoner/${prisonerNumber}/contacts/manage/${contactId}/relationship/${prisonerContactId}/address/${contactAddressId}/primary-or-postal#`,
       )
   })
 })

--- a/server/routes/contacts/manage/date-of-death/manageContactEnterDateOfDeathController.test.ts
+++ b/server/routes/contacts/manage/date-of-death/manageContactEnterDateOfDeathController.test.ts
@@ -225,7 +225,7 @@ describe('POST /prisoner/:prisonerNumber/contacts/manage/:contactId/relationship
       .expect(302)
       .expect(
         'Location',
-        `/prisoner/${prisonerNumber}/contacts/manage/${contactId}/relationship/${prisonerContactId}/enter-date-of-death`,
+        `/prisoner/${prisonerNumber}/contacts/manage/${contactId}/relationship/${prisonerContactId}/enter-date-of-death#`,
       )
   })
 })

--- a/server/routes/contacts/manage/email/edit/manageContactEditEmailController.test.ts
+++ b/server/routes/contacts/manage/email/edit/manageContactEditEmailController.test.ts
@@ -177,7 +177,7 @@ describe('POST /prisoner/:prisonerNumber/contacts/manage/:contactId/relationship
       .expect(302)
       .expect(
         'Location',
-        `/prisoner/${prisonerNumber}/contacts/manage/${contactId}/relationship/${prisonerContactId}/email/6/edit`,
+        `/prisoner/${prisonerNumber}/contacts/manage/${contactId}/relationship/${prisonerContactId}/email/6/edit#`,
       )
     expect(contactsService.updateContactEmail).not.toHaveBeenCalled()
     expect(flashProvider).not.toHaveBeenCalledWith(FLASH_KEY__SUCCESS_BANNER, expect.anything)

--- a/server/routes/contacts/manage/gender/contactGenderController.test.ts
+++ b/server/routes/contacts/manage/gender/contactGenderController.test.ts
@@ -111,7 +111,7 @@ describe('POST /prisoner/:prisonerNumber/contacts/manage/:contactId/relationship
       .expect(302)
       .expect(
         'Location',
-        `/prisoner/${prisonerNumber}/contacts/manage/${contactId}/relationship/${prisonerContactId}/gender`,
+        `/prisoner/${prisonerNumber}/contacts/manage/${contactId}/relationship/${prisonerContactId}/gender#`,
       )
   })
 })

--- a/server/routes/contacts/manage/identities/add/manageContactAddIdentityController.test.ts
+++ b/server/routes/contacts/manage/identities/add/manageContactAddIdentityController.test.ts
@@ -196,7 +196,7 @@ describe(`POST /prisoner/:prisonerNumber/contacts/manage/:contactId/relationship
       .expect(302)
       .expect(
         'Location',
-        `/prisoner/${prisonerNumber}/contacts/manage/${contactId}/relationship/${prisonerContactId}/identity/create`,
+        `/prisoner/${prisonerNumber}/contacts/manage/${contactId}/relationship/${prisonerContactId}/identity/create#`,
       )
     expect(contactsService.createContactIdentities).not.toHaveBeenCalled()
     expect(flashProvider).toHaveBeenCalledWith('validationErrors', expect.anything())

--- a/server/routes/contacts/manage/identities/edit/manageContactEditIdentityController.test.ts
+++ b/server/routes/contacts/manage/identities/edit/manageContactEditIdentityController.test.ts
@@ -217,7 +217,7 @@ describe('POST /prisoner/:prisonerNumber/contacts/manage/:contactId/relationship
       .expect(302)
       .expect(
         'Location',
-        `/prisoner/${prisonerNumber}/contacts/manage/${contactId}/relationship/${prisonerContactId}/identity/999/edit`,
+        `/prisoner/${prisonerNumber}/contacts/manage/${contactId}/relationship/${prisonerContactId}/identity/999/edit#`,
       )
     expect(contactsService.updateContactIdentity).not.toHaveBeenCalled()
   })

--- a/server/routes/contacts/manage/name/changeTitleOrMiddleNamesController.test.ts
+++ b/server/routes/contacts/manage/name/changeTitleOrMiddleNamesController.test.ts
@@ -235,7 +235,7 @@ describe('POST /prisoner/:prisonerNumber/contacts/manage/:contactId/relationship
       .expect(302)
       .expect(
         'Location',
-        `/prisoner/${prisonerNumber}/contacts/manage/${contactId}/relationship/${prisonerContactId}/change-contact-title-or-middle-names`,
+        `/prisoner/${prisonerNumber}/contacts/manage/${contactId}/relationship/${prisonerContactId}/change-contact-title-or-middle-names#`,
       )
   })
 })

--- a/server/routes/contacts/manage/phone/add/manageContactAddPhoneController.test.ts
+++ b/server/routes/contacts/manage/phone/add/manageContactAddPhoneController.test.ts
@@ -160,7 +160,7 @@ describe('POST /prisoner/:prisonerNumber/contacts/manage/:contactId/relationship
       .expect(302)
       .expect(
         'Location',
-        `/prisoner/${prisonerNumber}/contacts/manage/${contactId}/relationship/${prisonerContactId}/phone/create`,
+        `/prisoner/${prisonerNumber}/contacts/manage/${contactId}/relationship/${prisonerContactId}/phone/create#`,
       )
     expect(contactsService.createContactAddressPhones).not.toHaveBeenCalled()
   })

--- a/server/routes/contacts/manage/phone/edit/manageContactEditPhoneController.test.ts
+++ b/server/routes/contacts/manage/phone/edit/manageContactEditPhoneController.test.ts
@@ -206,7 +206,7 @@ describe('POST /prisoner/:prisonerNumber/contacts/manage/:contactId/relationship
       .expect(302)
       .expect(
         'Location',
-        `/prisoner/${prisonerNumber}/contacts/manage/${contactId}/relationship/${prisonerContactId}/phone/999/edit`,
+        `/prisoner/${prisonerNumber}/contacts/manage/${contactId}/relationship/${prisonerContactId}/phone/999/edit#`,
       )
     expect(contactsService.updateContactPhone).not.toHaveBeenCalled()
     expect(flashProvider).not.toHaveBeenCalledWith(FLASH_KEY__SUCCESS_BANNER, expect.anything)

--- a/server/routes/contacts/manage/prisoner-search/prisonerSearchController.test.ts
+++ b/server/routes/contacts/manage/prisoner-search/prisonerSearchController.test.ts
@@ -81,7 +81,7 @@ describe('POST /contacts/manage/prisoner-search/:journeyId', () => {
       .type('form')
       .send({ search: 'A' })
       .expect(302)
-      .expect('Location', `/contacts/manage/prisoner-search/${journeyId}`)
+      .expect('Location', `/contacts/manage/prisoner-search/${journeyId}#`)
 
     expect(flashProvider).toHaveBeenCalledWith('validationErrors', `{"search":["${ENTER_TWO_CHARS_MIN}"]}`)
   })

--- a/server/routes/contacts/manage/prisoner-search/prisonerSearchResultsController.test.ts
+++ b/server/routes/contacts/manage/prisoner-search/prisonerSearchResultsController.test.ts
@@ -232,7 +232,7 @@ describe('POST /contacts/manage/prisoner-search-results/:journeyId', () => {
       .type('form')
       .send({ search: 'A' })
       .expect(302)
-      .expect('Location', `/contacts/manage/prisoner-search-results/${journeyId}`)
+      .expect('Location', `/contacts/manage/prisoner-search-results/${journeyId}#`)
 
     expect(flashProvider).toHaveBeenCalledWith('validationErrors', `{"search":["${ENTER_TWO_CHARS_MIN}"]}`)
   })

--- a/server/routes/contacts/manage/relationship/approved-to-visit/manageApprovedToVisitController.test.ts
+++ b/server/routes/contacts/manage/relationship/approved-to-visit/manageApprovedToVisitController.test.ts
@@ -122,7 +122,7 @@ describe('POST /prisoner/:prisonerNumber/contacts/manage/:contactId/relationship
       .expect(302)
       .expect(
         'Location',
-        `/prisoner/${prisonerNumber}/contacts/manage/${contactId}/relationship/${prisonerContactId}/approved-to-visit`,
+        `/prisoner/${prisonerNumber}/contacts/manage/${contactId}/relationship/${prisonerContactId}/approved-to-visit#`,
       )
   })
 })

--- a/server/routes/contacts/manage/relationship/comments/manageRelationshipCommentsController.test.ts
+++ b/server/routes/contacts/manage/relationship/comments/manageRelationshipCommentsController.test.ts
@@ -110,7 +110,7 @@ describe(`POST /prisoner/:prisonerNumber/contacts/manage/:contactId/relationship
       .expect(302)
       .expect(
         'Location',
-        `/prisoner/${prisonerNumber}/contacts/manage/${contactId}/relationship/${prisonerContactId}/relationship-comments`,
+        `/prisoner/${prisonerNumber}/contacts/manage/${contactId}/relationship/${prisonerContactId}/relationship-comments#`,
       )
   })
 })

--- a/server/routes/contacts/manage/relationship/emergency-contact-or-next-of-kin/manageEmergencyContactOrNextOfKinController.test.ts
+++ b/server/routes/contacts/manage/relationship/emergency-contact-or-next-of-kin/manageEmergencyContactOrNextOfKinController.test.ts
@@ -134,7 +134,7 @@ describe('POST /prisoner/:prisonerNumber/contacts/manage/:contactId/relationship
       .expect(302)
       .expect(
         'Location',
-        `/prisoner/${prisonerNumber}/contacts/manage/${contactId}/relationship/${prisonerContactId}/emergency-contact-or-next-of-kin`,
+        `/prisoner/${prisonerNumber}/contacts/manage/${contactId}/relationship/${prisonerContactId}/emergency-contact-or-next-of-kin#`,
       )
   })
 })

--- a/server/routes/contacts/manage/relationship/relationship-to-prisoner/manageContactRelationshipToPrisonerController.test.ts
+++ b/server/routes/contacts/manage/relationship/relationship-to-prisoner/manageContactRelationshipToPrisonerController.test.ts
@@ -186,7 +186,7 @@ describe('POST /prisoner/:prisonerNumber/contacts/manage/:contactId/relationship
       .expect(302)
       .expect(
         'Location',
-        `/prisoner/${prisonerNumber}/contacts/manage/${contactId}/relationship/${prisonerContactId}/update-relationship-to-prisoner`,
+        `/prisoner/${prisonerNumber}/contacts/manage/${contactId}/relationship/${prisonerContactId}/update-relationship-to-prisoner#`,
       )
     expect(contactsService.updateContactRelationshipById).not.toHaveBeenCalled()
   })

--- a/server/routes/contacts/manage/relationship/status/manageRelationshipStatusController.test.ts
+++ b/server/routes/contacts/manage/relationship/status/manageRelationshipStatusController.test.ts
@@ -117,7 +117,7 @@ describe(`POST /prisoner/:prisonerNumber/contacts/manage/:contactId/relationship
       .expect(302)
       .expect(
         'Location',
-        `/prisoner/${prisonerNumber}/contacts/manage/${contactId}/relationship/${prisonerContactId}/relationship-status`,
+        `/prisoner/${prisonerNumber}/contacts/manage/${contactId}/relationship/${prisonerContactId}/relationship-status#`,
       )
   })
 })

--- a/server/routes/contacts/manage/relationship/type/select-new-relationship-to-prisoner/changeRelationshipTypeRelationshipToPrisonerController.test.ts
+++ b/server/routes/contacts/manage/relationship/type/select-new-relationship-to-prisoner/changeRelationshipTypeRelationshipToPrisonerController.test.ts
@@ -235,7 +235,7 @@ describe(`POST /prisoner/:prisonerNumber/contacts/manage/:contactId/relationship
       .expect(302)
       .expect(
         'Location',
-        `/prisoner/${prisonerNumber}/contacts/manage/${contactId}/relationship/${prisonerContactId}/type/select-new-relationship-to-prisoner/${journeyId}`,
+        `/prisoner/${prisonerNumber}/contacts/manage/${contactId}/relationship/${prisonerContactId}/type/select-new-relationship-to-prisoner/${journeyId}#`,
       )
     expect(contactsService.updateContactRelationshipById).not.toHaveBeenCalled()
   })

--- a/server/routes/contacts/manage/relationship/type/select-new-relationship-type/changeRelationshipTypeController.test.ts
+++ b/server/routes/contacts/manage/relationship/type/select-new-relationship-type/changeRelationshipTypeController.test.ts
@@ -159,7 +159,7 @@ describe('POST /prisoner/:prisonerNumber/contacts/manage/:contactId/relationship
       .expect(302)
       .expect(
         'Location',
-        `/prisoner/${prisonerNumber}/contacts/manage/${contactId}/relationship/${prisonerContactId}/type/select-new-relationship-type/${journeyId}`,
+        `/prisoner/${prisonerNumber}/contacts/manage/${contactId}/relationship/${prisonerContactId}/type/select-new-relationship-type/${journeyId}#`,
       )
   })
 

--- a/server/routes/contacts/manage/staff/manageContactStaffController.test.ts
+++ b/server/routes/contacts/manage/staff/manageContactStaffController.test.ts
@@ -106,7 +106,7 @@ describe('POST /prisoner/:prisonerNumber/contacts/manage/:contactId/relationship
       .expect(302)
       .expect(
         'Location',
-        `/prisoner/${prisonerNumber}/contacts/manage/${contactId}/relationship/${prisonerContactId}/staff`,
+        `/prisoner/${prisonerNumber}/contacts/manage/${contactId}/relationship/${prisonerContactId}/staff#`,
       )
   })
 })

--- a/server/routes/contacts/manage/update-dob/manageContactEnterDobController.test.ts
+++ b/server/routes/contacts/manage/update-dob/manageContactEnterDobController.test.ts
@@ -155,7 +155,7 @@ describe('POST /prisoner/:prisonerNumber/contacts/manage/:contactId/relationship
       .expect(302)
       .expect(
         'Location',
-        `/prisoner/${prisonerNumber}/contacts/manage/${contactId}/relationship/${prisonerContactId}/update-dob`,
+        `/prisoner/${prisonerNumber}/contacts/manage/${contactId}/relationship/${prisonerContactId}/update-dob#`,
       )
   })
 })

--- a/server/routes/restrictions/enter-restriction/enterNewRestrictionController.test.ts
+++ b/server/routes/restrictions/enter-restriction/enterNewRestrictionController.test.ts
@@ -259,7 +259,7 @@ describe('POST /prisoner/:prisonerNumber/contacts/:contactId/relationship/:priso
         .expect(302)
         .expect(
           'Location',
-          `/prisoner/${prisonerNumber}/contacts/${contactId}/relationship/${prisonerContactId}/restriction/add/${restrictionClass}/enter-restriction/${journeyId}`,
+          `/prisoner/${prisonerNumber}/contacts/${contactId}/relationship/${prisonerContactId}/restriction/add/${restrictionClass}/enter-restriction/${journeyId}#`,
         )
     },
   )

--- a/server/routes/restrictions/update-restriction/updateRestrictionController.test.ts
+++ b/server/routes/restrictions/update-restriction/updateRestrictionController.test.ts
@@ -279,7 +279,7 @@ describe('POST /prisoner/:prisonerNumber/contacts/:contactId/relationship/:priso
         .expect(302)
         .expect(
           'Location',
-          `/prisoner/${prisonerNumber}/contacts/${contactId}/relationship/${prisonerContactId}/restriction/update/${restrictionClass}/enter-restriction/${restrictionId}`,
+          `/prisoner/${prisonerNumber}/contacts/${contactId}/relationship/${prisonerContactId}/restriction/update/${restrictionClass}/enter-restriction/${restrictionId}#`,
         )
     },
   )


### PR DESCRIPTION
When we have a deep link to an element, e.g., a change link that focuses the firstName field we use a URL fragment to focus it. This has a side effect of forcing focus to that element even on validation error. As the browser maintains the fragment only on the client side we have no way of knowing if a fragment is in play. To resolve this we reset to a default fragment (#) whenever redirecting on error.