### PR TITLE
PRC-654: UI fixes for contact list

### DIFF
--- a/assets/scss/local.scss
+++ b/assets/scss/local.scss
@@ -138,3 +138,13 @@ div.moj-action-bar__filter::after { content: none !important; }
     }
   }
 }
+
+// make the name and person id as small as possible and ensure DOB doesn't wrap but let everything else fit to content.
+#prisoner-contact-list tr{
+  th:first-child {
+    width: 5%;
+  }
+  th:nth-child(2) {
+    min-width: 130px;
+  }
+}

--- a/server/routes/contacts/manage/list/listContactsController.test.ts
+++ b/server/routes/contacts/manage/list/listContactsController.test.ts
@@ -380,7 +380,7 @@ describe('listContactsController', () => {
           totalExpired: 5,
           active: [{ restrictionType: 'BAN', restrictionTypeDescription: 'Banned' }],
         },
-        ['Banned', '(Contact has 5 expired restrictions)'],
+        ['Banned', '(Contact also has 5 expired restrictions)'],
       ],
     ])('should render restrictions column correctly', async (restrictionSummary, expectedRows) => {
       // Given

--- a/server/views/pages/contacts/manage/listContacts.njk
+++ b/server/views/pages/contacts/manage/listContacts.njk
@@ -151,18 +151,18 @@
             No active restrictions
             {% endif %}
             {% if restrictionSummary.totalExpired > 0 %}
-              <br> <span class="govuk-hint">(Contact has {{ restrictionSummary.totalExpired }} expired restriction{{ 's' if restrictionSummary.totalExpired !== 1 }})</span>
+              <br> <span class="govuk-hint">(Contact {{ 'also ' if restrictionSummary.totalActive > 0}}has {{ restrictionSummary.totalExpired }} expired restriction{{ 's' if restrictionSummary.totalExpired !== 1 }})</span>
             {% endif %}
           {% endset %}
 
-          {% set classes = 'light-grey' if not contact.isRelationshipActive else '' %}
+          {% set classes = 'light-grey govuk-!-padding-top-3 govuk-!-padding-bottom-3' if not contact.isRelationshipActive else 'govuk-!-padding-top-3 govuk-!-padding-bottom-3' %}
           {% set rows = (rows.push([
-            { html: contactNameAndNumber, classes: classes },
+            { html: contactNameAndNumber, classes: classes + ' govuk-!-padding-left-1'},
             { html: contact | formatDob, classes: classes },
             { html: relationshipHtml, classes: classes },
             { html: (contact | addressToLines or 'Not provided') | escape | nl2br, classes: classes },
             { text: 'Approved' if contact.isApprovedVisitor else 'Not approved or has not been checked', classes: classes },
-            { html: restrictionsHtml, classes: classes }
+            { html: restrictionsHtml, classes: classes + ' govuk-!-padding-right-1' }
           ]), rows) %}
         {% endfor %}
 
@@ -186,7 +186,7 @@
               text: "Primary or default address"
             },
             {
-              text: "Visit approval status"
+              text: "Visits approval status"
             },
             {
               text: "Relationship and global restrictions"


### PR DESCRIPTION
Column heading should be "Visits approval status"
Should include the word "also" when there are both active and inactive restrictions. Add some padding to rows.
Squeeze the name and person id column as small as possible and make sure DOB column does not wrap by setting custom widths.