### PR TITLE
PRC-655: Delete employer link tweak

### DIFF
--- a/assets/scss/local.scss
+++ b/assets/scss/local.scss
@@ -148,3 +148,7 @@ div.moj-action-bar__filter::after { content: none !important; }
     min-width: 130px;
   }
 }
+
+.delete-employer-no-wrap {
+  min-width: 160px
+}

--- a/server/views/pages/contacts/manage/employments/index.njk
+++ b/server/views/pages/contacts/manage/employments/index.njk
@@ -46,7 +46,7 @@
                   {
                     href: updateEmploymentBaseLink + loop.index + "/delete-employment/" + journeyId,
                     text: "Delete employer",
-                    classes: "govuk-link--no-visited-state"
+                    classes: "govuk-link--no-visited-state delete-employer-no-wrap"
                   }
                 ]
               }


### PR DESCRIPTION
Make sure the link doesn't wrap and has sufficient padding with long org names.