### PR TITLE
PRC-619: RBAC enforced on visit approval

### DIFF
--- a/assets/scss/local.scss
+++ b/assets/scss/local.scss
@@ -39,9 +39,9 @@ div.contact-list {
   .govuk-summary-list__row { border-bottom: 0 }
 }
 
-.unsupported-identity-hint {
+.summary-card-key-hint {
   margin-bottom: 0;
-  color: $govuk-secondary-text-colour;
+  color: govuk-colour("dark-grey");
 }
 
 // DPS standard styling on top of GDS summary cards.

--- a/integration_tests/e2e/addExistingContactAsAdmin.cy.ts
+++ b/integration_tests/e2e/addExistingContactAsAdmin.cy.ts
@@ -1,0 +1,408 @@
+import Page from '../pages/page'
+import LinkExistingContactCYAPage from '../pages/linkExistingContactCYAPage'
+import TestData from '../../server/routes/testutils/testData'
+import ListContactsPage from '../pages/listContacts'
+import SelectRelationshipPage from '../pages/selectRelationshipPage'
+import SearchContactPage from '../pages/searchContactPage'
+import ContactConfirmationPage from '../pages/contactConfirmationPage'
+import AddContactSuccessPage from '../pages/addContactSuccessPage'
+import ManageContactDetailsPage from '../pages/manageContactDetails'
+import SelectRelationshipTypePage from '../pages/selectRelationshipTypePage'
+import RelationshipCommentsPage from '../pages/contact-details/relationship/relationshipCommentsPage'
+import SelectEmergencyContactOrNextOfKinPage from '../pages/contact-details/relationship/selectEmergencyContactOrNextOfKinPage'
+import CancelAddContactPage from '../pages/cancelAddContactPage'
+
+context('Add existing contact as admin user so cannot set visit approval', () => {
+  const { prisonerNumber } = TestData.prisoner()
+  const contactId = 654321
+  const prisonerContactId = 987654
+  const contact = TestData.contact({
+    id: contactId,
+    lastName: 'Contact',
+    firstName: 'Existing',
+  })
+  const searchResult = TestData.contactSearchResultItem({
+    id: contact.id,
+    lastName: contact.lastName,
+    firstName: contact.firstName,
+    middleNames: contact.middleNames,
+  })
+
+  const globalRestriction = TestData.getContactRestrictionDetails({ contactId: contact.id })
+
+  beforeEach(() => {
+    cy.task('reset')
+    cy.task('stubComponentsMeta')
+    cy.task('stubSignIn', { roles: ['PRISON', 'CONTACTS_ADMIN'] })
+    cy.task('stubTitlesReferenceData')
+    cy.task('stubRelationshipReferenceData')
+    cy.task('stubOfficialRelationshipReferenceData')
+    cy.task('stubRelationshipTypeReferenceData')
+    cy.task('stubPhoneTypeReferenceData')
+    cy.task('stubPrisonerById', TestData.prisoner())
+    cy.task('stubContactList', prisonerNumber)
+    cy.task('stubGetContactById', contact)
+    cy.task('stubGetContactNameById', contact)
+    cy.task('stubGetGlobalRestrictions', [globalRestriction])
+    cy.task('stubGetPrisonerContactRelationshipById', {
+      id: prisonerContactId,
+      response: TestData.prisonerContactRelationship(),
+    })
+    cy.task('stubGetPrisonerContactRestrictions', {
+      prisonerContactId,
+      response: {
+        prisonerContactRestrictions: [],
+        contactGlobalRestrictions: [],
+      },
+    })
+    cy.task('stubGetLinkedPrisoners', { contactId, linkedPrisoners: [] })
+    cy.task('stubAddContactRelationship', { contactId, createdPrisonerContactId: prisonerContactId })
+    cy.task('stubContactSearch', {
+      results: {
+        page: {
+          totalPages: 1,
+          totalElements: 1,
+        },
+        content: [searchResult],
+      },
+      lastName: 'Contact',
+      firstName: '',
+      middleNames: '',
+      dateOfBirth: '',
+    })
+
+    cy.signIn({ startUrl: `/prisoner/${prisonerNumber}/contacts/list` })
+
+    Page.verifyOnPage(ListContactsPage, 'John Smith') //
+      .clickAddNewContactButton()
+
+    Page.verifyOnPage(SearchContactPage) //
+      .enterLastName('Contact')
+      .clickSearchButton()
+  })
+
+  it('Can add an existing contact with all fields and the contact has a date of birth', () => {
+    cy.task('stubGetContactById', {
+      id: contactId,
+      firstName: 'Existing',
+      lastName: 'Contact',
+      dateOfBirth: '1990-01-14',
+      employments: [],
+    })
+
+    Page.verifyOnPage(SearchContactPage) //
+      .clickTheContactLink(contactId)
+
+    Page.verifyOnPage(ContactConfirmationPage, 'Existing Contact', 'John Smith') //
+      .selectIsTheRightPersonYesRadio()
+      .clickContinue()
+
+    Page.verifyOnPage(SelectRelationshipTypePage, 'Existing Contact', 'John Smith') //
+      .selectRelationshipType('S')
+      .clickContinue()
+
+    Page.verifyOnPage(SelectRelationshipPage, 'Existing Contact', 'John Smith') //
+      .selectRelationship('MOT')
+      .clickContinue()
+
+    Page.verifyOnPage(SelectEmergencyContactOrNextOfKinPage, 'Existing Contact', 'John Smith', true, 'John Smith', true) //
+      .selectIsEmergencyContactOrNextOfKin('NOK')
+      .clickContinue()
+
+    Page.verifyOnPage(RelationshipCommentsPage, 'Existing Contact', 'John Smith', true) //
+      .enterComments('Some comments about the relationship')
+      .clickContinue()
+
+    Page.verifyOnPage(LinkExistingContactCYAPage) //
+      .verifyShowsNameAs('Existing Contact (654321)')
+      .verifyShowRelationshipAs('Mother')
+      .verifyShowIsEmergencyContactAs('No')
+      .verifyShowIsNextOfKinAs('Yes')
+      .verifyShowCommentsAs('Some comments about the relationship')
+      .clickContinue()
+
+    Page.verifyOnPage(AddContactSuccessPage) //
+      .clickLink('add the restrictions now')
+
+    Page.verifyOnPage(ManageContactDetailsPage, 'Existing Contact')
+
+    cy.verifyLastAPICall(
+      {
+        method: 'POST',
+        urlPath: `/prisoner-contact`,
+      },
+      {
+        contactId,
+        relationship: {
+          prisonerNumber: 'A1234BC',
+          relationshipTypeCode: 'S',
+          relationshipToPrisonerCode: 'MOT',
+          isNextOfKin: true,
+          isEmergencyContact: false,
+          isApprovedVisitor: false,
+          comments: 'Some comments about the relationship',
+        },
+      },
+    )
+  })
+
+  it('Can add an existing contact with only optional fields', () => {
+    cy.task('stubGetContactById', {
+      id: contactId,
+      firstName: 'Existing',
+      lastName: 'Contact',
+      employments: [],
+    })
+
+    Page.verifyOnPage(SearchContactPage) //
+      .clickTheContactLink(contactId)
+
+    Page.verifyOnPage(ContactConfirmationPage, 'Existing Contact', 'John Smith') //
+      .selectIsTheRightPersonYesRadio()
+      .clickContinue()
+
+    Page.verifyOnPage(SelectRelationshipTypePage, 'Existing Contact', 'John Smith') //
+      .selectRelationshipType('S')
+      .clickContinue()
+
+    Page.verifyOnPage(SelectRelationshipPage, 'Existing Contact', 'John Smith') //
+      .selectRelationship('MOT')
+      .clickContinue()
+
+    Page.verifyOnPage(SelectEmergencyContactOrNextOfKinPage, 'Existing Contact', 'John Smith', true, 'John Smith', true) //
+      .clickContinue()
+
+    Page.verifyOnPage(RelationshipCommentsPage, 'Existing Contact', 'John Smith', true) //
+      .clickContinue()
+
+    Page.verifyOnPage(LinkExistingContactCYAPage) //
+      .verifyShowsNameAs('Existing Contact (654321)')
+      .verifyShowRelationshipAs('Mother')
+      .verifyShowIsEmergencyContactAs('Not provided')
+      .verifyShowIsNextOfKinAs('Not provided')
+      .clickContinue()
+
+    Page.verifyOnPage(AddContactSuccessPage) //
+      .clickLink('View Existing Contact’s contact information')
+
+    Page.verifyOnPage(ManageContactDetailsPage, 'Existing Contact')
+
+    cy.verifyLastAPICall(
+      {
+        method: 'POST',
+        urlPath: `/prisoner-contact`,
+      },
+      {
+        contactId,
+        relationship: {
+          prisonerNumber: 'A1234BC',
+          relationshipTypeCode: 'S',
+          relationshipToPrisonerCode: 'MOT',
+          isNextOfKin: false,
+          isEmergencyContact: false,
+          isApprovedVisitor: false,
+        },
+      },
+    )
+  })
+
+  it('Can add an official contact', () => {
+    cy.task('stubGetContactById', {
+      id: contactId,
+      firstName: 'Existing',
+      lastName: 'Contact',
+    })
+
+    Page.verifyOnPage(SearchContactPage) //
+      .clickTheContactLink(contactId)
+
+    Page.verifyOnPage(ContactConfirmationPage, 'Existing Contact', 'John Smith') //
+      .selectIsTheRightPersonYesRadio()
+      .clickContinue()
+
+    Page.verifyOnPage(SelectRelationshipTypePage, 'Existing Contact', 'John Smith') //
+      .selectRelationshipType('O')
+      .clickContinue()
+
+    Page.verifyOnPage(SelectRelationshipPage, 'Existing Contact', 'John Smith') //
+      .selectRelationship('DR')
+      .clickContinue()
+
+    Page.verifyOnPage(SelectEmergencyContactOrNextOfKinPage, 'Existing Contact', 'John Smith', true) //
+      .selectIsEmergencyContactOrNextOfKin('EC')
+      .clickContinue()
+
+    Page.verifyOnPage(RelationshipCommentsPage, 'Existing Contact', 'John Smith', true) //
+      .clickContinue()
+
+    Page.verifyOnPage(LinkExistingContactCYAPage) //
+      .verifyShowsNameAs('Existing Contact (654321)')
+      .verifyShowRelationshipAs('Doctor')
+      .verifyShowIsEmergencyContactAs('Yes')
+      .verifyShowIsNextOfKinAs('No')
+      .clickContinue()
+
+    Page.verifyOnPage(AddContactSuccessPage)
+
+    cy.verifyLastAPICall(
+      {
+        method: 'POST',
+        urlPath: `/prisoner-contact`,
+      },
+      {
+        contactId,
+        relationship: {
+          prisonerNumber: 'A1234BC',
+          relationshipTypeCode: 'O',
+          relationshipToPrisonerCode: 'DR',
+          isNextOfKin: false,
+          isEmergencyContact: true,
+          isApprovedVisitor: false,
+        },
+      },
+    )
+  })
+
+  it('Should require selection of contact relationship', () => {
+    cy.task('stubGetContactById', {
+      id: contactId,
+      firstName: 'Existing',
+      lastName: 'Contact',
+    })
+
+    Page.verifyOnPage(SearchContactPage) //
+      .clickTheContactLink(contactId)
+
+    Page.verifyOnPage(ContactConfirmationPage, 'Existing Contact', 'John Smith') //
+      .selectIsTheRightPersonYesRadio()
+      .clickContinue()
+
+    Page.verifyOnPage(SelectRelationshipTypePage, 'Existing Contact', 'John Smith') //
+      .selectRelationshipType('S')
+      .clickContinue()
+
+    const selectRelationshipPage = Page.verifyOnPage(SelectRelationshipPage, 'Existing Contact', 'John Smith')
+    selectRelationshipPage.clickContinue()
+
+    selectRelationshipPage.hasFieldInError('relationship', 'Select the contact’s relationship to the prisoner')
+  })
+
+  it('Can navigate all the way back to search from relationship comments', () => {
+    cy.task('stubGetContactById', {
+      id: contactId,
+      firstName: 'Existing',
+      lastName: 'Contact',
+      dateOfBirth: '1990-01-14',
+    })
+
+    Page.verifyOnPage(SearchContactPage) //
+      .clickTheContactLink(contactId)
+
+    Page.verifyOnPage(ContactConfirmationPage, 'Existing Contact', 'John Smith') //
+      .selectIsTheRightPersonYesRadio()
+      .clickContinue()
+
+    Page.verifyOnPage(SelectRelationshipTypePage, 'Existing Contact', 'John Smith') //
+      .selectRelationshipType('S')
+      .continueTo(SelectRelationshipPage, 'Existing Contact', 'John Smith')
+      .selectRelationship('MOT')
+      .continueTo(SelectEmergencyContactOrNextOfKinPage, 'Existing Contact', 'John Smith', true)
+      .selectIsEmergencyContactOrNextOfKin('NONE')
+      .continueTo(RelationshipCommentsPage, 'Existing Contact', 'John Smith', true)
+      .continueTo(LinkExistingContactCYAPage)
+      .backTo(RelationshipCommentsPage, 'Existing Contact', 'John Smith', true)
+      .backTo(SelectEmergencyContactOrNextOfKinPage, 'Existing Contact', 'John Smith', true)
+      .backTo(SelectRelationshipPage, 'Existing Contact', 'John Smith')
+      .backTo(SelectRelationshipTypePage, 'Existing Contact', 'John Smith')
+      .backTo(ContactConfirmationPage, 'Existing Contact', 'John Smith')
+      .backTo(SearchContactPage)
+      .verifyShowsNameAs('Contact, Existing')
+  })
+
+  it('Can add a deceased contact and show the deceased date on check answers page', () => {
+    cy.task('stubGetContactById', {
+      id: contactId,
+      firstName: 'Deceased',
+      lastName: 'Contact',
+      dateOfBirth: '1990-01-14',
+      deceasedDate: '2020-12-25',
+    })
+
+    Page.verifyOnPage(SearchContactPage) //
+      .clickTheContactLink(contactId)
+
+    Page.verifyOnPage(ContactConfirmationPage, 'Deceased Contact', 'John Smith') //
+      .selectIsTheRightPersonYesRadio()
+      .clickContinue()
+
+    Page.verifyOnPage(SelectRelationshipTypePage, 'Deceased Contact', 'John Smith') //
+      .selectRelationshipType('S')
+      .clickContinue()
+
+    Page.verifyOnPage(SelectRelationshipPage, 'Deceased Contact', 'John Smith') //
+      .selectRelationship('MOT')
+      .clickContinue()
+
+    Page.verifyOnPage(SelectEmergencyContactOrNextOfKinPage, 'Deceased Contact', 'John Smith', true) //
+      .selectIsEmergencyContactOrNextOfKin('NOK')
+      .clickContinue()
+
+    Page.verifyOnPage(RelationshipCommentsPage, 'Deceased Contact', 'John Smith', true) //
+      .clickContinue()
+
+    Page.verifyOnPage(LinkExistingContactCYAPage) //
+      .verifyShowsNameAs('Deceased Contact (654321)')
+      .continueTo(AddContactSuccessPage)
+
+    cy.verifyLastAPICall(
+      {
+        method: 'POST',
+        urlPath: `/prisoner-contact`,
+      },
+      {
+        contactId,
+        relationship: {
+          prisonerNumber: 'A1234BC',
+          relationshipTypeCode: 'S',
+          relationshipToPrisonerCode: 'MOT',
+          isNextOfKin: true,
+          isEmergencyContact: false,
+          isApprovedVisitor: false,
+        },
+      },
+    )
+  })
+
+  it('Cancelling from check answers prompts for confirmation', () => {
+    cy.task('stubGetContactById', {
+      id: contactId,
+      firstName: 'Existing',
+      lastName: 'Contact',
+      dateOfBirth: '1990-01-14',
+      employments: [],
+    })
+
+    Page.verifyOnPage(SearchContactPage) //
+      .clickTheContactLink(contactId)
+
+    Page.verifyOnPage(ContactConfirmationPage, 'Existing Contact', 'John Smith') //
+      .selectIsTheRightPersonYesRadio()
+      .continueTo(SelectRelationshipTypePage, 'Existing Contact', 'John Smith') //
+      .selectRelationshipType('S')
+      .continueTo(SelectRelationshipPage, 'Existing Contact', 'John Smith') //
+      .selectRelationship('MOT')
+      .continueTo(SelectEmergencyContactOrNextOfKinPage, 'Existing Contact', 'John Smith', true) //
+      .selectIsEmergencyContactOrNextOfKin('NONE')
+      .continueTo(RelationshipCommentsPage, 'Existing Contact', 'John Smith', true) //
+      .enterComments('Some comments about the relationship')
+      .continueTo(LinkExistingContactCYAPage) //
+      .clickLink('Cancel')
+
+    Page.verifyOnPage(CancelAddContactPage, 'Existing Contact') //
+      .clickButtonTo('No, return to check answers', LinkExistingContactCYAPage)
+      .clickLinkTo('Cancel', CancelAddContactPage, 'Existing Contact')
+      .clickButton('Yes, cancel')
+
+    Page.verifyOnPage(ListContactsPage, 'John Smith')
+  })
+})

--- a/integration_tests/e2e/addExistingContactCheckAnswers.cy.ts
+++ b/integration_tests/e2e/addExistingContactCheckAnswers.cy.ts
@@ -11,7 +11,7 @@ import RelationshipCommentsPage from '../pages/contact-details/relationship/rela
 import SelectApprovedVisitorPage from '../pages/contact-details/relationship/selectApprovedVisitorPage'
 import SelectEmergencyContactOrNextOfKinPage from '../pages/contact-details/relationship/selectEmergencyContactOrNextOfKinPage'
 
-context('Add Existing Contact Check Answers', () => {
+context('Add existing contact check answers including authoriser fields', () => {
   const { prisonerNumber } = TestData.prisoner()
   const contactId = 654321
   const contact = TestData.contact({
@@ -30,7 +30,7 @@ context('Add Existing Contact Check Answers', () => {
   beforeEach(() => {
     cy.task('reset')
     cy.task('stubComponentsMeta')
-    cy.task('stubSignIn', { roles: ['PRISON'] })
+    cy.task('stubSignIn', { roles: ['PRISON', 'CONTACTS_AUTHORISER'] })
     cy.task('stubTitlesReferenceData')
     cy.task('stubRelationshipReferenceData')
     cy.task('stubOfficialRelationshipReferenceData')
@@ -125,6 +125,39 @@ context('Add Existing Contact Check Answers', () => {
           isNextOfKin: false,
           isEmergencyContact: true,
           isApprovedVisitor: false,
+          comments: 'Some comments about the relationship',
+        },
+      },
+    )
+  })
+
+  it('Can change approved to visit from check answers', () => {
+    Page.verifyOnPage(LinkExistingContactCYAPage, 'Existing Contact') //
+      .verifyShowApprovedVisitorAs('No')
+      .clickLink('Change if the contact is approved to visit the prisoner')
+
+    Page.verifyOnPage(SelectApprovedVisitorPage, 'Existing Contact', 'John Smith', true) //
+      .selectIsApprovedVisitor('YES')
+      .clickContinue()
+
+    Page.verifyOnPage(LinkExistingContactCYAPage) //
+      .verifyShowApprovedVisitorAs('Yes')
+      .continueTo(AddContactSuccessPage)
+
+    cy.verifyLastAPICall(
+      {
+        method: 'POST',
+        urlPath: '/prisoner-contact',
+      },
+      {
+        contactId,
+        relationship: {
+          prisonerNumber: 'A1234BC',
+          relationshipTypeCode: 'S',
+          relationshipToPrisonerCode: 'MOT',
+          isNextOfKin: true,
+          isEmergencyContact: false,
+          isApprovedVisitor: true,
           comments: 'Some comments about the relationship',
         },
       },

--- a/integration_tests/e2e/addExistingContactCheckAnswersChangeRelationship.cy.ts
+++ b/integration_tests/e2e/addExistingContactCheckAnswersChangeRelationship.cy.ts
@@ -8,7 +8,6 @@ import ContactConfirmationPage from '../pages/contactConfirmationPage'
 import AddContactSuccessPage from '../pages/addContactSuccessPage'
 import SelectRelationshipTypePage from '../pages/selectRelationshipTypePage'
 import RelationshipCommentsPage from '../pages/contact-details/relationship/relationshipCommentsPage'
-import SelectApprovedVisitorPage from '../pages/contact-details/relationship/selectApprovedVisitorPage'
 import SelectEmergencyContactOrNextOfKinPage from '../pages/contact-details/relationship/selectEmergencyContactOrNextOfKinPage'
 
 context('Add Existing Contact Check Answers', () => {
@@ -30,7 +29,7 @@ context('Add Existing Contact Check Answers', () => {
   beforeEach(() => {
     cy.task('reset')
     cy.task('stubComponentsMeta')
-    cy.task('stubSignIn', { roles: ['PRISON'] })
+    cy.task('stubSignIn', { roles: ['PRISON', 'CONTACTS_ADMIN'] })
     cy.task('stubTitlesReferenceData')
     cy.task('stubRelationshipReferenceData')
     cy.task('stubOfficialRelationshipReferenceData')
@@ -85,8 +84,6 @@ context('Add Existing Contact Check Answers', () => {
       .selectRelationship('MOT')
       .continueTo(SelectEmergencyContactOrNextOfKinPage, 'Existing Contact', 'John Smith', true) //
       .selectIsEmergencyContactOrNextOfKin('NOK')
-      .continueTo(SelectApprovedVisitorPage, 'Existing Contact', 'John Smith', true) //
-      .selectIsApprovedVisitor('NO')
       .continueTo(RelationshipCommentsPage, 'Existing Contact', 'John Smith', true) //
       .enterComments('Some comments about the relationship')
       .continueTo(LinkExistingContactCYAPage) //

--- a/integration_tests/e2e/createContactEnterDomesticStatus.cy.ts
+++ b/integration_tests/e2e/createContactEnterDomesticStatus.cy.ts
@@ -9,7 +9,6 @@ import CreateContactSuccessPage from '../pages/createContactSuccessPage'
 import SelectRelationshipTypePage from '../pages/selectRelationshipTypePage'
 import AddContactAdditionalInfoPage from '../pages/addContactAdditionalInfoPage'
 import SelectDomesticStatusPage from '../pages/contact-details/additional-information/selectDomesticStatusPage'
-import SelectApprovedVisitorPage from '../pages/contact-details/relationship/selectApprovedVisitorPage'
 import SelectEmergencyContactOrNextOfKinPage from '../pages/contact-details/relationship/selectEmergencyContactOrNextOfKinPage'
 import ManageDobPage from '../pages/contact-details/dobPage'
 
@@ -20,7 +19,7 @@ context('Create Contact and Enter Domestic Status', () => {
   beforeEach(() => {
     cy.task('reset')
     cy.task('stubComponentsMeta')
-    cy.task('stubSignIn', { roles: ['PRISON'] })
+    cy.task('stubSignIn', { roles: ['PRISON', 'CONTACTS_ADMIN'] })
     cy.task('stubTitlesReferenceData')
     cy.task('stubPhoneTypeReferenceData')
     cy.task('stubRelationshipReferenceData')
@@ -81,10 +80,6 @@ context('Create Contact and Enter Domestic Status', () => {
 
     Page.verifyOnPage(SelectEmergencyContactOrNextOfKinPage, 'First Last', 'John Smith', true) //
       .selectIsEmergencyContactOrNextOfKin('NOK')
-      .clickContinue()
-
-    Page.verifyOnPage(SelectApprovedVisitorPage, 'First Last', 'John Smith', true) //
-      .selectIsApprovedVisitor('NO')
       .clickContinue()
   })
 

--- a/integration_tests/e2e/createContactEnterGender.cy.ts
+++ b/integration_tests/e2e/createContactEnterGender.cy.ts
@@ -9,7 +9,6 @@ import CreateContactSuccessPage from '../pages/createContactSuccessPage'
 import SelectRelationshipTypePage from '../pages/selectRelationshipTypePage'
 import AddContactAdditionalInfoPage from '../pages/addContactAdditionalInfoPage'
 import SelectGenderPage from '../pages/selectGenderPage'
-import SelectApprovedVisitorPage from '../pages/contact-details/relationship/selectApprovedVisitorPage'
 import SelectEmergencyContactOrNextOfKinPage from '../pages/contact-details/relationship/selectEmergencyContactOrNextOfKinPage'
 import ManageDobPage from '../pages/contact-details/dobPage'
 
@@ -20,7 +19,7 @@ context('Create Contact and Enter Gender', () => {
   beforeEach(() => {
     cy.task('reset')
     cy.task('stubComponentsMeta')
-    cy.task('stubSignIn', { roles: ['PRISON'] })
+    cy.task('stubSignIn', { roles: ['PRISON', 'CONTACTS_ADMIN'] })
     cy.task('stubTitlesReferenceData')
     cy.task('stubPhoneTypeReferenceData')
     cy.task('stubRelationshipReferenceData')
@@ -81,10 +80,6 @@ context('Create Contact and Enter Gender', () => {
 
     Page.verifyOnPage(SelectEmergencyContactOrNextOfKinPage, 'First Last', 'John Smith', true) //
       .selectIsEmergencyContactOrNextOfKin('NOK')
-      .clickContinue()
-
-    Page.verifyOnPage(SelectApprovedVisitorPage, 'First Last', 'John Smith', true) //
-      .selectIsApprovedVisitor('NO')
       .clickContinue()
   })
 

--- a/integration_tests/e2e/createContactEnterIsStaff.cy.ts
+++ b/integration_tests/e2e/createContactEnterIsStaff.cy.ts
@@ -9,7 +9,6 @@ import CreateContactSuccessPage from '../pages/createContactSuccessPage'
 import SelectRelationshipTypePage from '../pages/selectRelationshipTypePage'
 import AddContactAdditionalInfoPage from '../pages/addContactAdditionalInfoPage'
 import SelectStaffStatusPage from '../pages/contact-details/selectStaffStatus'
-import SelectApprovedVisitorPage from '../pages/contact-details/relationship/selectApprovedVisitorPage'
 import SelectEmergencyContactOrNextOfKinPage from '../pages/contact-details/relationship/selectEmergencyContactOrNextOfKinPage'
 import ManageDobPage from '../pages/contact-details/dobPage'
 
@@ -20,7 +19,7 @@ context('Create Contact and Select Staff Status', () => {
   beforeEach(() => {
     cy.task('reset')
     cy.task('stubComponentsMeta')
-    cy.task('stubSignIn', { roles: ['PRISON'] })
+    cy.task('stubSignIn', { roles: ['PRISON', 'CONTACTS_ADMIN'] })
     cy.task('stubTitlesReferenceData')
     cy.task('stubPhoneTypeReferenceData')
     cy.task('stubRelationshipReferenceData')
@@ -80,10 +79,6 @@ context('Create Contact and Select Staff Status', () => {
 
     Page.verifyOnPage(SelectEmergencyContactOrNextOfKinPage, 'First Last', 'John Smith', true) //
       .selectIsEmergencyContactOrNextOfKin('NOK')
-      .clickContinue()
-
-    Page.verifyOnPage(SelectApprovedVisitorPage, 'First Last', 'John Smith', true) //
-      .selectIsApprovedVisitor('NO')
       .clickContinue()
   })
 

--- a/integration_tests/e2e/createContactEnterLanguageAndInterpreter.cy.ts
+++ b/integration_tests/e2e/createContactEnterLanguageAndInterpreter.cy.ts
@@ -9,7 +9,6 @@ import CreateContactSuccessPage from '../pages/createContactSuccessPage'
 import SelectRelationshipTypePage from '../pages/selectRelationshipTypePage'
 import AddContactAdditionalInfoPage from '../pages/addContactAdditionalInfoPage'
 import SelectLanguageAndInterpreterPage from '../pages/contact-details/additional-information/selectLanguageAndInterpreterPage'
-import SelectApprovedVisitorPage from '../pages/contact-details/relationship/selectApprovedVisitorPage'
 import SelectEmergencyContactOrNextOfKinPage from '../pages/contact-details/relationship/selectEmergencyContactOrNextOfKinPage'
 import ManageDobPage from '../pages/contact-details/dobPage'
 
@@ -20,7 +19,7 @@ context('Create Contact and Select Staff Status', () => {
   beforeEach(() => {
     cy.task('reset')
     cy.task('stubComponentsMeta')
-    cy.task('stubSignIn', { roles: ['PRISON'] })
+    cy.task('stubSignIn', { roles: ['PRISON', 'CONTACTS_ADMIN'] })
     cy.task('stubTitlesReferenceData')
     cy.task('stubPhoneTypeReferenceData')
     cy.task('stubRelationshipReferenceData')
@@ -81,10 +80,6 @@ context('Create Contact and Select Staff Status', () => {
 
     Page.verifyOnPage(SelectEmergencyContactOrNextOfKinPage, 'First Last', 'John Smith', true) //
       .selectIsEmergencyContactOrNextOfKin('NOK')
-      .clickContinue()
-
-    Page.verifyOnPage(SelectApprovedVisitorPage, 'First Last', 'John Smith', true) //
-      .selectIsApprovedVisitor('NO')
       .clickContinue()
   })
 

--- a/integration_tests/e2e/createContactWithAddresses.cy.ts
+++ b/integration_tests/e2e/createContactWithAddresses.cy.ts
@@ -17,7 +17,6 @@ import SelectAddressFlagsPage from '../pages/contact-methods/address/selectAddre
 import EnterAddressCommentsPage from '../pages/contact-methods/address/enterAddressCommentsPage'
 import ConfirmDeleteAddressPhonePage from '../pages/contact-methods/address/phone/confirmDeleteAddressPhonePage'
 import ConfirmDeleteContactAddressPage from '../pages/confirmDeleteContactAddressPage'
-import SelectApprovedVisitorPage from '../pages/contact-details/relationship/selectApprovedVisitorPage'
 import SelectEmergencyContactOrNextOfKinPage from '../pages/contact-details/relationship/selectEmergencyContactOrNextOfKinPage'
 import ManageDobPage from '../pages/contact-details/dobPage'
 
@@ -28,7 +27,7 @@ context('Create Contact With Addresses', () => {
   beforeEach(() => {
     cy.task('reset')
     cy.task('stubComponentsMeta')
-    cy.task('stubSignIn', { roles: ['PRISON'] })
+    cy.task('stubSignIn', { roles: ['PRISON', 'CONTACTS_ADMIN'] })
     cy.task('stubTitlesReferenceData')
     cy.task('stubRelationshipReferenceData')
     cy.task('stubOfficialRelationshipReferenceData')
@@ -94,10 +93,6 @@ context('Create Contact With Addresses', () => {
 
     Page.verifyOnPage(SelectEmergencyContactOrNextOfKinPage, 'First Last', 'John Smith', true) //
       .selectIsEmergencyContactOrNextOfKin('NOK')
-      .clickContinue()
-
-    Page.verifyOnPage(SelectApprovedVisitorPage, 'First Last', 'John Smith', true) //
-      .selectIsApprovedVisitor('NO')
       .clickContinue()
 
     // Can submit without entering a phone number and also go back to additional info

--- a/integration_tests/e2e/createContactWithEmailAddresses.cy.ts
+++ b/integration_tests/e2e/createContactWithEmailAddresses.cy.ts
@@ -10,7 +10,6 @@ import SelectRelationshipTypePage from '../pages/selectRelationshipTypePage'
 import AddContactAdditionalInfoPage from '../pages/addContactAdditionalInfoPage'
 import ConfirmDeleteEmailPage from '../pages/confirmDeleteEmailPage'
 import AddEmailsPage from '../pages/addEmailsPage'
-import SelectApprovedVisitorPage from '../pages/contact-details/relationship/selectApprovedVisitorPage'
 import SelectEmergencyContactOrNextOfKinPage from '../pages/contact-details/relationship/selectEmergencyContactOrNextOfKinPage'
 import ManageDobPage from '../pages/contact-details/dobPage'
 
@@ -21,7 +20,7 @@ context('Create Contact With Email addresses', () => {
   beforeEach(() => {
     cy.task('reset')
     cy.task('stubComponentsMeta')
-    cy.task('stubSignIn', { roles: ['PRISON'] })
+    cy.task('stubSignIn', { roles: ['PRISON', 'CONTACTS_ADMIN'] })
     cy.task('stubTitlesReferenceData')
     cy.task('stubRelationshipReferenceData')
     cy.task('stubOfficialRelationshipReferenceData')
@@ -83,10 +82,6 @@ context('Create Contact With Email addresses', () => {
 
     Page.verifyOnPage(SelectEmergencyContactOrNextOfKinPage, 'First Last', 'John Smith', true) //
       .selectIsEmergencyContactOrNextOfKin('NOK')
-      .clickContinue()
-
-    Page.verifyOnPage(SelectApprovedVisitorPage, 'First Last', 'John Smith', true) //
-      .selectIsApprovedVisitor('NO')
       .clickContinue()
 
     // Can submit without entering an email address and also go back to additional info

--- a/integration_tests/e2e/createContactWithEmployments.cy.ts
+++ b/integration_tests/e2e/createContactWithEmployments.cy.ts
@@ -8,7 +8,6 @@ import SearchContactPage from '../pages/searchContactPage'
 import CreateContactSuccessPage from '../pages/createContactSuccessPage'
 import SelectRelationshipTypePage from '../pages/selectRelationshipTypePage'
 import AddContactAdditionalInfoPage from '../pages/addContactAdditionalInfoPage'
-import SelectApprovedVisitorPage from '../pages/contact-details/relationship/selectApprovedVisitorPage'
 import SelectEmergencyContactOrNextOfKinPage from '../pages/contact-details/relationship/selectEmergencyContactOrNextOfKinPage'
 import UpdateEmploymentsPage from '../pages/update-employments/updateEmploymentsPage'
 import OrganisationSearchPage from '../pages/update-employments/organisationSearchPage'
@@ -24,7 +23,7 @@ context('Create Contact With Addresses', () => {
   beforeEach(() => {
     cy.task('reset')
     cy.task('stubComponentsMeta')
-    cy.task('stubSignIn', { roles: ['PRISON'] })
+    cy.task('stubSignIn', { roles: ['PRISON', 'CONTACTS_ADMIN'] })
     cy.task('stubTitlesReferenceData')
     cy.task('stubRelationshipReferenceData')
     cy.task('stubOfficialRelationshipReferenceData')
@@ -115,10 +114,6 @@ context('Create Contact With Addresses', () => {
 
     Page.verifyOnPage(SelectEmergencyContactOrNextOfKinPage, 'First Last', 'John Smith', true) //
       .selectIsEmergencyContactOrNextOfKin('NOK')
-      .clickContinue()
-
-    Page.verifyOnPage(SelectApprovedVisitorPage, 'First Last', 'John Smith', true) //
-      .selectIsApprovedVisitor('NO')
       .clickContinue()
 
     // Can submit without adding an employer and also go back to additional info

--- a/integration_tests/e2e/createContactWithIdentityDocuments.cy.ts
+++ b/integration_tests/e2e/createContactWithIdentityDocuments.cy.ts
@@ -10,7 +10,6 @@ import SelectRelationshipTypePage from '../pages/selectRelationshipTypePage'
 import AddContactAdditionalInfoPage from '../pages/addContactAdditionalInfoPage'
 import AddIdentityDocumentsPage from '../pages/addIdentityDocumentsPage'
 import ConfirmDeleteIdentityPage from '../pages/contact-details/confirmDeleteIdentityPage'
-import SelectApprovedVisitorPage from '../pages/contact-details/relationship/selectApprovedVisitorPage'
 import SelectEmergencyContactOrNextOfKinPage from '../pages/contact-details/relationship/selectEmergencyContactOrNextOfKinPage'
 import ManageDobPage from '../pages/contact-details/dobPage'
 
@@ -21,7 +20,7 @@ context('Create Contact With Identity documents', () => {
   beforeEach(() => {
     cy.task('reset')
     cy.task('stubComponentsMeta')
-    cy.task('stubSignIn', { roles: ['PRISON'] })
+    cy.task('stubSignIn', { roles: ['PRISON', 'CONTACTS_ADMIN'] })
     cy.task('stubTitlesReferenceData')
     cy.task('stubRelationshipReferenceData')
     cy.task('stubOfficialRelationshipReferenceData')
@@ -84,10 +83,6 @@ context('Create Contact With Identity documents', () => {
 
     Page.verifyOnPage(SelectEmergencyContactOrNextOfKinPage, 'First Last', 'John Smith', true) //
       .selectIsEmergencyContactOrNextOfKin('NOK')
-      .clickContinue()
-
-    Page.verifyOnPage(SelectApprovedVisitorPage, 'First Last', 'John Smith', true) //
-      .selectIsApprovedVisitor('NO')
       .clickContinue()
 
     // Can submit without entering an identity document and also go back to additional info

--- a/integration_tests/e2e/createContactWithPhones.cy.ts
+++ b/integration_tests/e2e/createContactWithPhones.cy.ts
@@ -10,7 +10,6 @@ import SelectRelationshipTypePage from '../pages/selectRelationshipTypePage'
 import AddContactAdditionalInfoPage from '../pages/addContactAdditionalInfoPage'
 import AddPhonesPage from '../pages/contact-methods/addPhonesPage'
 import ConfirmDeletePhonePage from '../pages/confirmDeletePhonePage'
-import SelectApprovedVisitorPage from '../pages/contact-details/relationship/selectApprovedVisitorPage'
 import SelectEmergencyContactOrNextOfKinPage from '../pages/contact-details/relationship/selectEmergencyContactOrNextOfKinPage'
 import ManageDobPage from '../pages/contact-details/dobPage'
 
@@ -21,7 +20,7 @@ context('Create Contact With Phone Numbers', () => {
   beforeEach(() => {
     cy.task('reset')
     cy.task('stubComponentsMeta')
-    cy.task('stubSignIn', { roles: ['PRISON'] })
+    cy.task('stubSignIn', { roles: ['PRISON', 'CONTACTS_ADMIN'] })
     cy.task('stubTitlesReferenceData')
     cy.task('stubRelationshipReferenceData')
     cy.task('stubOfficialRelationshipReferenceData')
@@ -83,10 +82,6 @@ context('Create Contact With Phone Numbers', () => {
 
     Page.verifyOnPage(SelectEmergencyContactOrNextOfKinPage, 'First Last', 'John Smith', true) //
       .selectIsEmergencyContactOrNextOfKin('NOK')
-      .clickContinue()
-
-    Page.verifyOnPage(SelectApprovedVisitorPage, 'First Last', 'John Smith', true) //
-      .selectIsApprovedVisitor('NO')
       .clickContinue()
 
     // Can submit without entering a phone number and also go back to additional info

--- a/integration_tests/e2e/createNewContactAsAdmin.cy.ts
+++ b/integration_tests/e2e/createNewContactAsAdmin.cy.ts
@@ -1,0 +1,423 @@
+import Page from '../pages/page'
+import EnterNamePage from '../pages/enterNamePage'
+import CreateContactCheckYourAnswersPage from '../pages/createContactCheckYourAnswersPage'
+import TestData from '../../server/routes/testutils/testData'
+import ListContactsPage from '../pages/listContacts'
+import SelectRelationshipPage from '../pages/selectRelationshipPage'
+import SearchContactPage from '../pages/searchContactPage'
+import ManageContactDetailsPage from '../pages/manageContactDetails'
+import CreateContactSuccessPage from '../pages/createContactSuccessPage'
+import SelectRelationshipTypePage from '../pages/selectRelationshipTypePage'
+import CancelAddContactPage from '../pages/cancelAddContactPage'
+import RelationshipCommentsPage from '../pages/contact-details/relationship/relationshipCommentsPage'
+import AddContactAdditionalInfoPage from '../pages/addContactAdditionalInfoPage'
+import SelectEmergencyContactOrNextOfKinPage from '../pages/contact-details/relationship/selectEmergencyContactOrNextOfKinPage'
+import ManageDobPage from '../pages/contact-details/dobPage'
+
+context('Create new contact as admin who cannot set visit approval', () => {
+  const contactId = 654321
+  const prisonerContactId = 987654
+
+  beforeEach(() => {
+    cy.task('reset')
+    cy.task('stubComponentsMeta')
+    cy.task('stubSignIn', { roles: ['PRISON', 'CONTACTS_ADMIN'] })
+    cy.task('stubTitlesReferenceData')
+    cy.task('stubPhoneTypeReferenceData')
+    cy.task('stubRelationshipReferenceData')
+    cy.task('stubOfficialRelationshipReferenceData')
+    cy.task('stubRelationshipTypeReferenceData')
+    cy.task('stubPrisonerById', TestData.prisoner())
+    cy.task('stubContactList', TestData.prisoner().prisonerNumber)
+    cy.task('stubCreateContact', {
+      createdContact: { id: contactId },
+      createdRelationship: { prisonerContactId },
+    })
+    cy.task(
+      'stubGetContactById',
+      TestData.contact({
+        id: contactId,
+        lastName: 'Last',
+        firstName: 'First',
+      }),
+    )
+    cy.task('stubGetContactNameById', { id: contactId, lastName: 'Last', firstName: 'First' })
+    cy.task('stubGetPrisonerContactRelationshipById', {
+      id: prisonerContactId,
+      response: TestData.prisonerContactRelationship(),
+    })
+    cy.task('stubGetPrisonerContactRestrictions', {
+      prisonerContactId,
+      response: {
+        prisonerContactRestrictions: [],
+        contactGlobalRestrictions: [],
+      },
+    })
+    cy.task('stubGetLinkedPrisoners', { contactId, linkedPrisoners: [] })
+    const { prisonerNumber } = TestData.prisoner()
+    cy.signIn({ startUrl: `/prisoner/${prisonerNumber}/contacts/list` })
+
+    Page.verifyOnPage(ListContactsPage, 'John Smith') //
+      .clickAddNewContactButton()
+
+    Page.verifyOnPage(SearchContactPage) //
+      .clickAddNewContactLink()
+  })
+
+  it('Can create a contact with only required fields', () => {
+    Page.verifyOnPage(EnterNamePage) //
+      .enterLastName('Last')
+      .enterFirstName('First')
+      .clickContinue()
+
+    Page.verifyOnPage(ManageDobPage, 'First Last', true) //
+      .clickContinue()
+
+    Page.verifyOnPage(SelectRelationshipTypePage, 'First Last', 'John Smith') //
+      .selectRelationshipType('S')
+      .clickContinue()
+
+    Page.verifyOnPage(SelectRelationshipPage, 'First Last', 'John Smith') //
+      .selectRelationship('MOT')
+      .clickContinue()
+
+    Page.verifyOnPage(SelectEmergencyContactOrNextOfKinPage, 'First Last', 'John Smith', true) //
+      .selectIsEmergencyContactOrNextOfKin('NOK')
+      .clickContinue()
+
+    Page.verifyOnPage(AddContactAdditionalInfoPage, 'First Last') //
+      .clickContinue()
+
+    Page.verifyOnPage(CreateContactCheckYourAnswersPage, 'John Smith') //
+      .verifyShowsTitleAs('Not provided')
+      .verifyShowsNameAs('First Last')
+      .verifyShowsDateOfBirthAs('Not provided')
+      .verifyShowRelationshipTypeAs('Social')
+      .verifyShowRelationshipAs('Mother')
+      .verifyShowIsEmergencyContactAs('No')
+      .verifyShowIsNextOfKinAs('Yes')
+      .verifyShowCommentsAs('Not provided')
+      .clickContinue()
+
+    Page.verifyOnPage(CreateContactSuccessPage) //
+      .clickLink('add the restrictions now')
+
+    Page.verifyOnPage(ManageContactDetailsPage, 'First Last')
+
+    cy.verifyLastAPICall(
+      {
+        method: 'POST',
+        urlPath: '/contact',
+      },
+      {
+        lastName: 'Last',
+        firstName: 'First',
+        isStaff: false,
+        interpreterRequired: false,
+        relationship: {
+          prisonerNumber: 'A1234BC',
+          relationshipTypeCode: 'S',
+          relationshipToPrisonerCode: 'MOT',
+          isNextOfKin: true,
+          isEmergencyContact: false,
+          isApprovedVisitor: false,
+        },
+      },
+    )
+  })
+
+  it('Can create a contact with all fields', () => {
+    Page.verifyOnPage(EnterNamePage) //
+      .selectTitle('Mr')
+      .enterLastName('Last')
+      .enterFirstName('First')
+      .enterMiddleNames('Middle')
+      .clickContinue()
+
+    Page.verifyOnPage(ManageDobPage, 'First Middle Last', true) //
+      .enterDay('15')
+      .enterMonth('06')
+      .enterYear('1982')
+      .clickContinue()
+
+    Page.verifyOnPage(SelectRelationshipTypePage, 'First Middle Last', 'John Smith') //
+      .selectRelationshipType('S')
+      .clickContinue()
+
+    Page.verifyOnPage(SelectRelationshipPage, 'First Middle Last', 'John Smith') //
+      .selectRelationship('MOT')
+      .clickContinue()
+
+    Page.verifyOnPage(SelectEmergencyContactOrNextOfKinPage, 'First Middle Last', 'John Smith', true) //
+      .selectIsEmergencyContactOrNextOfKin('EC')
+      .clickContinue()
+
+    Page.verifyOnPage(AddContactAdditionalInfoPage, 'First Middle Last') //
+      .clickLink('Comments on their relationship with John Smith')
+
+    Page.verifyOnPage(RelationshipCommentsPage, 'First Middle Last', 'John Smith', true) //
+      .enterComments('Some comments about this relationship')
+      .clickContinue()
+
+    Page.verifyOnPage(AddContactAdditionalInfoPage, 'First Middle Last') //
+      .clickContinue()
+
+    Page.verifyOnPage(CreateContactCheckYourAnswersPage, 'John Smith') //
+      .verifyShowsTitleAs('Mr')
+      .verifyShowsNameAs('First Middle Last')
+      .verifyShowsDateOfBirthAs('15 June 1982')
+      .verifyShowRelationshipAs('Mother')
+      .verifyShowIsEmergencyContactAs('Yes')
+      .verifyShowIsNextOfKinAs('No')
+      .verifyShowCommentsAs('Some comments about this relationship')
+      .clickContinue()
+
+    Page.verifyOnPage(CreateContactSuccessPage)
+
+    cy.verifyLastAPICall(
+      {
+        method: 'POST',
+        urlPath: '/contact',
+      },
+      {
+        titleCode: 'MR',
+        lastName: 'Last',
+        firstName: 'First',
+        middleNames: 'Middle',
+        dateOfBirth: '1982-06-15',
+        isStaff: false,
+        interpreterRequired: false,
+        relationship: {
+          prisonerNumber: 'A1234BC',
+          relationshipTypeCode: 'S',
+          relationshipToPrisonerCode: 'MOT',
+          isNextOfKin: false,
+          isEmergencyContact: true,
+          isApprovedVisitor: false,
+          comments: 'Some comments about this relationship',
+        },
+      },
+    )
+  })
+
+  it('Can create an official contact', () => {
+    Page.verifyOnPage(EnterNamePage) //
+      .enterLastName('Last')
+      .enterFirstName('First')
+      .clickContinue()
+
+    Page.verifyOnPage(ManageDobPage, 'First Last', true) //
+      .clickContinue()
+
+    Page.verifyOnPage(SelectRelationshipTypePage, 'First Last', 'John Smith') //
+      .selectRelationshipType('O')
+      .clickContinue()
+
+    Page.verifyOnPage(SelectRelationshipPage, 'First Last', 'John Smith') //
+      .selectRelationship('DR')
+      .clickContinue()
+
+    Page.verifyOnPage(SelectEmergencyContactOrNextOfKinPage, 'First Last', 'John Smith', true) //
+      .selectIsEmergencyContactOrNextOfKin('NOK')
+      .clickContinue()
+
+    Page.verifyOnPage(AddContactAdditionalInfoPage, 'First Last') //
+      .clickContinue()
+
+    Page.verifyOnPage(CreateContactCheckYourAnswersPage, 'John Smith') //
+      .verifyShowsTitleAs('Not provided')
+      .verifyShowsNameAs('First Last')
+      .verifyShowsDateOfBirthAs('Not provided')
+      .verifyShowRelationshipAs('Doctor')
+      .verifyShowIsEmergencyContactAs('No')
+      .verifyShowIsNextOfKinAs('Yes')
+      .clickContinue()
+
+    Page.verifyOnPage(CreateContactSuccessPage) //
+      .clickLink('add the restrictions now')
+
+    Page.verifyOnPage(ManageContactDetailsPage, 'First Last')
+
+    cy.verifyLastAPICall(
+      {
+        method: 'POST',
+        urlPath: '/contact',
+      },
+      {
+        lastName: 'Last',
+        firstName: 'First',
+        isStaff: false,
+        interpreterRequired: false,
+        relationship: {
+          prisonerNumber: 'A1234BC',
+          relationshipTypeCode: 'O',
+          relationshipToPrisonerCode: 'DR',
+          isNextOfKin: true,
+          isEmergencyContact: false,
+          isApprovedVisitor: false,
+        },
+      },
+    )
+  })
+  it('First name is required', () => {
+    const enterNamePage = Page.verifyOnPage(EnterNamePage)
+    enterNamePage.enterLastName('Last').clickContinue()
+
+    enterNamePage.hasFieldInError('firstName', 'Enter the contact’s first name')
+  })
+
+  it('Last name is required', () => {
+    const enterNamePage = Page.verifyOnPage(EnterNamePage)
+    enterNamePage.enterFirstName('First').clickContinue()
+
+    enterNamePage.hasFieldInError('lastName', 'Enter the contact’s last name')
+  })
+
+  it('Names are limited to 35 characters', () => {
+    const enterNamePage = Page.verifyOnPage(EnterNamePage)
+    enterNamePage //
+      .enterLastName('Last'.padEnd(36))
+      .enterFirstName('First'.padEnd(36))
+      .enterMiddleNames('Middle'.padEnd(36))
+      .clickContinue()
+
+    enterNamePage.hasFieldInError('lastName', 'Contact’s last name must be 35 characters or less')
+    enterNamePage.hasFieldInError('firstName', 'Contact’s first name must be 35 characters or less')
+    enterNamePage.hasFieldInError('middleNames', 'Contact’s middle names must be 35 characters or less')
+  })
+
+  it('Cannot enter a blank first name or last name', () => {
+    const enterNamePage = Page.verifyOnPage(EnterNamePage)
+    enterNamePage //
+      .enterLastName('  ')
+      .enterFirstName('  ')
+      .clickContinue()
+
+    enterNamePage.hasFieldInError('lastName', 'Enter the contact’s last name')
+    enterNamePage.hasFieldInError('firstName', 'Enter the contact’s first name')
+  })
+
+  it('Must select the contacts relationship to the prisoner', () => {
+    Page.verifyOnPage(EnterNamePage) //
+      .enterLastName('Last')
+      .enterFirstName('First')
+      .continueTo(ManageDobPage, 'First Last', true)
+      .clickContinue()
+
+    Page.verifyOnPage(SelectRelationshipTypePage, 'First Last', 'John Smith') //
+      .selectRelationshipType('S')
+      .clickContinue()
+
+    const selectRelationshipPage = Page.verifyOnPage(SelectRelationshipPage, 'First Last', 'John Smith')
+    selectRelationshipPage.clickContinue()
+
+    selectRelationshipPage.hasFieldInError('relationship', 'Select the contact’s relationship to the prisoner')
+  })
+
+  it('Must enter dob if it is known', () => {
+    Page.verifyOnPage(EnterNamePage) //
+      .enterLastName('Last')
+      .enterFirstName('First')
+      .clickContinue()
+
+    const enterDobPage = Page.verifyOnPage(ManageDobPage, 'First Last', true)
+    enterDobPage.enterYear(' ').clickContinue()
+    enterDobPage.hasFieldInError('dob', 'Date of birth must include a day and a month')
+    enterDobPage.errorSummaryItems.spread((...$lis) => {
+      expect($lis).to.have.lengthOf(2)
+      expect($lis[0]).to.contain('Date of birth must include a day and a month')
+      expect($lis[1]).to.contain('Year must include 4 numbers')
+    })
+  })
+
+  it('Day, month and year must be numbers', () => {
+    Page.verifyOnPage(EnterNamePage) //
+      .enterLastName('Last')
+      .enterFirstName('First')
+      .clickContinue()
+
+    const enterDobPage = Page.verifyOnPage(ManageDobPage, 'First Last', true)
+    enterDobPage.enterDay('aa').enterMonth('bb').enterYear('cccc').clickContinue()
+
+    enterDobPage.hasFieldInError('dob', 'Date of birth must be a real date')
+    enterDobPage.errorSummaryItems.spread((...$lis) => {
+      expect($lis).to.have.lengthOf(1)
+      expect($lis[0]).to.contain('Date of birth must be a real date')
+    })
+  })
+
+  it('Relationship comments must be less than 240 characters', () => {
+    Page.verifyOnPage(EnterNamePage) //
+      .enterLastName('Last')
+      .enterFirstName('First')
+      .continueTo(ManageDobPage, 'First Last', true) //
+      .continueTo(SelectRelationshipTypePage, 'First Last', 'John Smith')
+      .selectRelationshipType('S')
+      .continueTo(SelectRelationshipPage, 'First Last', 'John Smith') //
+      .selectRelationship('MOT')
+      .continueTo(SelectEmergencyContactOrNextOfKinPage, 'First Last', 'John Smith', true) //
+      .selectIsEmergencyContactOrNextOfKin('NOK')
+      .continueTo(AddContactAdditionalInfoPage, 'First Last')
+      .clickLink('Comments on their relationship with John Smith')
+
+    const commentsPage = Page.verifyOnPage(RelationshipCommentsPage, 'First Last', 'John Smith', true) //
+      .enterComments(''.padEnd(241))
+      .continueTo(RelationshipCommentsPage, 'First Last', 'John Smith', true)
+
+    commentsPage.hasFieldInError('comments', 'Comments must be 240 characters or less')
+  })
+
+  it('Can navigate back through all pages', () => {
+    const relationshipCommentsPage = Page.verifyOnPage(EnterNamePage) //
+      .enterLastName('Last')
+      .enterFirstName('First')
+      .continueTo(ManageDobPage, 'First Last', true)
+      .continueTo(SelectRelationshipTypePage, 'First Last', 'John Smith')
+      .selectRelationshipType('S')
+      .continueTo(SelectRelationshipPage, 'First Last', 'John Smith')
+      .selectRelationship('MOT')
+      .continueTo(SelectEmergencyContactOrNextOfKinPage, 'First Last', 'John Smith', true) //
+      .selectIsEmergencyContactOrNextOfKin('NOK')
+      .continueTo(AddContactAdditionalInfoPage, 'First Last')
+      .clickLinkTo(
+        'Comments on their relationship with John Smith',
+        RelationshipCommentsPage,
+        'First Last',
+        'John Smith',
+        true,
+      )
+      .backTo(AddContactAdditionalInfoPage, 'First Last')
+      .continueTo(CreateContactCheckYourAnswersPage, 'John Smith')
+
+    relationshipCommentsPage //
+      .backTo(AddContactAdditionalInfoPage, 'First Last')
+      .backTo(SelectEmergencyContactOrNextOfKinPage, 'First Last', 'John Smith', true)
+      .backTo(SelectRelationshipPage, 'First Last', 'John Smith')
+      .backTo(SelectRelationshipTypePage, 'First Last', 'John Smith')
+      .backTo(ManageDobPage, 'First Last', true)
+      .backTo(EnterNamePage)
+  })
+
+  it('Cancelling from check answers prompts for confirmation', () => {
+    Page.verifyOnPage(EnterNamePage) //
+      .enterLastName('Last')
+      .enterFirstName('First')
+      .continueTo(ManageDobPage, 'First Last', true) //
+      .continueTo(SelectRelationshipTypePage, 'First Last', 'John Smith') //
+      .selectRelationshipType('S')
+      .continueTo(SelectRelationshipPage, 'First Last', 'John Smith') //
+      .selectRelationship('MOT')
+      .continueTo(SelectEmergencyContactOrNextOfKinPage, 'First Last', 'John Smith', true) //
+      .selectIsEmergencyContactOrNextOfKin('NOK')
+      .continueTo(AddContactAdditionalInfoPage, 'First Last')
+      .continueTo(CreateContactCheckYourAnswersPage, 'John Smith') //
+      .clickLink('Cancel')
+
+    Page.verifyOnPage(CancelAddContactPage, 'NEW', 'First Last') //
+      .clickButtonTo('No, return to check answers', CreateContactCheckYourAnswersPage, 'John Smith')
+      .clickLinkTo('Cancel', CancelAddContactPage, 'NEW', 'First Last') //
+      .clickButton('Yes, cancel')
+
+    Page.verifyOnPage(ListContactsPage, 'John Smith')
+  })
+})

--- a/integration_tests/e2e/createNewContactAsAuthoriser.cy.ts
+++ b/integration_tests/e2e/createNewContactAsAuthoriser.cy.ts
@@ -15,14 +15,14 @@ import SelectApprovedVisitorPage from '../pages/contact-details/relationship/sel
 import SelectEmergencyContactOrNextOfKinPage from '../pages/contact-details/relationship/selectEmergencyContactOrNextOfKinPage'
 import ManageDobPage from '../pages/contact-details/dobPage'
 
-context('Create Contacts', () => {
+context('Create new contact as authoriser who can set visit approval', () => {
   const contactId = 654321
   const prisonerContactId = 987654
 
   beforeEach(() => {
     cy.task('reset')
     cy.task('stubComponentsMeta')
-    cy.task('stubSignIn', { roles: ['PRISON'] })
+    cy.task('stubSignIn', { roles: ['PRISON', 'CONTACTS_AUTHORISER'] })
     cy.task('stubTitlesReferenceData')
     cy.task('stubPhoneTypeReferenceData')
     cy.task('stubRelationshipReferenceData')
@@ -87,7 +87,7 @@ context('Create Contacts', () => {
       .clickContinue()
 
     Page.verifyOnPage(SelectApprovedVisitorPage, 'First Last', 'John Smith', true) //
-      .selectIsApprovedVisitor('NO')
+      .selectIsApprovedVisitor('YES')
       .clickContinue()
 
     Page.verifyOnPage(AddContactAdditionalInfoPage, 'First Last') //
@@ -125,7 +125,7 @@ context('Create Contacts', () => {
           relationshipToPrisonerCode: 'MOT',
           isNextOfKin: true,
           isEmergencyContact: false,
-          isApprovedVisitor: false,
+          isApprovedVisitor: true,
         },
       },
     )

--- a/integration_tests/e2e/selectApprovedVisitor.cy.ts
+++ b/integration_tests/e2e/selectApprovedVisitor.cy.ts
@@ -17,7 +17,7 @@ context('Manage contact update approved visitor contact', () => {
   beforeEach(() => {
     cy.task('reset')
     cy.task('stubComponentsMeta')
-    cy.task('stubSignIn', { roles: ['PRISON'] })
+    cy.task('stubSignIn', { roles: ['PRISON', 'CONTACTS_AUTHORISER'] })
     cy.task('stubTitlesReferenceData')
     cy.task('stubPhoneTypeReferenceData')
     cy.task('stubPrisonerById', TestData.prisoner())

--- a/integration_tests/pages/createContactCheckYourAnswersPage.ts
+++ b/integration_tests/pages/createContactCheckYourAnswersPage.ts
@@ -100,6 +100,11 @@ export default class CreateContactCheckYourAnswersPage extends Page {
     return this
   }
 
+  verifyShowApprovedVisitorAs(expected: string): CreateContactCheckYourAnswersPage {
+    this.checkAnswersApprovedVisitorValue().should('contain.text', expected)
+    return this
+  }
+
   private checkAnswersTitleValue = (): PageElement => cy.get('.check-answers-title-value')
 
   private checkAnswersNameValue = (): PageElement => cy.get('.check-answers-name-value')
@@ -115,6 +120,8 @@ export default class CreateContactCheckYourAnswersPage extends Page {
   private checkAnswersNextOfKinValue = (): PageElement => cy.get('.check-answers-next-of-kin-value')
 
   private checkAnswersCommentsValue = (): PageElement => cy.get('.check-answers-comments-value')
+
+  private checkAnswersApprovedVisitorValue = (): PageElement => cy.get('.check-answers-approved-visitor-value')
 
   private checkAnswersGenderValue = (): PageElement => cy.get('.check-answers-gender-value')
 

--- a/integration_tests/pages/linkExistingContactCYAPage.ts
+++ b/integration_tests/pages/linkExistingContactCYAPage.ts
@@ -55,6 +55,11 @@ export default class LinkExistingContactCYAPage extends Page {
     return this
   }
 
+  verifyShowApprovedVisitorAs(expected: string): LinkExistingContactCYAPage {
+    this.checkAnswersApprovedVisitorValue().should('contain.text', expected)
+    return this
+  }
+
   private checkAnswersNameValue = (): PageElement => cy.findByText('Contact:').next()
 
   private checkAnswersRelationshipValue = (): PageElement => cy.get('.check-answers-relationship-to-prisoner-value')
@@ -62,6 +67,8 @@ export default class LinkExistingContactCYAPage extends Page {
   private checkAnswersRelationshipTypeValue = (): PageElement => cy.get('.check-answers-relationship-type-value')
 
   private checkAnswersEmergencyContactValue = (): PageElement => cy.get('.check-answers-emergency-contact-value')
+
+  private checkAnswersApprovedVisitorValue = (): PageElement => cy.get('.check-answers-approved-visitor-value')
 
   private checkAnswersNextOfKinValue = (): PageElement => cy.get('.check-answers-next-of-kin-value')
 

--- a/server/routes/contacts/add/addContactFlowControl.test.ts
+++ b/server/routes/contacts/add/addContactFlowControl.test.ts
@@ -3,6 +3,8 @@ import { navigationForAddContactJourney, nextPageForAddContactJourney } from './
 import { Page } from '../../../services/auditService'
 import { BreadcrumbType, Navigation } from '../common/navigation'
 import { AddContactJourney } from '../../../@types/journeys'
+import { adminUser, authorisingUser } from '../../testutils/appSetup'
+import { HmppsUser } from '../../../interfaces/hmppsUser'
 
 describe('addContactFlowControl', () => {
   describe('add new contact', () => {
@@ -15,112 +17,143 @@ describe('addContactFlowControl', () => {
           `/prisoner/A1234BC/contacts/search/${journeyId}`,
           undefined,
           'Back to contact search',
+          adminUser,
         ],
         [
           Page.CREATE_CONTACT_DOB_PAGE,
           `/prisoner/A1234BC/contacts/create/enter-name/${journeyId}`,
           undefined,
           undefined,
+          adminUser,
         ],
         [
           Page.SELECT_RELATIONSHIP_TYPE,
           `/prisoner/A1234BC/contacts/create/enter-dob/${journeyId}`,
           undefined,
           undefined,
+          adminUser,
         ],
         [
           Page.SELECT_CONTACT_RELATIONSHIP,
           `/prisoner/A1234BC/contacts/create/select-relationship-type/${journeyId}`,
           undefined,
           undefined,
+          adminUser,
         ],
         [
           Page.SELECT_EMERGENCY_CONTACT_OR_NEXT_OF_KIN,
           `/prisoner/A1234BC/contacts/create/select-relationship-to-prisoner/${journeyId}`,
           undefined,
           undefined,
+          adminUser,
         ],
         [
           Page.ADD_CONTACT_APPROVED_TO_VISIT_PAGE,
           `/prisoner/A1234BC/contacts/create/emergency-contact-or-next-of-kin/${journeyId}`,
           undefined,
           undefined,
+          adminUser,
+        ],
+        [
+          Page.ENTER_ADDITIONAL_INFORMATION_PAGE,
+          `/prisoner/A1234BC/contacts/create/emergency-contact-or-next-of-kin/${journeyId}`,
+          undefined,
+          `Back to emergency contact and next of kin`,
+          adminUser,
         ],
         [
           Page.ENTER_ADDITIONAL_INFORMATION_PAGE,
           `/prisoner/A1234BC/contacts/create/approved-to-visit/${journeyId}`,
           undefined,
           `Back to visits approval`,
+          authorisingUser,
         ],
         [
           Page.ENTER_RELATIONSHIP_COMMENTS,
           `/prisoner/A1234BC/contacts/add/enter-additional-info/${journeyId}`,
           undefined,
           undefined,
+          adminUser,
         ],
         [
           Page.CREATE_CONTACT_CHECK_ANSWERS_PAGE,
           `/prisoner/A1234BC/contacts/add/enter-additional-info/${journeyId}`,
           `/prisoner/A1234BC/contacts/add/cancel/${journeyId}`,
           'Back to additional information options',
+          adminUser,
         ],
         [
           Page.ADD_CONTACT_CANCEL_PAGE,
           `/prisoner/A1234BC/contacts/create/check-answers/${journeyId}`,
           undefined,
           undefined,
+          adminUser,
         ],
         [
           Page.ADD_CONTACT_ADD_PHONE_PAGE,
           `/prisoner/A1234BC/contacts/add/enter-additional-info/${journeyId}`,
           undefined,
           undefined,
+          adminUser,
         ],
         [
           Page.ADD_CONTACT_DELETE_PHONE_PAGE,
           `/prisoner/A1234BC/contacts/create/check-answers/${journeyId}`,
           `/prisoner/A1234BC/contacts/create/check-answers/${journeyId}`,
           undefined,
+          adminUser,
         ],
         [
           Page.ADD_CONTACT_ENTER_GENDER_PAGE,
           `/prisoner/A1234BC/contacts/add/enter-additional-info/${journeyId}`,
           undefined,
           undefined,
+          adminUser,
         ],
         [
           Page.ADD_CONTACT_IS_STAFF_PAGE,
           `/prisoner/A1234BC/contacts/add/enter-additional-info/${journeyId}`,
           undefined,
           undefined,
+          adminUser,
         ],
         [
           Page.ADD_CONTACT_LANGUAGE_INTERPRETER_PAGE,
           `/prisoner/A1234BC/contacts/add/enter-additional-info/${journeyId}`,
           undefined,
           undefined,
+          adminUser,
         ],
         [
           Page.ADD_CONTACT_DOMESTIC_STATUS_PAGE,
           `/prisoner/A1234BC/contacts/add/enter-additional-info/${journeyId}`,
           undefined,
           undefined,
+          adminUser,
         ],
         [
           Page.ADD_EMPLOYMENTS,
           `/prisoner/A1234BC/contacts/add/enter-additional-info/${journeyId}`,
           undefined,
           'Back to additional information options',
+          adminUser,
         ],
         [
           Page.ADD_ADDRESSES,
           `/prisoner/A1234BC/contacts/add/enter-additional-info/${journeyId}`,
           undefined,
           'Back to additional information options',
+          adminUser,
         ],
       ])(
         'Should go back to previous page: from %s to %s',
-        (page: Page, expectedBackUrl?: string, expectedCancelButton?: string, expectedBackLabel?: string) => {
+        (
+          page: Page,
+          expectedBackUrl: string | undefined,
+          expectedCancelButton: string | undefined,
+          expectedBackLabel: string | undefined,
+          user: HmppsUser,
+        ) => {
           const journey: AddContactJourney = {
             id: journeyId,
             lastTouched: new Date().toISOString(),
@@ -141,7 +174,7 @@ describe('addContactFlowControl', () => {
             cancelButton: expectedCancelButton,
           }
 
-          const nav = navigationForAddContactJourney(page, journey)
+          const nav = navigationForAddContactJourney(page, journey, user)
 
           expect(nav).toStrictEqual(expected)
         },
@@ -187,7 +220,7 @@ describe('addContactFlowControl', () => {
             cancelButton,
           }
 
-          const nav = navigationForAddContactJourney(page, journey)
+          const nav = navigationForAddContactJourney(page, journey, adminUser)
 
           expect(nav).toStrictEqual(expected)
         },
@@ -198,101 +231,96 @@ describe('addContactFlowControl', () => {
       const journeyId = uuidv4()
 
       it.each([
-        [Page.CREATE_CONTACT_START_PAGE, `/prisoner/A1234BC/contacts/search/${journeyId}`],
-        [Page.ADD_CONTACT_MODE_PAGE, `/prisoner/A1234BC/contacts/create/enter-name/${journeyId}`],
-        [Page.CREATE_CONTACT_NAME_PAGE, `/prisoner/A1234BC/contacts/create/enter-dob/${journeyId}`],
-        [Page.CREATE_CONTACT_DOB_PAGE, `/prisoner/A1234BC/contacts/create/select-relationship-type/${journeyId}`],
+        [Page.CREATE_CONTACT_START_PAGE, `/prisoner/A1234BC/contacts/search/${journeyId}`, adminUser],
+        [Page.ADD_CONTACT_MODE_PAGE, `/prisoner/A1234BC/contacts/create/enter-name/${journeyId}`, adminUser],
+        [Page.CREATE_CONTACT_NAME_PAGE, `/prisoner/A1234BC/contacts/create/enter-dob/${journeyId}`, adminUser],
+        [
+          Page.CREATE_CONTACT_DOB_PAGE,
+          `/prisoner/A1234BC/contacts/create/select-relationship-type/${journeyId}`,
+          adminUser,
+        ],
         [
           Page.SELECT_RELATIONSHIP_TYPE,
           `/prisoner/A1234BC/contacts/create/select-relationship-to-prisoner/${journeyId}`,
+          adminUser,
         ],
         [
           Page.SELECT_CONTACT_RELATIONSHIP,
           `/prisoner/A1234BC/contacts/create/emergency-contact-or-next-of-kin/${journeyId}`,
+          adminUser,
+        ],
+        [
+          Page.SELECT_EMERGENCY_CONTACT_OR_NEXT_OF_KIN,
+          `/prisoner/A1234BC/contacts/add/enter-additional-info/${journeyId}`,
+          adminUser,
         ],
         [
           Page.SELECT_EMERGENCY_CONTACT_OR_NEXT_OF_KIN,
           `/prisoner/A1234BC/contacts/create/approved-to-visit/${journeyId}`,
+          authorisingUser,
         ],
-        [Page.ADD_CONTACT_APPROVED_TO_VISIT_PAGE, `/prisoner/A1234BC/contacts/add/enter-additional-info/${journeyId}`],
-        [Page.ENTER_RELATIONSHIP_COMMENTS, `/prisoner/A1234BC/contacts/add/enter-additional-info/${journeyId}`],
-        [Page.CREATE_CONTACT_CHECK_ANSWERS_PAGE, `/prisoner/A1234BC/contact/NEW/123456/654321/success`],
-        [Page.ADD_CONTACT_ADD_PHONE_PAGE, `/prisoner/A1234BC/contacts/add/enter-additional-info/${journeyId}`],
-        [Page.ADD_CONTACT_DELETE_PHONE_PAGE, `/prisoner/A1234BC/contacts/create/check-answers/${journeyId}`],
-        [Page.ADD_CONTACT_ENTER_GENDER_PAGE, `/prisoner/A1234BC/contacts/add/enter-additional-info/${journeyId}`],
-        [Page.ADD_CONTACT_IS_STAFF_PAGE, `/prisoner/A1234BC/contacts/add/enter-additional-info/${journeyId}`],
+        [
+          Page.ADD_CONTACT_APPROVED_TO_VISIT_PAGE,
+          `/prisoner/A1234BC/contacts/add/enter-additional-info/${journeyId}`,
+          adminUser,
+        ],
+        [
+          Page.ENTER_RELATIONSHIP_COMMENTS,
+          `/prisoner/A1234BC/contacts/add/enter-additional-info/${journeyId}`,
+          adminUser,
+        ],
+        [Page.CREATE_CONTACT_CHECK_ANSWERS_PAGE, `/prisoner/A1234BC/contact/NEW/123456/654321/success`, adminUser],
+        [
+          Page.ADD_CONTACT_ADD_PHONE_PAGE,
+          `/prisoner/A1234BC/contacts/add/enter-additional-info/${journeyId}`,
+          adminUser,
+        ],
+        [Page.ADD_CONTACT_DELETE_PHONE_PAGE, `/prisoner/A1234BC/contacts/create/check-answers/${journeyId}`, adminUser],
+        [
+          Page.ADD_CONTACT_ENTER_GENDER_PAGE,
+          `/prisoner/A1234BC/contacts/add/enter-additional-info/${journeyId}`,
+          adminUser,
+        ],
+        [
+          Page.ADD_CONTACT_IS_STAFF_PAGE,
+          `/prisoner/A1234BC/contacts/add/enter-additional-info/${journeyId}`,
+          adminUser,
+        ],
         [
           Page.ADD_CONTACT_LANGUAGE_INTERPRETER_PAGE,
           `/prisoner/A1234BC/contacts/add/enter-additional-info/${journeyId}`,
+          adminUser,
         ],
-        [Page.ADD_CONTACT_DOMESTIC_STATUS_PAGE, `/prisoner/A1234BC/contacts/add/enter-additional-info/${journeyId}`],
-      ])('Should go to next page if not checking answers: from %s to %s', (page: Page, expectedNextUrl?: string) => {
-        const journey: AddContactJourney = {
-          id: journeyId,
-          lastTouched: new Date().toISOString(),
-          prisonerNumber: 'A1234BC',
-          returnPoint: {
-            url: '/foo',
-          },
-          isCheckingAnswers: false,
-          dateOfBirth: {
-            isKnown: 'NO',
-          },
-          mode: 'NEW',
-          contactId: 123456,
-          prisonerContactId: 654321,
-        }
-
-        const nav = nextPageForAddContactJourney(page, journey)
-
-        expect(nav).toStrictEqual(expectedNextUrl)
-      })
-
-      it.each([
-        [Page.CREATE_CONTACT_NAME_PAGE],
-        [Page.SELECT_RELATIONSHIP_TYPE],
-        [Page.SELECT_CONTACT_RELATIONSHIP],
-        [Page.SELECT_EMERGENCY_CONTACT_OR_NEXT_OF_KIN],
-        [Page.ADD_CONTACT_APPROVED_TO_VISIT_PAGE],
-        [Page.CREATE_CONTACT_DOB_PAGE],
-        [Page.ENTER_RELATIONSHIP_COMMENTS],
-        [Page.ADD_CONTACT_ADD_PHONE_PAGE],
-        [Page.ADD_CONTACT_DELETE_PHONE_PAGE],
-        [Page.ADD_CONTACT_ENTER_GENDER_PAGE],
-        [Page.ADD_CONTACT_IS_STAFF_PAGE],
-        [Page.ADD_CONTACT_LANGUAGE_INTERPRETER_PAGE],
-        [Page.ADD_CONTACT_DOMESTIC_STATUS_PAGE],
-      ])('Should go back to checking answer page: from %s', (page: Page) => {
-        const journey: AddContactJourney = {
-          id: journeyId,
-          lastTouched: new Date().toISOString(),
-          prisonerNumber: 'A1234BC',
-          returnPoint: {
-            url: '/foo',
-          },
-          dateOfBirth: {
-            isKnown: 'YES',
-          },
-          relationship: {
-            pendingNewRelationshipType: 'S',
-            relationshipType: 'S',
-            relationshipToPrisoner: 'MOT',
-          },
-          isCheckingAnswers: true,
-          previousAnswers: {
-            relationship: {
-              relationshipType: 'S',
-              relationshipToPrisoner: 'MOT',
+        [
+          Page.ADD_CONTACT_DOMESTIC_STATUS_PAGE,
+          `/prisoner/A1234BC/contacts/add/enter-additional-info/${journeyId}`,
+          adminUser,
+        ],
+      ])(
+        'Should go to next page if not checking answers: from %s to %s',
+        (page: Page, expectedNextUrl: string | undefined, user: HmppsUser) => {
+          const journey: AddContactJourney = {
+            id: journeyId,
+            lastTouched: new Date().toISOString(),
+            prisonerNumber: 'A1234BC',
+            returnPoint: {
+              url: '/foo',
             },
-          },
-          mode: 'NEW',
-        }
-        const expected = `/prisoner/A1234BC/contacts/create/check-answers/${journeyId}`
+            isCheckingAnswers: false,
+            dateOfBirth: {
+              isKnown: 'NO',
+            },
+            mode: 'NEW',
+            contactId: 123456,
+            prisonerContactId: 654321,
+          }
 
-        const nav = nextPageForAddContactJourney(page, journey)
+          const nav = nextPageForAddContactJourney(page, journey, user)
 
-        expect(nav).toStrictEqual(expected)
-      })
+          expect(nav).toStrictEqual(expectedNextUrl)
+        },
+      )
+
       it.each([
         ['S', 'O', `/prisoner/A1234BC/contacts/create/select-relationship-to-prisoner/${journeyId}`],
         ['O', 'S', `/prisoner/A1234BC/contacts/create/select-relationship-to-prisoner/${journeyId}`],
@@ -323,7 +351,7 @@ describe('addContactFlowControl', () => {
             },
           }
 
-          const nav = nextPageForAddContactJourney(Page.SELECT_RELATIONSHIP_TYPE, journey)
+          const nav = nextPageForAddContactJourney(Page.SELECT_RELATIONSHIP_TYPE, journey, adminUser)
 
           expect(nav).toStrictEqual(expected)
         },
@@ -340,52 +368,73 @@ describe('addContactFlowControl', () => {
           `/prisoner/A1234BC/contacts/search/${journeyId}`,
           undefined,
           'Back to contact search',
+          adminUser,
         ],
         [
           Page.SELECT_RELATIONSHIP_TYPE,
           `/prisoner/A1234BC/contacts/add/match/12346789/${journeyId}`,
           undefined,
           undefined,
+          adminUser,
         ],
         [
           Page.SELECT_CONTACT_RELATIONSHIP,
           `/prisoner/A1234BC/contacts/create/select-relationship-type/${journeyId}`,
           undefined,
           undefined,
+          adminUser,
         ],
         [
           Page.SELECT_EMERGENCY_CONTACT_OR_NEXT_OF_KIN,
           `/prisoner/A1234BC/contacts/create/select-relationship-to-prisoner/${journeyId}`,
           undefined,
           undefined,
+          adminUser,
         ],
         [
           Page.ADD_CONTACT_APPROVED_TO_VISIT_PAGE,
           `/prisoner/A1234BC/contacts/create/emergency-contact-or-next-of-kin/${journeyId}`,
           undefined,
           undefined,
+          adminUser,
+        ],
+        [
+          Page.ENTER_RELATIONSHIP_COMMENTS,
+          `/prisoner/A1234BC/contacts/create/emergency-contact-or-next-of-kin/${journeyId}`,
+          undefined,
+          undefined,
+          adminUser,
         ],
         [
           Page.ENTER_RELATIONSHIP_COMMENTS,
           `/prisoner/A1234BC/contacts/create/approved-to-visit/${journeyId}`,
           undefined,
           undefined,
+          authorisingUser,
         ],
         [
           Page.CREATE_CONTACT_CHECK_ANSWERS_PAGE,
           `/prisoner/A1234BC/contacts/create/enter-relationship-comments/${journeyId}`,
           `/prisoner/A1234BC/contacts/add/cancel/${journeyId}`,
           'Back to relationship comments',
+          adminUser,
         ],
         [
           Page.ADD_CONTACT_CANCEL_PAGE,
           `/prisoner/A1234BC/contacts/create/check-answers/${journeyId}`,
           undefined,
           undefined,
+          adminUser,
         ],
       ])(
         'Should go back to previous page: from %s to %s',
-        (page: Page, expectedBackUrl?: string, expectedCancelButton?: string, expectedBackLinkLabel?: string) => {
+        (
+          page: Page,
+          expectedBackUrl: string | undefined,
+          expectedCancelButton: string | undefined,
+          expectedBackLinkLabel: string | undefined,
+          user: HmppsUser,
+        ) => {
           const journey: AddContactJourney = {
             id: journeyId,
             lastTouched: new Date().toISOString(),
@@ -404,7 +453,7 @@ describe('addContactFlowControl', () => {
             cancelButton: expectedCancelButton,
           }
 
-          const nav = navigationForAddContactJourney(page, journey)
+          const nav = navigationForAddContactJourney(page, journey, user)
 
           expect(nav).toStrictEqual(expected)
         },
@@ -434,7 +483,7 @@ describe('addContactFlowControl', () => {
           cancelButton: undefined,
         }
 
-        const nav = navigationForAddContactJourney(page, journey)
+        const nav = navigationForAddContactJourney(page, journey, adminUser)
 
         expect(nav).toStrictEqual(expected)
       })
@@ -443,80 +492,61 @@ describe('addContactFlowControl', () => {
     describe('getNextPageForAddContactJourney', () => {
       const journeyId = uuidv4()
       it.each([
-        [Page.CREATE_CONTACT_START_PAGE, `/prisoner/A1234BC/contacts/search/${journeyId}`],
-        [Page.CONTACT_MATCH_PAGE, `/prisoner/A1234BC/contacts/add/mode/EXISTING/${journeyId}`],
-        [Page.ADD_CONTACT_MODE_PAGE, `/prisoner/A1234BC/contacts/create/select-relationship-type/${journeyId}`],
+        [Page.CREATE_CONTACT_START_PAGE, `/prisoner/A1234BC/contacts/search/${journeyId}`, adminUser],
+        [Page.CONTACT_MATCH_PAGE, `/prisoner/A1234BC/contacts/add/mode/EXISTING/${journeyId}`, adminUser],
+        [
+          Page.ADD_CONTACT_MODE_PAGE,
+          `/prisoner/A1234BC/contacts/create/select-relationship-type/${journeyId}`,
+          adminUser,
+        ],
         [
           Page.SELECT_RELATIONSHIP_TYPE,
           `/prisoner/A1234BC/contacts/create/select-relationship-to-prisoner/${journeyId}`,
+          adminUser,
         ],
         [
           Page.SELECT_CONTACT_RELATIONSHIP,
           `/prisoner/A1234BC/contacts/create/emergency-contact-or-next-of-kin/${journeyId}`,
+          adminUser,
         ],
         [
           Page.SELECT_EMERGENCY_CONTACT_OR_NEXT_OF_KIN,
           `/prisoner/A1234BC/contacts/create/approved-to-visit/${journeyId}`,
+          authorisingUser,
+        ],
+        [
+          Page.SELECT_EMERGENCY_CONTACT_OR_NEXT_OF_KIN,
+          `/prisoner/A1234BC/contacts/create/enter-relationship-comments/${journeyId}`,
+          adminUser,
         ],
         [
           Page.ADD_CONTACT_APPROVED_TO_VISIT_PAGE,
           `/prisoner/A1234BC/contacts/create/enter-relationship-comments/${journeyId}`,
+          adminUser,
         ],
-        [Page.ENTER_RELATIONSHIP_COMMENTS, `/prisoner/A1234BC/contacts/create/check-answers/${journeyId}`],
-        [Page.CREATE_CONTACT_CHECK_ANSWERS_PAGE, `/prisoner/A1234BC/contact/EXISTING/123456/654321/success`],
-      ])('Should go to next page if not checking answers: from %s to %s', (page: Page, expectedNextUrl?: string) => {
-        const journey: AddContactJourney = {
-          id: journeyId,
-          lastTouched: new Date().toISOString(),
-          prisonerNumber: 'A1234BC',
-          returnPoint: {
-            url: '/foo',
-          },
-          mode: 'EXISTING',
-          isCheckingAnswers: false,
-          contactId: 123456,
-          prisonerContactId: 654321,
-        }
-
-        const nav = nextPageForAddContactJourney(page, journey)
-
-        expect(nav).toStrictEqual(expectedNextUrl)
-      })
-
-      it.each([
-        [Page.SELECT_RELATIONSHIP_TYPE],
-        [Page.SELECT_CONTACT_RELATIONSHIP],
-        [Page.SELECT_EMERGENCY_CONTACT_OR_NEXT_OF_KIN],
-        [Page.ADD_CONTACT_APPROVED_TO_VISIT_PAGE],
-        [Page.ENTER_RELATIONSHIP_COMMENTS],
-      ])('Should go back to checking answer page: from %s', (page: Page) => {
-        const journey: AddContactJourney = {
-          id: journeyId,
-          lastTouched: new Date().toISOString(),
-          prisonerNumber: 'A1234BC',
-          returnPoint: {
-            url: '/foo',
-          },
-          mode: 'EXISTING',
-          relationship: {
-            relationshipType: 'S',
-            pendingNewRelationshipType: 'S',
-            relationshipToPrisoner: 'MOT',
-          },
-          isCheckingAnswers: true,
-          previousAnswers: {
-            relationship: {
-              relationshipType: 'S',
-              relationshipToPrisoner: 'MOT',
+        [Page.ENTER_RELATIONSHIP_COMMENTS, `/prisoner/A1234BC/contacts/create/check-answers/${journeyId}`, adminUser],
+        [Page.CREATE_CONTACT_CHECK_ANSWERS_PAGE, `/prisoner/A1234BC/contact/EXISTING/123456/654321/success`, adminUser],
+      ])(
+        'Should go to next page if not checking answers: from %s to %s',
+        (page: Page, expectedNextUrl: string, user: HmppsUser) => {
+          const journey: AddContactJourney = {
+            id: journeyId,
+            lastTouched: new Date().toISOString(),
+            prisonerNumber: 'A1234BC',
+            returnPoint: {
+              url: '/foo',
             },
-          },
-        }
-        const expected = `/prisoner/A1234BC/contacts/create/check-answers/${journeyId}`
+            mode: 'EXISTING',
+            isCheckingAnswers: false,
+            contactId: 123456,
+            prisonerContactId: 654321,
+          }
 
-        const nav = nextPageForAddContactJourney(page, journey)
+          const nav = nextPageForAddContactJourney(page, journey, user)
 
-        expect(nav).toStrictEqual(expected)
-      })
+          expect(nav).toStrictEqual(expectedNextUrl)
+        },
+      )
 
       it.each([
         ['S', 'O', `/prisoner/A1234BC/contacts/create/select-relationship-to-prisoner/${journeyId}`],
@@ -548,7 +578,7 @@ describe('addContactFlowControl', () => {
             },
           }
 
-          const nav = nextPageForAddContactJourney(Page.SELECT_RELATIONSHIP_TYPE, journey)
+          const nav = nextPageForAddContactJourney(Page.SELECT_RELATIONSHIP_TYPE, journey, adminUser)
 
           expect(nav).toStrictEqual(expected)
         },
@@ -579,7 +609,7 @@ describe('addContactFlowControl', () => {
         cancelButton: undefined,
       }
 
-      const nav = navigationForAddContactJourney(page, journey)
+      const nav = navigationForAddContactJourney(page, journey, adminUser)
 
       expect(nav).toStrictEqual(expected)
     })
@@ -601,7 +631,7 @@ describe('addContactFlowControl', () => {
       }
       if (mode) journey.mode = mode as 'NEW' | 'EXISTING'
 
-      const nav = nextPageForAddContactJourney(page, journey)
+      const nav = nextPageForAddContactJourney(page, journey, adminUser)
 
       expect(nav).toStrictEqual(expectedNextUrl)
     })

--- a/server/routes/contacts/add/additional-info/addContactAdditionalInfoController.ts
+++ b/server/routes/contacts/add/additional-info/addContactAdditionalInfoController.ts
@@ -11,12 +11,14 @@ export default class AddContactAdditionalInfoController implements PageHandler {
   GET = async (req: Request<PrisonerJourneyParams>, res: Response): Promise<void> => {
     const { journeyId } = req.params
     const journey = req.session.addContactJourneys![journeyId]!
+    const { user } = res.locals
+
     delete journey.pendingEmployments
     delete journey.pendingAddresses
     const view = {
       journey,
       caption: captionForAddContactJourney(journey),
-      navigation: navigationForAddContactJourney(this.PAGE_NAME, journey),
+      navigation: navigationForAddContactJourney(this.PAGE_NAME, journey, user),
     }
     res.render('pages/contacts/add/additionalInfo', view)
   }
@@ -24,6 +26,8 @@ export default class AddContactAdditionalInfoController implements PageHandler {
   POST = async (req: Request<PrisonerJourneyParams>, res: Response): Promise<void> => {
     const { journeyId } = req.params
     const journey = req.session.addContactJourneys![journeyId]!
-    res.redirect(nextPageForAddContactJourney(this.PAGE_NAME, journey))
+    const { user } = res.locals
+
+    res.redirect(nextPageForAddContactJourney(this.PAGE_NAME, journey, user))
   }
 }

--- a/server/routes/contacts/add/addresses/addAddressesController.ts
+++ b/server/routes/contacts/add/addresses/addAddressesController.ts
@@ -23,7 +23,7 @@ export default class AddAddressesController implements PageHandler {
       ...req.params,
       contact: journey.names,
       addresses: await formatAddresses(journey.pendingAddresses, this.referenceDataService, user),
-      navigation: navigationForAddContactJourney(this.PAGE_NAME, journey),
+      navigation: navigationForAddContactJourney(this.PAGE_NAME, journey, user),
     }
     res.render('pages/contacts/add/addresses/index', view)
   }
@@ -31,12 +31,13 @@ export default class AddAddressesController implements PageHandler {
   POST = async (req: Request<PrisonerJourneyParams>, res: Response): Promise<void> => {
     const { journeyId } = req.params
     const journey = req.session.addContactJourneys![journeyId]!
+    const { user } = res.locals
 
     if (journey.pendingAddresses?.length) {
       journey.addresses = journey.pendingAddresses
     } else {
       delete journey.addresses
     }
-    res.redirect(nextPageForAddContactJourney(this.PAGE_NAME, journey))
+    res.redirect(nextPageForAddContactJourney(this.PAGE_NAME, journey, user))
   }
 }

--- a/server/routes/contacts/add/approved-to-visit/approvedToVisitController.ts
+++ b/server/routes/contacts/add/approved-to-visit/approvedToVisitController.ts
@@ -3,19 +3,23 @@ import { navigationForAddContactJourney, nextPageForAddContactJourney } from '..
 import { PageHandler } from '../../../../interfaces/pageHandler'
 import { Page } from '../../../../services/auditService'
 import { PrisonerJourneyParams } from '../../../../@types/journeys'
+import Permission from '../../../../enumeration/permission'
 
 export default class ApprovedToVisitController implements PageHandler {
   public PAGE_NAME = Page.ADD_CONTACT_APPROVED_TO_VISIT_PAGE
 
+  public REQUIRED_PERMISSION = Permission.APPROVE_TO_VISIT
+
   GET = async (req: Request<PrisonerJourneyParams>, res: Response): Promise<void> => {
     const { journeyId } = req.params
     const journey = req.session.addContactJourneys![journeyId]!
+    const { user } = res.locals
     const viewModel = {
       isNewContact: true,
       journey,
       contact: journey.names,
       isApprovedVisitor: journey.relationship?.isApprovedVisitor,
-      navigation: navigationForAddContactJourney(this.PAGE_NAME, journey),
+      navigation: navigationForAddContactJourney(this.PAGE_NAME, journey, user),
     }
     res.render('pages/contacts/manage/contactDetails/relationship/manageApprovedToVisit', viewModel)
   }
@@ -26,6 +30,7 @@ export default class ApprovedToVisitController implements PageHandler {
   ): Promise<void> => {
     const { journeyId } = req.params
     const journey = req.session.addContactJourneys![journeyId]!
+    const { user } = res.locals
     const { isApprovedToVisit } = req.body
     journey.relationship ??= {}
     if (isApprovedToVisit) {
@@ -33,6 +38,6 @@ export default class ApprovedToVisitController implements PageHandler {
     } else {
       delete journey.relationship.isApprovedVisitor
     }
-    res.redirect(nextPageForAddContactJourney(this.PAGE_NAME, journey))
+    res.redirect(nextPageForAddContactJourney(this.PAGE_NAME, journey, user))
   }
 }

--- a/server/routes/contacts/add/cancel/cancelAddContactController.ts
+++ b/server/routes/contacts/add/cancel/cancelAddContactController.ts
@@ -13,7 +13,8 @@ export default class CancelAddContactController implements PageHandler {
   GET = async (req: Request<PrisonerJourneyParams, unknown, unknown>, res: Response): Promise<void> => {
     const { journeyId } = req.params
     const journey = req.session.addContactJourneys![journeyId]!
-    const navigation = navigationForAddContactJourney(this.PAGE_NAME, journey)
+    const { user } = res.locals
+    const navigation = navigationForAddContactJourney(this.PAGE_NAME, journey, user)
     const caption = captionForAddContactJourney(journey)
     let title: string
     let showPrisonerAndContact: boolean
@@ -39,12 +40,13 @@ export default class CancelAddContactController implements PageHandler {
   ): Promise<void> => {
     const { journeyId, prisonerNumber } = req.params
     const { action } = req.body
+    const { user } = res.locals
     if (action === 'YES') {
       delete req.session.addContactJourneys![journeyId]
       res.redirect(Urls.contactList(prisonerNumber))
     } else {
       const journey = req.session.addContactJourneys![journeyId]!
-      const navigation = navigationForAddContactJourney(this.PAGE_NAME, journey)
+      const navigation = navigationForAddContactJourney(this.PAGE_NAME, journey, user)
       res.redirect(navigation.backLink!)
     }
   }

--- a/server/routes/contacts/add/check-answers/createContactCheckAnswersController.ts
+++ b/server/routes/contacts/add/check-answers/createContactCheckAnswersController.ts
@@ -25,7 +25,7 @@ export default class CreateContactCheckAnswersController implements PageHandler 
     const { journeyId } = req.params
     const { back } = req.query
     const journey = req.session.addContactJourneys![journeyId]!
-    const navigation = navigationForAddContactJourney(this.PAGE_NAME, journey)
+    const navigation = navigationForAddContactJourney(this.PAGE_NAME, journey, user)
     if (back && navigation.backLink) {
       journey.isCheckingAnswers = false
       delete journey.previousAnswers
@@ -135,7 +135,7 @@ export default class CreateContactCheckAnswersController implements PageHandler 
         })
         .then(() => delete req.session.addContactJourneys![journeyId])
     }
-    res.redirect(nextPageForAddContactJourney(this.PAGE_NAME, journey))
+    res.redirect(nextPageForAddContactJourney(this.PAGE_NAME, journey, user))
   }
 
   private async getDescriptionIfSet(

--- a/server/routes/contacts/add/contact-match/contactMatchController.ts
+++ b/server/routes/contacts/add/contact-match/contactMatchController.ts
@@ -68,7 +68,7 @@ export default class ContactMatchController implements PageHandler {
       linkedPrisoners: linkedPrisoners.content,
       linkedPrisonersCount,
       isContactConfirmed: res.locals?.formResponses?.['isContactMatched'] ?? journey?.isContactMatched,
-      navigation: navigationForAddContactJourney(this.PAGE_NAME, journey),
+      navigation: navigationForAddContactJourney(this.PAGE_NAME, journey, user),
       phoneTypeOrderDictionary: getReferenceDataOrderDictionary(
         await this.referenceDataService.getReferenceData(ReferenceCodeType.PHONE_TYPE, user),
       ),
@@ -79,15 +79,16 @@ export default class ContactMatchController implements PageHandler {
     const { isContactMatched } = req.body
     const { journeyId } = req.params
     const journey = req.session.addContactJourneys![journeyId]!
+    const { user } = res.locals
     journey.isContactMatched = isContactMatched
     if (journey.isContactMatched === 'YES') {
       journey.mode = 'EXISTING'
       journey.contactId = journey.matchingContactId!
-      return res.redirect(nextPageForAddContactJourney(this.PAGE_NAME, journey))
+      return res.redirect(nextPageForAddContactJourney(this.PAGE_NAME, journey, user))
     }
     if (journey.isContactMatched === 'NO_CREATE_NEW') {
       journey.mode = 'NEW'
-      return res.redirect(nextPageForAddContactJourney(this.PAGE_NAME, journey))
+      return res.redirect(nextPageForAddContactJourney(this.PAGE_NAME, journey, user))
     }
     // return to search by default which will reset the mode
     return res.redirect(`/prisoner/${journey.prisonerNumber}/contacts/search/${journey.id}`)

--- a/server/routes/contacts/add/contact-search/contactSearchController.ts
+++ b/server/routes/contacts/add/contact-search/contactSearchController.ts
@@ -87,7 +87,7 @@ export default class ContactSearchController implements PageHandler {
       month: res.locals?.formResponses?.['month'] ?? month,
       year: res.locals?.formResponses?.['year'] ?? year,
       filter: dobError ? 'Filter cannot be applied' : hasDob && `${day}/${month}/${year}`,
-      navigation: navigationForAddContactJourney(this.PAGE_NAME, journey),
+      navigation: navigationForAddContactJourney(this.PAGE_NAME, journey, user),
       sort: journey.searchContact?.sort,
       journey,
       results,

--- a/server/routes/contacts/add/domestic-status/addContactDomesticStatusController.ts
+++ b/server/routes/contacts/add/domestic-status/addContactDomesticStatusController.ts
@@ -21,7 +21,7 @@ export default class AddContactDomesticStatusController implements PageHandler {
       domesticStatusOptions,
       isNewContact: true,
       domesticStatusCode: res.locals?.formResponses?.['domesticStatusCode'] ?? journey?.domesticStatusCode,
-      navigation: navigationForAddContactJourney(this.PAGE_NAME, journey),
+      navigation: navigationForAddContactJourney(this.PAGE_NAME, journey, user),
     }
     res.render('pages/contacts/manage/contactDetails/domesticStatus', view)
   }
@@ -38,8 +38,9 @@ export default class AddContactDomesticStatusController implements PageHandler {
   ): Promise<void> => {
     const { journeyId } = req.params
     const journey = req.session.addContactJourneys![journeyId]!
+    const { user } = res.locals
     const { body } = req
     journey.domesticStatusCode = body.domesticStatusCode
-    res.redirect(nextPageForAddContactJourney(this.PAGE_NAME, journey))
+    res.redirect(nextPageForAddContactJourney(this.PAGE_NAME, journey, user))
   }
 }

--- a/server/routes/contacts/add/emails/addContactAddEmailsController.ts
+++ b/server/routes/contacts/add/emails/addContactAddEmailsController.ts
@@ -11,6 +11,7 @@ export default class AddContactAddEmailsController implements PageHandler {
   GET = async (req: Request<PrisonerJourneyParams>, res: Response): Promise<void> => {
     const { journeyId } = req.params
     const journey = req.session.addContactJourneys![journeyId]!
+    const { user } = res.locals
     const existingEmails = journey.emailAddresses ?? []
     if (existingEmails.length === 0) {
       existingEmails.push({ emailAddress: '' })
@@ -19,7 +20,7 @@ export default class AddContactAddEmailsController implements PageHandler {
       isNewContact: true,
       names: journey.names,
       emails: res.locals?.formResponses?.['emails'] ?? existingEmails,
-      navigation: navigationForAddContactJourney(this.PAGE_NAME, journey),
+      navigation: navigationForAddContactJourney(this.PAGE_NAME, journey, user),
     }
     res.render('pages/contacts/manage/contactMethods/addEmails', viewModel)
   }
@@ -30,11 +31,12 @@ export default class AddContactAddEmailsController implements PageHandler {
   ): Promise<void> => {
     const { prisonerNumber, journeyId } = req.params
     const journey = req.session.addContactJourneys![journeyId]!
+    const { user } = res.locals
 
     const { emails, save, add, remove } = req.body
     if (save !== undefined) {
       journey.emailAddresses = emails
-      return res.redirect(nextPageForAddContactJourney(this.PAGE_NAME, journey))
+      return res.redirect(nextPageForAddContactJourney(this.PAGE_NAME, journey, user))
     }
 
     req.body.emails ??= [{ emailAddress: '' }]

--- a/server/routes/contacts/add/emails/addContactConfirmDeleteEmailController.ts
+++ b/server/routes/contacts/add/emails/addContactConfirmDeleteEmailController.ts
@@ -13,6 +13,7 @@ export default class AddContactConfirmDeleteEmailController implements PageHandl
   ): Promise<void> => {
     const { journeyId, index } = req.params
     const journey = req.session.addContactJourneys![journeyId]!
+    const { user } = res.locals
     const emailToRemove = journey.emailAddresses?.[Number(index) - 1]
     if (!emailToRemove) {
       throw new Error(`Couldn't find an email address at index ${index}`)
@@ -21,7 +22,7 @@ export default class AddContactConfirmDeleteEmailController implements PageHandl
       contact: journey.names,
       isNewContact: true,
       email: emailToRemove,
-      navigation: navigationForAddContactJourney(this.PAGE_NAME, journey),
+      navigation: navigationForAddContactJourney(this.PAGE_NAME, journey, user),
     }
     res.render('pages/contacts/manage/contactMethods/confirmDeleteEmail', view)
   }
@@ -29,11 +30,12 @@ export default class AddContactConfirmDeleteEmailController implements PageHandl
   POST = async (req: Request<PrisonerJourneyParams & { index: string }>, res: Response): Promise<void> => {
     const { journeyId, index } = req.params
     const journey = req.session.addContactJourneys![journeyId]!
+    const { user } = res.locals
     const indexNumber = Number(index) - 1
     if (journey.emailAddresses && indexNumber <= journey.emailAddresses.length - 1) {
       journey.emailAddresses.splice(indexNumber, 1)
     }
     if (!journey.emailAddresses?.length) delete journey.emailAddresses
-    res.redirect(nextPageForAddContactJourney(this.PAGE_NAME, journey))
+    res.redirect(nextPageForAddContactJourney(this.PAGE_NAME, journey, user))
   }
 }

--- a/server/routes/contacts/add/emergency-contact-or-next-of-kin/emergencyContactOrNextOfKinController.ts
+++ b/server/routes/contacts/add/emergency-contact-or-next-of-kin/emergencyContactOrNextOfKinController.ts
@@ -12,6 +12,7 @@ export default class EmergencyContactOrNextOfKinController implements PageHandle
   GET = async (req: Request<PrisonerJourneyParams, unknown, unknown>, res: Response): Promise<void> => {
     const { journeyId } = req.params
     const journey = req.session.addContactJourneys![journeyId]!
+    const { user } = res.locals
     const view = {
       isOptional: true,
       journey,
@@ -20,7 +21,7 @@ export default class EmergencyContactOrNextOfKinController implements PageHandle
       continueButtonLabel: 'Continue',
       emergencyContact: journey.relationship?.isEmergencyContact,
       nextOfKin: journey.relationship?.isNextOfKin,
-      navigation: navigationForAddContactJourney(this.PAGE_NAME, journey),
+      navigation: navigationForAddContactJourney(this.PAGE_NAME, journey, user),
     }
     res.render('pages/contacts/manage/contactDetails/relationship/manageNextOfKinAndEmergencyContact', view)
   }
@@ -31,9 +32,10 @@ export default class EmergencyContactOrNextOfKinController implements PageHandle
   ): Promise<void> => {
     const { journeyId } = req.params
     const journey = req.session.addContactJourneys![journeyId]!
+    const { user } = res.locals
     const { emergencyContact, nextOfKin } = req.body
     journey.relationship!.isEmergencyContact = emergencyContact
     journey.relationship!.isNextOfKin = nextOfKin
-    res.redirect(nextPageForAddContactJourney(this.PAGE_NAME, journey))
+    res.redirect(nextPageForAddContactJourney(this.PAGE_NAME, journey, user))
   }
 }

--- a/server/routes/contacts/add/employments/addEmploymentsController.ts
+++ b/server/routes/contacts/add/employments/addEmploymentsController.ts
@@ -10,6 +10,7 @@ export default class AddEmploymentsController implements PageHandler {
   GET = async (req: Request<PrisonerJourneyParams, unknown, unknown>, res: Response): Promise<void> => {
     const { journeyId, prisonerNumber } = req.params
     const journey = req.session.addContactJourneys![journeyId]!
+    const { user } = res.locals
 
     journey.pendingEmployments ??= journey.employments
     // clear search term whenever user comes back to this page
@@ -22,7 +23,7 @@ export default class AddEmploymentsController implements PageHandler {
       journeyId,
       contactNames: journey.names,
       employments: journey.pendingEmployments,
-      navigation: navigationForAddContactJourney(this.PAGE_NAME, journey),
+      navigation: navigationForAddContactJourney(this.PAGE_NAME, journey, user),
     }
     res.render('pages/contacts/manage/employments/index', view)
   }
@@ -30,12 +31,13 @@ export default class AddEmploymentsController implements PageHandler {
   POST = async (req: Request<PrisonerJourneyParams>, res: Response): Promise<void> => {
     const { journeyId } = req.params
     const journey = req.session.addContactJourneys![journeyId]!
+    const { user } = res.locals
 
     if (journey.pendingEmployments?.length) {
       journey.employments = journey.pendingEmployments
     } else {
       delete journey.employments
     }
-    res.redirect(nextPageForAddContactJourney(this.PAGE_NAME, journey))
+    res.redirect(nextPageForAddContactJourney(this.PAGE_NAME, journey, user))
   }
 }

--- a/server/routes/contacts/add/enter-dob/createContactEnterDobController.ts
+++ b/server/routes/contacts/add/enter-dob/createContactEnterDobController.ts
@@ -11,6 +11,7 @@ export default class CreateContactEnterDobController implements PageHandler {
   GET = async (req: Request<{ journeyId: string }>, res: Response): Promise<void> => {
     const { journeyId } = req.params
     const journey = req.session.addContactJourneys![journeyId]!
+    const { user } = res.locals
     const view = {
       isNewContact: true,
       contact: journey.names,
@@ -18,7 +19,7 @@ export default class CreateContactEnterDobController implements PageHandler {
       day: res.locals?.formResponses?.['day'] ?? journey?.dateOfBirth?.day,
       month: res.locals?.formResponses?.['month'] ?? journey?.dateOfBirth?.month,
       year: res.locals?.formResponses?.['year'] ?? journey?.dateOfBirth?.year,
-      navigation: navigationForAddContactJourney(this.PAGE_NAME, journey),
+      navigation: navigationForAddContactJourney(this.PAGE_NAME, journey, user),
     }
     res.render('pages/contacts/manage/contactDetails/manageDob', view)
   }
@@ -26,6 +27,7 @@ export default class CreateContactEnterDobController implements PageHandler {
   POST = async (req: Request<PrisonerJourneyParams, unknown, OptionalDobSchemaType>, res: Response): Promise<void> => {
     const { journeyId } = req.params
     const journey = req.session.addContactJourneys![journeyId]!
+    const { user } = res.locals
     const { day, month, year } = req.body
     if (day && month && year) {
       journey.dateOfBirth = {
@@ -39,6 +41,6 @@ export default class CreateContactEnterDobController implements PageHandler {
         isKnown: 'NO',
       }
     }
-    res.redirect(nextPageForAddContactJourney(this.PAGE_NAME, journey))
+    res.redirect(nextPageForAddContactJourney(this.PAGE_NAME, journey, user))
   }
 }

--- a/server/routes/contacts/add/enter-name/createContactEnterNameController.ts
+++ b/server/routes/contacts/add/enter-name/createContactEnterNameController.ts
@@ -25,7 +25,7 @@ export default class EnterNameController implements PageHandler {
       lastName: res.locals?.formResponses?.['lastName'] ?? journey?.names?.lastName,
       firstName: res.locals?.formResponses?.['firstName'] ?? journey?.names?.firstName,
       middleNames: res.locals?.formResponses?.['middleNames'] ?? journey?.names?.middleNames,
-      navigation: navigationForAddContactJourney(this.PAGE_NAME, journey),
+      navigation: navigationForAddContactJourney(this.PAGE_NAME, journey, user),
     }
     res.render('pages/contacts/add/new/enterName', viewModel)
   }
@@ -44,7 +44,8 @@ export default class EnterNameController implements PageHandler {
     const { journeyId } = req.params
     const { title, lastName, firstName, middleNames } = req.body
     const journey = req.session.addContactJourneys![journeyId]!
+    const { user } = res.locals
     journey.names = { title, lastName, firstName, middleNames }
-    res.redirect(nextPageForAddContactJourney(this.PAGE_NAME, journey))
+    res.redirect(nextPageForAddContactJourney(this.PAGE_NAME, journey, user))
   }
 }

--- a/server/routes/contacts/add/gender/addContactGenderController.ts
+++ b/server/routes/contacts/add/gender/addContactGenderController.ts
@@ -21,7 +21,7 @@ export default class AddContactGenderController implements PageHandler {
       genderOptions,
       isNewContact: true,
       gender: res.locals?.formResponses?.['gender'] ?? journey?.gender,
-      navigation: navigationForAddContactJourney(this.PAGE_NAME, journey),
+      navigation: navigationForAddContactJourney(this.PAGE_NAME, journey, user),
     }
     res.render('pages/contacts/manage/contactDetails/manageGender', view)
   }
@@ -38,8 +38,9 @@ export default class AddContactGenderController implements PageHandler {
   ): Promise<void> => {
     const { journeyId } = req.params
     const journey = req.session.addContactJourneys![journeyId]!
+    const { user } = res.locals
     const { body } = req
     journey.gender = body.gender
-    res.redirect(nextPageForAddContactJourney(this.PAGE_NAME, journey))
+    res.redirect(nextPageForAddContactJourney(this.PAGE_NAME, journey, user))
   }
 }

--- a/server/routes/contacts/add/identities/addContactAddIdentitiesController.ts
+++ b/server/routes/contacts/add/identities/addContactAddIdentitiesController.ts
@@ -27,7 +27,7 @@ export default class AddContactAddIdentitiesController implements PageHandler {
       contact: journey.names,
       typeOptions: await this.referenceDataService.getReferenceData(ReferenceCodeType.ID_TYPE, user),
       identities: res.locals?.formResponses?.['identities'] ?? existingIdentities,
-      navigation: navigationForAddContactJourney(this.PAGE_NAME, journey),
+      navigation: navigationForAddContactJourney(this.PAGE_NAME, journey, user),
     }
     res.render('pages/contacts/manage/addIdentities', viewModel)
   }
@@ -38,11 +38,12 @@ export default class AddContactAddIdentitiesController implements PageHandler {
   ): Promise<void> => {
     const { prisonerNumber, journeyId } = req.params
     const journey = req.session.addContactJourneys![journeyId]!
+    const { user } = res.locals
 
     const { identities, save, add, remove } = req.body
     if (save !== undefined) {
       journey.identities = identities
-      return res.redirect(nextPageForAddContactJourney(this.PAGE_NAME, journey))
+      return res.redirect(nextPageForAddContactJourney(this.PAGE_NAME, journey, user))
     }
 
     req.body.identities ??= [{ identityType: '', identityValue: '', issuingAuthority: '' }]

--- a/server/routes/contacts/add/identities/addContactConfirmDeleteIdentityController.ts
+++ b/server/routes/contacts/add/identities/addContactConfirmDeleteIdentityController.ts
@@ -34,7 +34,7 @@ export default class AddContactConfirmDeleteIdentityController implements PageHa
           user,
         ),
       },
-      navigation: navigationForAddContactJourney(this.PAGE_NAME, journey),
+      navigation: navigationForAddContactJourney(this.PAGE_NAME, journey, user),
     }
     res.render('pages/contacts/manage/contactDetails/confirmDeleteIdentity', view)
   }
@@ -42,11 +42,12 @@ export default class AddContactConfirmDeleteIdentityController implements PageHa
   POST = async (req: Request<PrisonerJourneyParams & { index: string }>, res: Response): Promise<void> => {
     const { journeyId, index } = req.params
     const journey = req.session.addContactJourneys![journeyId]!
+    const { user } = res.locals
     const indexNumber = Number(index) - 1
     if (journey.identities && indexNumber <= journey.identities.length - 1) {
       journey.identities.splice(indexNumber, 1)
     }
     if (!journey.identities?.length) delete journey.identities
-    res.redirect(nextPageForAddContactJourney(this.PAGE_NAME, journey))
+    res.redirect(nextPageForAddContactJourney(this.PAGE_NAME, journey, user))
   }
 }

--- a/server/routes/contacts/add/is-staff/createContactIsStaffController.ts
+++ b/server/routes/contacts/add/is-staff/createContactIsStaffController.ts
@@ -10,9 +10,10 @@ export default class CreateContactIsStaffController implements PageHandler {
   GET = async (req: Request<PrisonerJourneyParams, unknown, unknown>, res: Response): Promise<void> => {
     const { journeyId } = req.params
     const journey = req.session.addContactJourneys![journeyId]!
+    const { user } = res.locals
     const view = {
       journey,
-      navigation: navigationForAddContactJourney(this.PAGE_NAME, journey),
+      navigation: navigationForAddContactJourney(this.PAGE_NAME, journey, user),
       isNewContact: true,
       isStaff: res.locals?.formResponses?.['isStaff'] ?? journey?.isStaff,
     }
@@ -31,8 +32,9 @@ export default class CreateContactIsStaffController implements PageHandler {
   ): Promise<void> => {
     const { journeyId } = req.params
     const journey = req.session.addContactJourneys![journeyId]!
+    const { user } = res.locals
     const { body } = req
     journey.isStaff = body.isStaff
-    res.redirect(nextPageForAddContactJourney(this.PAGE_NAME, journey))
+    res.redirect(nextPageForAddContactJourney(this.PAGE_NAME, journey, user))
   }
 }

--- a/server/routes/contacts/add/language-interpreter/createContactLanguageAndInterpreterController.ts
+++ b/server/routes/contacts/add/language-interpreter/createContactLanguageAndInterpreterController.ts
@@ -23,7 +23,7 @@ export default class CreateContactLanguageAndInterpreterController implements Pa
       language: res.locals?.formResponses?.['language'] ?? journey?.languageAndInterpreter?.language,
       interpreterRequired:
         res.locals?.formResponses?.['interpreterRequired'] ?? journey?.languageAndInterpreter?.interpreterRequired,
-      navigation: navigationForAddContactJourney(this.PAGE_NAME, journey),
+      navigation: navigationForAddContactJourney(this.PAGE_NAME, journey, user),
     }
     res.render('pages/contacts/manage/contactDetails/languageAndInterpreter', view)
   }
@@ -34,6 +34,7 @@ export default class CreateContactLanguageAndInterpreterController implements Pa
   ): Promise<void> => {
     const { journeyId } = req.params
     const journey = req.session.addContactJourneys![journeyId]!
+    const { user } = res.locals
     const { body } = req
     delete journey.languageAndInterpreter
     if (body.language || body.interpreterRequired) {
@@ -42,6 +43,6 @@ export default class CreateContactLanguageAndInterpreterController implements Pa
         interpreterRequired: body.interpreterRequired ? body.interpreterRequired : undefined,
       }
     }
-    res.redirect(nextPageForAddContactJourney(this.PAGE_NAME, journey))
+    res.redirect(nextPageForAddContactJourney(this.PAGE_NAME, journey, user))
   }
 }

--- a/server/routes/contacts/add/mode/addContactModeController.ts
+++ b/server/routes/contacts/add/mode/addContactModeController.ts
@@ -48,6 +48,6 @@ export default class AddContactModeController implements PageHandler {
         }
       }
     }
-    res.redirect(nextPageForAddContactJourney(this.PAGE_NAME, journey))
+    res.redirect(nextPageForAddContactJourney(this.PAGE_NAME, journey, user))
   }
 }

--- a/server/routes/contacts/add/phone/addContactAddPhoneController.ts
+++ b/server/routes/contacts/add/phone/addContactAddPhoneController.ts
@@ -24,7 +24,7 @@ export default class AddContactAddPhoneController implements PageHandler {
       journey,
       typeOptions: await this.referenceDataService.getReferenceData(ReferenceCodeType.PHONE_TYPE, user),
       phones: res.locals?.formResponses?.['phones'] ?? existingPhoneNumbers,
-      navigation: navigationForAddContactJourney(this.PAGE_NAME, journey),
+      navigation: navigationForAddContactJourney(this.PAGE_NAME, journey, user),
       isNewContact: true,
     }
     res.render('pages/contacts/manage/contactMethods/addPhone', viewModel)
@@ -33,11 +33,12 @@ export default class AddContactAddPhoneController implements PageHandler {
   POST = async (req: Request<PrisonerJourneyParams, unknown, PhonesSchemaType>, res: Response): Promise<void> => {
     const { prisonerNumber, journeyId } = req.params
     const journey = req.session.addContactJourneys![journeyId]!
+    const { user } = res.locals
 
     const { phones, save, add, remove } = req.body
     if (save !== undefined) {
       journey.phoneNumbers = phones
-      return res.redirect(nextPageForAddContactJourney(this.PAGE_NAME, journey))
+      return res.redirect(nextPageForAddContactJourney(this.PAGE_NAME, journey, user))
     }
     if (add !== undefined) {
       phones.push({ type: '', phoneNumber: '', extension: '' })

--- a/server/routes/contacts/add/phone/addContactConfirmDeletePhoneController.ts
+++ b/server/routes/contacts/add/phone/addContactConfirmDeletePhoneController.ts
@@ -34,7 +34,7 @@ export default class AddContactConfirmDeletePhoneController implements PageHandl
           user,
         ),
       },
-      navigation: navigationForAddContactJourney(this.PAGE_NAME, journey),
+      navigation: navigationForAddContactJourney(this.PAGE_NAME, journey, user),
     }
     res.render('pages/contacts/manage/contactMethods/confirmDeletePhone', view)
   }
@@ -42,10 +42,11 @@ export default class AddContactConfirmDeletePhoneController implements PageHandl
   POST = async (req: Request<PrisonerJourneyParams & { index: string }>, res: Response): Promise<void> => {
     const { journeyId, index } = req.params
     const journey = req.session.addContactJourneys![journeyId]!
+    const { user } = res.locals
     const indexNumber = Number(index)
     if (journey.phoneNumbers && indexNumber <= journey.phoneNumbers.length - 1) {
       journey.phoneNumbers.splice(indexNumber, 1)
     }
-    res.redirect(nextPageForAddContactJourney(this.PAGE_NAME, journey))
+    res.redirect(nextPageForAddContactJourney(this.PAGE_NAME, journey, user))
   }
 }

--- a/server/routes/contacts/add/relationship-comments/enterRelationshipCommentsController.ts
+++ b/server/routes/contacts/add/relationship-comments/enterRelationshipCommentsController.ts
@@ -11,12 +11,13 @@ export default class EnterRelationshipCommentsController implements PageHandler 
   GET = async (req: Request<PrisonerJourneyParams, unknown, unknown>, res: Response): Promise<void> => {
     const { journeyId } = req.params
     const journey = req.session.addContactJourneys![journeyId]!
+    const { user } = res.locals
     const view = {
       journey,
       isUpdateJourney: false,
       names: journey.names,
       comments: res.locals?.formResponses?.['comments'] ?? journey?.relationship?.comments,
-      navigation: navigationForAddContactJourney(this.PAGE_NAME, journey),
+      navigation: navigationForAddContactJourney(this.PAGE_NAME, journey, user),
     }
     res.render('pages/contacts/manage/contactDetails/relationship/relationshipComments', view)
   }
@@ -27,8 +28,9 @@ export default class EnterRelationshipCommentsController implements PageHandler 
   ): Promise<void> => {
     const { journeyId } = req.params
     const journey = req.session.addContactJourneys![journeyId]!
+    const { user } = res.locals
     const { body } = req
     journey.relationship!.comments = body.comments
-    res.redirect(nextPageForAddContactJourney(this.PAGE_NAME, journey))
+    res.redirect(nextPageForAddContactJourney(this.PAGE_NAME, journey, user))
   }
 }

--- a/server/routes/contacts/add/relationship-to-prisoner/selectRelationshipToPrisonerController.ts
+++ b/server/routes/contacts/add/relationship-to-prisoner/selectRelationshipToPrisonerController.ts
@@ -28,7 +28,7 @@ export default class SelectRelationshipToPrisonerController implements PageHandl
       relationshipType,
       relationshipOptions,
       journey,
-      navigation: navigationForAddContactJourney(this.PAGE_NAME, journey),
+      navigation: navigationForAddContactJourney(this.PAGE_NAME, journey, user),
       continueButtonLabel: 'Continue',
     }
     res.render('pages/contacts/manage/contactDetails/relationship/selectRelationship', viewModel)
@@ -41,6 +41,7 @@ export default class SelectRelationshipToPrisonerController implements PageHandl
     const { journeyId } = req.params
     const { relationship } = req.body
     const journey = req.session.addContactJourneys![journeyId]!
+    const { user } = res.locals
     if (!journey.relationship) {
       journey.relationship = {}
     }
@@ -48,6 +49,6 @@ export default class SelectRelationshipToPrisonerController implements PageHandl
     journey.relationship.relationshipType = (journey.relationship.pendingNewRelationshipType ??
       journey.relationship.relationshipType)!
     delete journey.relationship.pendingNewRelationshipType
-    res.redirect(nextPageForAddContactJourney(this.PAGE_NAME, journey))
+    res.redirect(nextPageForAddContactJourney(this.PAGE_NAME, journey, user))
   }
 }

--- a/server/routes/contacts/add/relationship-type/relationshipTypeController.ts
+++ b/server/routes/contacts/add/relationship-type/relationshipTypeController.ts
@@ -11,6 +11,7 @@ export default class RelationshipTypeController implements PageHandler {
   GET = async (req: Request<PrisonerJourneyParams, unknown, unknown>, res: Response): Promise<void> => {
     const { journeyId } = req.params
     const journey = req.session.addContactJourneys![journeyId]!
+    const { user } = res.locals
     const view = {
       isNewContact: true,
       journey,
@@ -18,7 +19,7 @@ export default class RelationshipTypeController implements PageHandler {
         res.locals?.formResponses?.['relationshipType'] ??
         journey?.relationship?.pendingNewRelationshipType ??
         journey?.relationship?.relationshipType,
-      navigation: navigationForAddContactJourney(this.PAGE_NAME, journey),
+      navigation: navigationForAddContactJourney(this.PAGE_NAME, journey, user),
     }
     res.render('pages/contacts/add/relationshipType', view)
   }
@@ -26,11 +27,12 @@ export default class RelationshipTypeController implements PageHandler {
   POST = async (req: Request<PrisonerJourneyParams, unknown, RelationshipTypeSchema>, res: Response): Promise<void> => {
     const { journeyId } = req.params
     const journey = req.session.addContactJourneys![journeyId]!
+    const { user } = res.locals
     const { body } = req
     if (!journey.relationship) {
       journey.relationship = {}
     }
     journey.relationship.pendingNewRelationshipType = body.relationshipType
-    res.redirect(nextPageForAddContactJourney(this.PAGE_NAME, journey))
+    res.redirect(nextPageForAddContactJourney(this.PAGE_NAME, journey, user))
   }
 }

--- a/server/routes/contacts/add/start/startAddContactJourneyController.ts
+++ b/server/routes/contacts/add/start/startAddContactJourneyController.ts
@@ -12,6 +12,7 @@ export default class StartAddContactJourneyController implements PageHandler {
 
   GET = async (req: Request<{ prisonerNumber: string }>, res: Response): Promise<void> => {
     const { prisonerNumber } = req.params
+    const { user } = res.locals
     const returnPoint: ReturnPoint = { url: `/prisoner/${prisonerNumber}/contacts/list` }
     const journey: AddContactJourney = {
       id: uuidv4(),
@@ -33,6 +34,6 @@ export default class StartAddContactJourneyController implements PageHandler {
         .slice(this.MAX_JOURNEYS)
         .forEach(journeyToRemove => delete req.session.addContactJourneys![journeyToRemove.id])
     }
-    res.redirect(nextPageForAddContactJourney(this.PAGE_NAME, journey))
+    res.redirect(nextPageForAddContactJourney(this.PAGE_NAME, journey, user))
   }
 }

--- a/server/routes/contacts/manage/relationship/approved-to-visit/manageApprovedToVisitController.ts
+++ b/server/routes/contacts/manage/relationship/approved-to-visit/manageApprovedToVisitController.ts
@@ -8,11 +8,14 @@ import { FLASH_KEY__SUCCESS_BANNER } from '../../../../../middleware/setUpSucces
 import { formatNameFirstNameFirst } from '../../../../../utils/formatName'
 import { ManageApprovedToVisitSchemaType } from './manageApprovedToVisitSchema'
 import { ContactDetails, PatchRelationshipRequest } from '../../../../../@types/contactsApiClient'
+import Permission from '../../../../../enumeration/permission'
 
 export default class ManageApprovedToVisitController implements PageHandler {
   constructor(private readonly contactsService: ContactsService) {}
 
   public PAGE_NAME = Page.MANAGE_CONTACT_UPDATE_APPROVED_TO_VISIT_PAGE
+
+  public REQUIRED_PERMISSION = Permission.APPROVE_TO_VISIT
 
   GET = async (
     req: Request<{ prisonerNumber: string; contactId: string; prisonerContactId: string }>,

--- a/server/views/pages/contacts/add/existing/checkAnswers.njk
+++ b/server/views/pages/contacts/add/existing/checkAnswers.njk
@@ -103,22 +103,24 @@
                 },
                 {
                   key: {
-                  text: "Approved for visits"
-                },
+                    text: "Approved for visits"
+                  },
                   value: {
-                  html: "Not provided" if journey.relationship.isApprovedVisitor == undefined else (journey.relationship.isApprovedVisitor | formatYesNo)
-                },
+                    html: "Not provided" if journey.relationship.isApprovedVisitor == undefined else (journey.relationship.isApprovedVisitor | formatYesNo),
+                    classes: 'check-answers-approved-visitor-value'
+                  },
                   actions: {
-                  items: [
-                    {
-                      href: baseChangeUrl + "/approved-to-visit/"  + journey.id,
-                      text: "Change",
-                      visuallyHiddenText: "if the contact is approved to visit the prisoner",
-                      classes: "govuk-link--no-visited-state"
-                    }
-                  ]
-                }
-                },
+                    items: [
+                      {
+                        href: baseChangeUrl + "/approved-to-visit/"  + journey.id,
+                        text: "Change",
+                        visuallyHiddenText: "if the contact is approved to visit the prisoner",
+                        attributes: {"data-qa": "change-approved-visitor-link"},
+                        classes: "govuk-link--no-visited-state"
+                      }
+                    ]
+                  }
+                } if ( user | hasPermission('APPROVE_TO_VISIT') ),
                 {
                   key: {
                   text: "Comments on this relationship"

--- a/server/views/pages/contacts/add/new/checkAnswers.njk
+++ b/server/views/pages/contacts/add/new/checkAnswers.njk
@@ -207,22 +207,24 @@
                         },
                         {
                           key: {
-                          text: "Approved for visits"
-                        },
+                            text: "Approved for visits"
+                          },
                           value: {
-                          html: "Not provided" if journey.relationship.isApprovedVisitor == undefined else (journey.relationship.isApprovedVisitor | formatYesNo)
-                        },
+                            html: "Not provided" if journey.relationship.isApprovedVisitor == undefined else (journey.relationship.isApprovedVisitor | formatYesNo),
+                            classes: 'check-answers-approved-visitor-value'
+                          },
                           actions: {
-                          items: [
-                            {
-                              href: baseChangeUrl + "/approved-to-visit/"  + journey.id,
-                              text: "Change",
-                              visuallyHiddenText: "if the contact is approved to visit the prisoner",
-                              classes: "govuk-link--no-visited-state"
-                            }
-                          ]
-                        }
-                        },
+                            items: [
+                              {
+                                href: baseChangeUrl + "/approved-to-visit/"  + journey.id,
+                                text: "Change",
+                                visuallyHiddenText: "if the contact is approved to visit the prisoner",
+                                attributes: {"data-qa": "change-next-of-kin-link"},
+                                classes: "govuk-link--no-visited-state"
+                              }
+                            ]
+                          }
+                        } if ( user | hasPermission('APPROVE_TO_VISIT') ),
                         {
                             key: {
                                 text: "Comments on this relationship"

--- a/server/views/pages/contacts/manage/contactDetails/details/contactDetailsTab.njk
+++ b/server/views/pages/contacts/manage/contactDetails/details/contactDetailsTab.njk
@@ -34,6 +34,7 @@
         contact: contact,
         relationship: prisonerContactRelationship,
         prisonerDetails: prisonerDetails,
+        user: user,
         showActions: false
       }) }}
 

--- a/server/views/pages/contacts/manage/contactDetails/details/editContactDetails.njk
+++ b/server/views/pages/contacts/manage/contactDetails/details/editContactDetails.njk
@@ -31,6 +31,7 @@
           contact: contact,
           relationship: prisonerContactRelationship,
           prisonerDetails: prisonerDetails,
+          user: user,
           showActions: true
         })
       }}

--- a/server/views/partials/contactDetails/identityDocumentationCard.njk
+++ b/server/views/partials/contactDetails/identityDocumentationCard.njk
@@ -32,7 +32,7 @@
 
       {% set identityNumbers = identityNumbers.concat([{
         key: {
-          html: item.identityTypeDescription | escape + ('<p class="unsupported-identity-hint">Cannot be changed as the document type is no longer supported in DPS and NOMIS.</p>' if showActions and item.identityTypeIsActive === false else '')
+          html: item.identityTypeDescription | escape + ('<p class="summary-card-key-hint">Cannot be changed as the document type is no longer supported in DPS and NOMIS.</p>' if showActions and item.identityTypeIsActive === false else '')
         },
         value: {
           html: item.identityValue | escape + ('<p>Issued by ' + item.issuingAuthority | escape + '</p>' if item.issuingAuthority else '')

--- a/server/views/partials/contactDetails/relationshipToPrisonerCard.njk
+++ b/server/views/partials/contactDetails/relationshipToPrisonerCard.njk
@@ -6,6 +6,13 @@
   {% set relationship = opts.relationship %}
   {% set showActions = opts.showActions %}
   {% set prisonerDetails = opts.prisonerDetails %}
+  {% set user = opts.user %}
+
+  {% set canApproveToVisit = (user | hasPermission('APPROVE_TO_VISIT')) %}
+  {% set approvedForVisitsKey = 'Approved for visits' %}
+  {% if showActions and not canApproveToVisit %}
+  {% set approvedForVisitsKey = approvedForVisitsKey + '<br><p data-qa="cant-approve-visit-hint" class="summary-card-key-hint">Cannot be changed as you do not have permission to authorise visits on DPS.</p>'%}
+  {% endif %}
 
   {{ govukSummaryList({
     card: {
@@ -112,7 +119,7 @@
       },
       {
         key: {
-          text: 'Approved for visits'
+          html: approvedForVisitsKey
         },
         value: {
           text: relationship.isApprovedVisitor | formatYesNo
@@ -126,7 +133,7 @@
               attributes: {"data-qa": "change-approved-visitor-link"},
               classes: "govuk-link--no-visited-state"
             }
-          ] if showActions else []
+          ] if showActions and canApproveToVisit else []
         }
       },
       {


### PR DESCRIPTION
Apply RBAC to approve to visit pages so you will be redirected to not found if you attempt to GET or POST on a relevant controller.

Hide change visit approval link if you do not have permission and offer a hint as to why.

Remove visit approval from the create & link contact journeys if you do not have permission.