### PR TITLE
PRC-605: Tweak success page when not authoriser

### DIFF
--- a/server/routes/contacts/add/success/successfullyAddedContactController.test.ts
+++ b/server/routes/contacts/add/success/successfullyAddedContactController.test.ts
@@ -182,4 +182,29 @@ describe('GET /prisoner/:prisonerNumber/contacts/create/check-answers/:journeyId
       expect($('h2:contains("Add restrictions")')).toHaveLength(0)
     },
   )
+
+  it.each([
+    [adminUser, 'It’s important to make sure the information in the contact record is accurate and up to date.'],
+    [
+      authorisingUser,
+      'It’s also important to make sure the information in the contact record is accurate and up to date.',
+    ],
+  ])('Should show next step hint when existing and as user %j', async (user, expected) => {
+    currentUser = user
+
+    contactsService.getContactName.mockResolvedValue(
+      TestData.contact({
+        lastName: 'Last',
+        middleNames: 'Middle Names',
+        firstName: 'First',
+      }),
+    )
+
+    // When
+    const response = await request(app).get(`/prisoner/A1234BC/contact/EXISTING/123456/654321/success`)
+
+    // Then
+    const $ = cheerio.load(response.text)
+    expect($('[data-qa=next-step-hint]').first().text()).toStrictEqual(expected)
+  })
 })

--- a/server/views/pages/contacts/common/addedContactSuccessfully.njk
+++ b/server/views/pages/contacts/common/addedContactSuccessfully.njk
@@ -54,7 +54,7 @@
                 {% endif %}
                 {% if mode === 'EXISTING' %}
                 <h2 class="govuk-heading-l govuk-!-font-size-24 govuk-!-margin-bottom-3">Check the contact information is up to date</h2>
-                <p class="govuk-body">It’s also important to make sure the information in the contact record is accurate and up to date.</p>
+                <p class="govuk-body" data-qa="next-step-hint">It’s{% if user | hasPermission('MANAGE_RESTRICTIONS') %} also{% endif %} important to make sure the information in the contact record is accurate and up to date.</p>
                 <a href="{{ contactRecordLink }}" class="govuk-body govuk-link--no-visited-state" data-qa="go-to-contact-info-link">
                     View {{ names | formatNameFirstNameFirst(possessiveSuffix = true) }} contact information
                 </a>


### PR DESCRIPTION
Remove the word "also" from the hint text when linking an existing contact as we do not show the restrictions content before so "also" doesn't make sense.