### PR TITLE
PRC-723: Remove use of "returnUrl"

### DIFF
--- a/server/@types/express/index.d.ts
+++ b/server/@types/express/index.d.ts
@@ -8,7 +8,6 @@ import {
   ChangeRelationshipTypeJourney,
   ManageContactsJourney,
   PrisonerDetails,
-  StandaloneManageContactJourney,
   UpdateEmploymentsJourney,
 } from '../journeys'
 
@@ -71,7 +70,6 @@ export declare global {
       message?: string
       status?: number
       stack?: string | null | undefined
-      journey: StandaloneManageContactJourney
     }
   }
 }

--- a/server/@types/journeys/index.d.ts
+++ b/server/@types/journeys/index.d.ts
@@ -5,7 +5,6 @@ export interface AddContactJourney {
   lastTouched: string
   prisonerNumber: string
   isCheckingAnswers: boolean
-  returnPoint: ReturnPoint
   mode?: 'EXISTING' | 'NEW' | undefined
   searchContact?:
     | {
@@ -99,7 +98,6 @@ export interface UpdateEmploymentsJourney {
   contactNames: ContactNames
   employments: EmploymentDetails[]
   employmentIdsToDelete?: number[]
-  returnPoint: ReturnPoint
   changeOrganisationId?: number
   organisationSearch: {
     page: number
@@ -117,11 +115,6 @@ export interface ChangeRelationshipTypeJourney {
   names: ContactNames
   relationshipType: string
   relationshipToPrisoner: string
-}
-
-export interface ReturnPoint {
-  url: string
-  anchor?: string
 }
 
 export interface PrisonerDetails {
@@ -196,14 +189,6 @@ export interface AddressMetadata {
   comments?: string | null | undefined
 }
 
-export interface StandaloneManageContactJourney {
-  returnPoint: ReturnPoint
-  names?: ContactNames
-  contactNames?: ContactNames
-  restrictionClass?: RestrictionClass
-  contactId?: string
-}
-
 export interface PhoneNumberForm {
   type: string
   phoneNumber: string
@@ -231,5 +216,6 @@ export type RestrictionClass = 'CONTACT_GLOBAL' | 'PRISONER_CONTACT'
 
 export type UpdateEmploymentJourneyParams = PrisonerJourneyParams & {
   contactId: string
+  prisonerContactId: string
   employmentIdx: string
 }

--- a/server/routes/contacts/add/addContactFlowControl.test.ts
+++ b/server/routes/contacts/add/addContactFlowControl.test.ts
@@ -158,9 +158,6 @@ describe('addContactFlowControl', () => {
             id: journeyId,
             lastTouched: new Date().toISOString(),
             prisonerNumber: 'A1234BC',
-            returnPoint: {
-              url: '/foo',
-            },
             mode: 'NEW',
             isCheckingAnswers: false,
             dateOfBirth: {
@@ -204,9 +201,6 @@ describe('addContactFlowControl', () => {
             id: journeyId,
             lastTouched: new Date().toISOString(),
             prisonerNumber: 'A1234BC',
-            returnPoint: {
-              url: '/foo',
-            },
             mode: 'NEW',
             isCheckingAnswers: true,
             dateOfBirth: {
@@ -303,9 +297,6 @@ describe('addContactFlowControl', () => {
             id: journeyId,
             lastTouched: new Date().toISOString(),
             prisonerNumber: 'A1234BC',
-            returnPoint: {
-              url: '/foo',
-            },
             isCheckingAnswers: false,
             dateOfBirth: {
               isKnown: 'NO',
@@ -333,9 +324,6 @@ describe('addContactFlowControl', () => {
             id: journeyId,
             lastTouched: new Date().toISOString(),
             prisonerNumber: 'A1234BC',
-            returnPoint: {
-              url: '/foo',
-            },
             mode: 'NEW',
             relationship: {
               relationshipType: before,
@@ -439,9 +427,6 @@ describe('addContactFlowControl', () => {
             id: journeyId,
             lastTouched: new Date().toISOString(),
             prisonerNumber: 'A1234BC',
-            returnPoint: {
-              url: '/foo',
-            },
             mode: 'EXISTING',
             matchingContactId: 12346789,
             isCheckingAnswers: false,
@@ -470,9 +455,6 @@ describe('addContactFlowControl', () => {
           id: journeyId,
           lastTouched: new Date().toISOString(),
           prisonerNumber: 'A1234BC',
-          returnPoint: {
-            url: '/foo',
-          },
           mode: 'EXISTING',
           isCheckingAnswers: true,
         }
@@ -533,9 +515,6 @@ describe('addContactFlowControl', () => {
             id: journeyId,
             lastTouched: new Date().toISOString(),
             prisonerNumber: 'A1234BC',
-            returnPoint: {
-              url: '/foo',
-            },
             mode: 'EXISTING',
             isCheckingAnswers: false,
             contactId: 123456,
@@ -560,9 +539,6 @@ describe('addContactFlowControl', () => {
             id: journeyId,
             lastTouched: new Date().toISOString(),
             prisonerNumber: 'A1234BC',
-            returnPoint: {
-              url: '/foo',
-            },
             mode: 'EXISTING',
             relationship: {
               relationshipType: before,
@@ -597,9 +573,6 @@ describe('addContactFlowControl', () => {
         id: journeyId,
         lastTouched: new Date().toISOString(),
         prisonerNumber: 'A1234BC',
-        returnPoint: {
-          url: '/foo',
-        },
         isCheckingAnswers: false,
       }
       const expected: Navigation = {
@@ -624,9 +597,6 @@ describe('addContactFlowControl', () => {
         id: journeyId,
         lastTouched: new Date().toISOString(),
         prisonerNumber: 'A1234BC',
-        returnPoint: {
-          url: '/foo',
-        },
         isCheckingAnswers: false,
       }
       if (mode) journey.mode = mode as 'NEW' | 'EXISTING'

--- a/server/routes/contacts/add/addContactMiddleware.test.ts
+++ b/server/routes/contacts/add/addContactMiddleware.test.ts
@@ -29,7 +29,6 @@ describe('createContactMiddleware', () => {
         lastTouched: lastTouchedBeforeCall.toISOString(),
         prisonerNumber,
         isCheckingAnswers: false,
-        returnPoint: { url: '/foo-bar' },
       }
       ensureInAddContactJourney(req, res, next)
       expect(next).toHaveBeenCalledTimes(1)

--- a/server/routes/contacts/add/addContactMiddleware.ts
+++ b/server/routes/contacts/add/addContactMiddleware.ts
@@ -34,7 +34,6 @@ export const resetAddContactJourney = async (
     lastTouched: existingJourney.lastTouched,
     isCheckingAnswers: false,
     prisonerNumber: existingJourney.prisonerNumber,
-    returnPoint: existingJourney.returnPoint,
     searchContact: existingJourney.searchContact,
   }
   return next()

--- a/server/routes/contacts/add/additional-info/addContactAdditionalInfoController.test.ts
+++ b/server/routes/contacts/add/additional-info/addContactAdditionalInfoController.test.ts
@@ -30,7 +30,6 @@ beforeEach(() => {
     lastTouched: new Date().toISOString(),
     prisonerNumber,
     isCheckingAnswers: false,
-    returnPoint: { url: '/foo-bar' },
     names: {
       lastName: 'last',
       middleNames: 'Middle',

--- a/server/routes/contacts/add/addresses/add-address-phone/createContactAddressPhoneController.test.ts
+++ b/server/routes/contacts/add/addresses/add-address-phone/createContactAddressPhoneController.test.ts
@@ -38,7 +38,6 @@ beforeEach(() => {
     lastTouched: new Date().toISOString(),
     prisonerNumber,
     isCheckingAnswers: false,
-    returnPoint: { url: '/foo-bar' },
     names: {
       lastName: 'last',
       middleNames: 'Middle',

--- a/server/routes/contacts/add/addresses/addAddressesController.test.ts
+++ b/server/routes/contacts/add/addresses/addAddressesController.test.ts
@@ -34,7 +34,6 @@ beforeEach(() => {
     lastTouched: new Date().toISOString(),
     prisonerNumber,
     isCheckingAnswers: false,
-    returnPoint: { url: '/foo-bar' },
     names: {
       lastName: 'last',
       middleNames: 'Middle',

--- a/server/routes/contacts/add/addresses/comments/createContactAddressCommentsController.test.ts
+++ b/server/routes/contacts/add/addresses/comments/createContactAddressCommentsController.test.ts
@@ -38,7 +38,6 @@ beforeEach(() => {
     lastTouched: new Date().toISOString(),
     prisonerNumber,
     isCheckingAnswers: false,
-    returnPoint: { url: '/foo-bar' },
     names: {
       lastName: 'last',
       middleNames: 'Middle',

--- a/server/routes/contacts/add/addresses/dates/createContactAddressDatesController.test.ts
+++ b/server/routes/contacts/add/addresses/dates/createContactAddressDatesController.test.ts
@@ -38,7 +38,6 @@ beforeEach(() => {
     lastTouched: new Date().toISOString(),
     prisonerNumber,
     isCheckingAnswers: false,
-    returnPoint: { url: '/foo-bar' },
     names: {
       lastName: 'last',
       middleNames: 'Middle',

--- a/server/routes/contacts/add/addresses/delete-address-phone/createContactDeleteAddressPhoneController.test.ts
+++ b/server/routes/contacts/add/addresses/delete-address-phone/createContactDeleteAddressPhoneController.test.ts
@@ -32,7 +32,6 @@ beforeEach(() => {
     lastTouched: new Date().toISOString(),
     prisonerNumber,
     isCheckingAnswers: false,
-    returnPoint: { url: '/foo-bar' },
     names: {
       lastName: 'last',
       middleNames: 'Middle',

--- a/server/routes/contacts/add/addresses/delete/createContactDeleteAddressController.test.ts
+++ b/server/routes/contacts/add/addresses/delete/createContactDeleteAddressController.test.ts
@@ -32,7 +32,6 @@ beforeEach(() => {
     lastTouched: new Date().toISOString(),
     prisonerNumber,
     isCheckingAnswers: false,
-    returnPoint: { url: '/foo-bar' },
     names: {
       lastName: 'last',
       middleNames: 'Middle',

--- a/server/routes/contacts/add/addresses/enter-address/createContactEnterAddressController.test.ts
+++ b/server/routes/contacts/add/addresses/enter-address/createContactEnterAddressController.test.ts
@@ -38,7 +38,6 @@ beforeEach(() => {
     lastTouched: new Date().toISOString(),
     prisonerNumber,
     isCheckingAnswers: false,
-    returnPoint: { url: '/foo-bar' },
     names: {
       lastName: 'last',
       middleNames: 'Middle',

--- a/server/routes/contacts/add/addresses/primary-or-postal/createContactAddressFlagsController.test.ts
+++ b/server/routes/contacts/add/addresses/primary-or-postal/createContactAddressFlagsController.test.ts
@@ -32,7 +32,6 @@ beforeEach(() => {
     lastTouched: new Date().toISOString(),
     prisonerNumber,
     isCheckingAnswers: false,
-    returnPoint: { url: '/foo-bar' },
     names: {
       lastName: 'last',
       middleNames: 'Middle',

--- a/server/routes/contacts/add/addresses/select-type/createContactAddressTypeController.test.ts
+++ b/server/routes/contacts/add/addresses/select-type/createContactAddressTypeController.test.ts
@@ -32,7 +32,6 @@ beforeEach(() => {
     lastTouched: new Date().toISOString(),
     prisonerNumber,
     isCheckingAnswers: false,
-    returnPoint: { url: '/foo-bar' },
     names: {
       lastName: 'last',
       middleNames: 'Middle',

--- a/server/routes/contacts/add/addresses/use-prisoner-address/createContactUsePrisonerAddressController.test.ts
+++ b/server/routes/contacts/add/addresses/use-prisoner-address/createContactUsePrisonerAddressController.test.ts
@@ -37,7 +37,6 @@ beforeEach(() => {
     lastTouched: new Date().toISOString(),
     prisonerNumber,
     isCheckingAnswers: false,
-    returnPoint: { url: '/foo-bar' },
     names: {
       lastName: 'last',
       middleNames: 'Middle',

--- a/server/routes/contacts/add/approved-to-visit/approvedToVisitController.test.ts
+++ b/server/routes/contacts/add/approved-to-visit/approvedToVisitController.test.ts
@@ -30,7 +30,6 @@ beforeEach(() => {
     lastTouched: new Date().toISOString(),
     prisonerNumber,
     isCheckingAnswers: false,
-    returnPoint: { url: '/foo-bar' },
     names: {
       lastName: 'last',
       middleNames: 'Middle',

--- a/server/routes/contacts/add/cancel/cancelAddContactController.test.ts
+++ b/server/routes/contacts/add/cancel/cancelAddContactController.test.ts
@@ -34,7 +34,6 @@ beforeEach(() => {
     lastTouched: new Date().toISOString(),
     prisonerNumber,
     isCheckingAnswers: false,
-    returnPoint: { url: '/foo-bar' },
     names: {
       lastName: 'last',
       firstName: 'first',

--- a/server/routes/contacts/add/check-answers/createContactCheckAnswersController.test.ts
+++ b/server/routes/contacts/add/check-answers/createContactCheckAnswersController.test.ts
@@ -35,7 +35,6 @@ beforeEach(() => {
     lastTouched: new Date().toISOString(),
     prisonerNumber,
     isCheckingAnswers: false,
-    returnPoint: { url: '/foo-bar' },
     names: {
       lastName: 'last',
       firstName: 'first',

--- a/server/routes/contacts/add/contact-match/contactMatchController.test.ts
+++ b/server/routes/contacts/add/contact-match/contactMatchController.test.ts
@@ -42,7 +42,6 @@ beforeEach(() => {
     lastTouched: new Date().toISOString(),
     prisonerNumber,
     isCheckingAnswers: false,
-    returnPoint: { url: '/foo-bar' },
     mode: 'EXISTING',
   }
   app = appWithAllRoutes({

--- a/server/routes/contacts/add/contact-search/contactSearchController.test.ts
+++ b/server/routes/contacts/add/contact-search/contactSearchController.test.ts
@@ -33,7 +33,6 @@ beforeEach(() => {
     lastTouched: new Date().toISOString(),
     prisonerNumber,
     isCheckingAnswers: false,
-    returnPoint: { url: '/foo-bar' },
   }
   app = appWithAllRoutes({
     services: {

--- a/server/routes/contacts/add/domestic-status/addContactDomesticStatusController.test.ts
+++ b/server/routes/contacts/add/domestic-status/addContactDomesticStatusController.test.ts
@@ -33,7 +33,6 @@ beforeEach(() => {
     lastTouched: new Date().toISOString(),
     prisonerNumber,
     isCheckingAnswers: false,
-    returnPoint: { url: '/foo-bar' },
     names: {
       lastName: 'last',
       middleNames: 'middle',

--- a/server/routes/contacts/add/emails/addContactAddEmailsController.test.ts
+++ b/server/routes/contacts/add/emails/addContactAddEmailsController.test.ts
@@ -39,7 +39,6 @@ beforeEach(() => {
     lastTouched: new Date().toISOString(),
     prisonerNumber,
     isCheckingAnswers: false,
-    returnPoint: { url: '/foo-bar' },
     names: {
       lastName: 'last',
       middleNames: 'middle',

--- a/server/routes/contacts/add/emails/addContactConfirmDeleteEmailController.test.ts
+++ b/server/routes/contacts/add/emails/addContactConfirmDeleteEmailController.test.ts
@@ -33,7 +33,6 @@ beforeEach(() => {
     lastTouched: new Date().toISOString(),
     prisonerNumber,
     isCheckingAnswers: true,
-    returnPoint: { url: '/foo-bar' },
     names: {
       lastName: 'last',
       middleNames: 'Middle',

--- a/server/routes/contacts/add/emergency-contact-or-next-of-kin/emergencyContactOrNextOfKinController.test.ts
+++ b/server/routes/contacts/add/emergency-contact-or-next-of-kin/emergencyContactOrNextOfKinController.test.ts
@@ -30,7 +30,6 @@ beforeEach(() => {
     lastTouched: new Date().toISOString(),
     prisonerNumber,
     isCheckingAnswers: false,
-    returnPoint: { url: '/foo-bar' },
     names: {
       lastName: 'last',
       middleNames: 'middle',

--- a/server/routes/contacts/add/employments/addEmploymentsController.test.ts
+++ b/server/routes/contacts/add/employments/addEmploymentsController.test.ts
@@ -34,7 +34,6 @@ beforeEach(() => {
     lastTouched: new Date().toISOString(),
     prisonerNumber,
     isCheckingAnswers: false,
-    returnPoint: { url: '/foo-bar' },
     names: {
       lastName: 'last',
       middleNames: 'Middle',

--- a/server/routes/contacts/add/employments/check-employer/createContactCheckEmployerController.test.ts
+++ b/server/routes/contacts/add/employments/check-employer/createContactCheckEmployerController.test.ts
@@ -34,7 +34,6 @@ beforeEach(() => {
     lastTouched: new Date().toISOString(),
     prisonerNumber,
     isCheckingAnswers: false,
-    returnPoint: { url: '/foo-bar' },
     names: {
       lastName: 'Mason',
       firstName: 'Jones',

--- a/server/routes/contacts/add/employments/delete-employment/createContactDeleteEmploymentController.test.ts
+++ b/server/routes/contacts/add/employments/delete-employment/createContactDeleteEmploymentController.test.ts
@@ -32,7 +32,6 @@ beforeEach(() => {
     lastTouched: new Date().toISOString(),
     prisonerNumber,
     isCheckingAnswers: false,
-    returnPoint: { url: '/foo-bar' },
     names: {
       lastName: 'Mason',
       firstName: 'Jones',

--- a/server/routes/contacts/add/employments/employment-status/createContactEmploymentStatusController.test.ts
+++ b/server/routes/contacts/add/employments/employment-status/createContactEmploymentStatusController.test.ts
@@ -32,7 +32,6 @@ beforeEach(() => {
     lastTouched: new Date().toISOString(),
     prisonerNumber,
     isCheckingAnswers: false,
-    returnPoint: { url: '/foo-bar' },
     names: {
       lastName: 'Mason',
       firstName: 'Jones',

--- a/server/routes/contacts/add/employments/organisation-search/createContactOrganisationSearchController.test.ts
+++ b/server/routes/contacts/add/employments/organisation-search/createContactOrganisationSearchController.test.ts
@@ -34,7 +34,6 @@ beforeEach(() => {
     lastTouched: new Date().toISOString(),
     prisonerNumber,
     isCheckingAnswers: false,
-    returnPoint: { url: '/foo-bar' },
     names: {
       lastName: 'last',
       middleNames: 'Middle',

--- a/server/routes/contacts/add/enter-dob/createContactEnterDobController.test.ts
+++ b/server/routes/contacts/add/enter-dob/createContactEnterDobController.test.ts
@@ -36,7 +36,6 @@ beforeEach(() => {
     lastTouched: new Date().toISOString(),
     prisonerNumber,
     isCheckingAnswers: false,
-    returnPoint: { url: '/foo-bar' },
     names: {
       lastName: 'last',
       middleNames: 'middle',

--- a/server/routes/contacts/add/enter-name/createContactEnterNameController.test.ts
+++ b/server/routes/contacts/add/enter-name/createContactEnterNameController.test.ts
@@ -39,7 +39,6 @@ beforeEach(() => {
     lastTouched: new Date().toISOString(),
     prisonerNumber,
     isCheckingAnswers: false,
-    returnPoint: { url: '/foo-bar' },
     mode: 'NEW',
   }
   app = appWithAllRoutes({

--- a/server/routes/contacts/add/gender/addContactGenderController.test.ts
+++ b/server/routes/contacts/add/gender/addContactGenderController.test.ts
@@ -33,7 +33,6 @@ beforeEach(() => {
     lastTouched: new Date().toISOString(),
     prisonerNumber,
     isCheckingAnswers: false,
-    returnPoint: { url: '/foo-bar' },
     names: {
       lastName: 'last',
       middleNames: 'middle',

--- a/server/routes/contacts/add/identities/addContactAddIdentitiesController.test.ts
+++ b/server/routes/contacts/add/identities/addContactAddIdentitiesController.test.ts
@@ -39,7 +39,6 @@ beforeEach(() => {
     lastTouched: new Date().toISOString(),
     prisonerNumber,
     isCheckingAnswers: false,
-    returnPoint: { url: '/foo-bar' },
     names: {
       lastName: 'last',
       middleNames: 'middle',

--- a/server/routes/contacts/add/identities/addContactConfirmDeleteIdentityController.test.ts
+++ b/server/routes/contacts/add/identities/addContactConfirmDeleteIdentityController.test.ts
@@ -33,7 +33,6 @@ beforeEach(() => {
     lastTouched: new Date().toISOString(),
     prisonerNumber,
     isCheckingAnswers: true,
-    returnPoint: { url: '/foo-bar' },
     names: {
       lastName: 'last',
       middleNames: 'Middle',

--- a/server/routes/contacts/add/is-staff/createContactIsStaffController.test.ts
+++ b/server/routes/contacts/add/is-staff/createContactIsStaffController.test.ts
@@ -30,7 +30,6 @@ beforeEach(() => {
     lastTouched: new Date().toISOString(),
     prisonerNumber,
     isCheckingAnswers: false,
-    returnPoint: { url: '/foo-bar' },
     names: {
       lastName: 'last',
       middleNames: 'Middle',

--- a/server/routes/contacts/add/language-interpreter/createContactLanguageAndInterpreterController.test.ts
+++ b/server/routes/contacts/add/language-interpreter/createContactLanguageAndInterpreterController.test.ts
@@ -33,7 +33,6 @@ beforeEach(() => {
     lastTouched: new Date().toISOString(),
     prisonerNumber,
     isCheckingAnswers: false,
-    returnPoint: { url: '/foo-bar' },
     names: {
       lastName: 'last',
       middleNames: 'middle',

--- a/server/routes/contacts/add/mode/addContactModeController.test.ts
+++ b/server/routes/contacts/add/mode/addContactModeController.test.ts
@@ -29,7 +29,6 @@ beforeEach(() => {
     lastTouched: new Date().toISOString(),
     prisonerNumber,
     isCheckingAnswers: false,
-    returnPoint: { url: '/foo-bar' },
   }
 
   app = appWithAllRoutes({

--- a/server/routes/contacts/add/phone/addContactAddPhoneController.test.ts
+++ b/server/routes/contacts/add/phone/addContactAddPhoneController.test.ts
@@ -39,7 +39,6 @@ beforeEach(() => {
     lastTouched: new Date().toISOString(),
     prisonerNumber,
     isCheckingAnswers: false,
-    returnPoint: { url: '/foo-bar' },
     names: {
       lastName: 'last',
       middleNames: 'middle',

--- a/server/routes/contacts/add/phone/addContactConfirmDeletePhoneController.test.ts
+++ b/server/routes/contacts/add/phone/addContactConfirmDeletePhoneController.test.ts
@@ -33,7 +33,6 @@ beforeEach(() => {
     lastTouched: new Date().toISOString(),
     prisonerNumber,
     isCheckingAnswers: true,
-    returnPoint: { url: '/foo-bar' },
     names: {
       lastName: 'last',
       middleNames: 'Middle',

--- a/server/routes/contacts/add/relationship-comments/enterRelationshipCommentsController.test.ts
+++ b/server/routes/contacts/add/relationship-comments/enterRelationshipCommentsController.test.ts
@@ -36,7 +36,6 @@ beforeEach(() => {
     lastTouched: new Date().toISOString(),
     prisonerNumber,
     isCheckingAnswers: false,
-    returnPoint: { url: '/foo-bar' },
     names: {
       lastName: 'last',
       middleNames: 'Middle',

--- a/server/routes/contacts/add/relationship-to-prisoner/selectRelationshipToPrisonerController.test.ts
+++ b/server/routes/contacts/add/relationship-to-prisoner/selectRelationshipToPrisonerController.test.ts
@@ -33,7 +33,6 @@ beforeEach(() => {
     lastTouched: new Date().toISOString(),
     prisonerNumber,
     isCheckingAnswers: false,
-    returnPoint: { url: '/foo-bar' },
     names: { firstName: 'First', middleNames: 'Middle', lastName: 'Last' },
     relationship: { pendingNewRelationshipType: 'S' },
     mode: 'NEW',

--- a/server/routes/contacts/add/relationship-type/relationshipTypeController.test.ts
+++ b/server/routes/contacts/add/relationship-type/relationshipTypeController.test.ts
@@ -32,7 +32,6 @@ beforeEach(() => {
     prisonerNumber,
     isCheckingAnswers: false,
     matchingContactId,
-    returnPoint: { url: '/foo-bar' },
     names: {
       lastName: 'last',
       middleNames: 'middle',

--- a/server/routes/contacts/add/start/startAddContactJourneyController.test.ts
+++ b/server/routes/contacts/add/start/startAddContactJourneyController.test.ts
@@ -5,7 +5,7 @@ import { v4 as uuidv4 } from 'uuid'
 import { adminUser, appWithAllRoutes, authorisingUser, basicPrisonUser } from '../../../testutils/appSetup'
 import { Page } from '../../../../services/auditService'
 import { MockedService } from '../../../../testutils/mockedServices'
-import { AddContactJourney, ReturnPoint } from '../../../../@types/journeys'
+import { AddContactJourney } from '../../../../@types/journeys'
 import { HmppsUser } from '../../../../interfaces/hmppsUser'
 
 jest.mock('../../../../services/auditService')
@@ -61,29 +61,6 @@ describe('GET /prisoner/:prisonerNumber/contacts/create/start', () => {
     expect(Object.entries(session.addContactJourneys!)).toHaveLength(1)
   })
 
-  it('should set the return point to prisoner contact if no return parameters are specified', async () => {
-    // Given
-    const expectedReturnPoint: ReturnPoint = {
-      url: `/prisoner/${prisonerNumber}/contacts/list`,
-    }
-
-    // When
-    const response = await request(app).get(`/prisoner/${prisonerNumber}/contacts/create/start`)
-
-    // Then
-    expect(auditService.logPageView).toHaveBeenCalledWith(Page.CREATE_CONTACT_START_PAGE, {
-      who: currentUser.username,
-      correlationId: expect.any(String),
-      details: {
-        prisonerNumber: 'A1234BC',
-      },
-    })
-    expect(response.status).toEqual(302)
-    expect(response.headers['location']).toContain('/contacts/search/')
-    const journey = Object.values(session.addContactJourneys!)[0]!
-    expect(journey.returnPoint).toStrictEqual(expectedReturnPoint)
-  })
-
   it('should not remove any existing add journeys in the session', async () => {
     // Given
     preExistingJourneysToAddToSession = [
@@ -91,7 +68,6 @@ describe('GET /prisoner/:prisonerNumber/contacts/create/start', () => {
         id: uuidv4(),
         lastTouched: new Date().toISOString(),
         isCheckingAnswers: false,
-        returnPoint: { url: '/foo-bar' },
         prisonerNumber,
         names: {
           lastName: 'foo',
@@ -121,35 +97,30 @@ describe('GET /prisoner/:prisonerNumber/contacts/create/start', () => {
         lastTouched: new Date(2024, 1, 1, 11, 30).toISOString(),
         prisonerNumber,
         isCheckingAnswers: false,
-        returnPoint: { url: '/foo-bar' },
       },
       {
         id: 'middle-aged',
         lastTouched: new Date(2024, 1, 1, 12, 30).toISOString(),
         prisonerNumber,
         isCheckingAnswers: false,
-        returnPoint: { url: '/foo-bar' },
       },
       {
         id: 'youngest',
         lastTouched: new Date(2024, 1, 1, 14, 30).toISOString(),
         prisonerNumber,
         isCheckingAnswers: false,
-        returnPoint: { url: '/foo-bar' },
       },
       {
         id: 'oldest',
         lastTouched: new Date(2024, 1, 1, 10, 30).toISOString(),
         prisonerNumber,
         isCheckingAnswers: false,
-        returnPoint: { url: '/foo-bar' },
       },
       {
         id: 'young',
         lastTouched: new Date(2024, 1, 1, 13, 30).toISOString(),
         prisonerNumber,
         isCheckingAnswers: false,
-        returnPoint: { url: '/foo-bar' },
       },
     ]
 

--- a/server/routes/contacts/add/start/startAddContactJourneyController.ts
+++ b/server/routes/contacts/add/start/startAddContactJourneyController.ts
@@ -3,7 +3,7 @@ import { v4 as uuidv4 } from 'uuid'
 import { Page } from '../../../../services/auditService'
 import { PageHandler } from '../../../../interfaces/pageHandler'
 import { nextPageForAddContactJourney } from '../addContactFlowControl'
-import { AddContactJourney, ReturnPoint } from '../../../../@types/journeys'
+import { AddContactJourney } from '../../../../@types/journeys'
 import Permission from '../../../../enumeration/permission'
 
 export default class StartAddContactJourneyController implements PageHandler {
@@ -16,12 +16,10 @@ export default class StartAddContactJourneyController implements PageHandler {
   GET = async (req: Request<{ prisonerNumber: string }>, res: Response): Promise<void> => {
     const { prisonerNumber } = req.params
     const { user } = res.locals
-    const returnPoint: ReturnPoint = { url: `/prisoner/${prisonerNumber}/contacts/list` }
     const journey: AddContactJourney = {
       id: uuidv4(),
       lastTouched: new Date().toISOString(),
       isCheckingAnswers: false,
-      returnPoint,
       prisonerNumber,
     }
     if (!req.session.addContactJourneys) {

--- a/server/routes/contacts/manage/addresses/start/startAddressJourneyController.ts
+++ b/server/routes/contacts/manage/addresses/start/startAddressJourneyController.ts
@@ -23,8 +23,7 @@ export default class StartAddressJourneyController implements PageHandler {
         prisonerContactId: string
       },
       unknown,
-      unknown,
-      { returnUrl: string }
+      unknown
     >,
     res: Response,
   ): Promise<void> => {

--- a/server/routes/contacts/manage/contact-details/contactDetailsController.test.ts
+++ b/server/routes/contacts/manage/contact-details/contactDetailsController.test.ts
@@ -392,7 +392,7 @@ describe('GET /contacts/manage/:contactId/relationship/:prisonerContactId', () =
         'No employers recorded.',
       )
       expect($('a:contains("Edit employers")').attr('href')).toEqual(
-        '/prisoner/A1234BC/contacts/manage/22/update-employments?returnUrl=/prisoner/A1234BC/contacts/manage/1/relationship/99',
+        '/prisoner/A1234BC/contacts/manage/1/relationship/99/update-employments',
       )
     })
 
@@ -427,7 +427,7 @@ describe('GET /contacts/manage/:contactId/relationship/:prisonerContactId', () =
       expect($('dt:contains("Business phone number at primary address")').next().text()).toMatch(/60511, ext\. 123/)
       expect($('dt:contains("Employment status")').next().text()).toMatch(/Inactive/)
       expect($('a:contains("Edit employers")').attr('href')).toEqual(
-        '/prisoner/A1234BC/contacts/manage/22/update-employments?returnUrl=/prisoner/A1234BC/contacts/manage/1/relationship/99',
+        '/prisoner/A1234BC/contacts/manage/1/relationship/99/update-employments',
       )
     })
 

--- a/server/routes/contacts/manage/manageContactsMiddleware.test.ts
+++ b/server/routes/contacts/manage/manageContactsMiddleware.test.ts
@@ -1,10 +1,10 @@
 import { Request as ExpressRequest, Response } from 'express'
 import { v4 as uuidv4 } from 'uuid'
 import { SessionData } from 'express-session'
-import { ensureInManageContactsJourney, prepareStandaloneManageContactJourney } from './manageContactsMiddleware'
+import { ensureInManageContactsJourney } from './manageContactsMiddleware'
 import { basicPrisonUser } from '../../testutils/appSetup'
-import resetAllMocks = jest.resetAllMocks
 import { PrisonerJourneyParams } from '../../../@types/journeys'
+import resetAllMocks = jest.resetAllMocks
 
 describe('manageContactsMiddleware', () => {
   describe('ensureInManageContactsJourney', () => {
@@ -77,63 +77,6 @@ describe('manageContactsMiddleware', () => {
         expect(next).toHaveBeenCalledTimes(0)
         expect(res.redirect).toHaveBeenCalledWith('/prisoner/A1234BC/contacts/list')
       })
-    })
-  })
-  describe('prepareStandaloneManageContactJourney', () => {
-    type Request = ExpressRequest
-
-    const journeyId = uuidv4()
-    let req: Request
-    let res: Response
-    let next: jest.Mock
-    let status: jest.Mock
-    let render: jest.Mock
-
-    beforeEach(() => {
-      resetAllMocks()
-      req = {
-        params: { journeyId },
-        session: {} as Partial<SessionData>,
-      } as unknown as Request
-      status = jest.fn()
-      render = jest.fn()
-      res = { status, render, locals: { user: basicPrisonUser } } as unknown as Response
-      next = jest.fn()
-    })
-
-    it('should set return url and anchor into the journey', () => {
-      req.query = { returnUrl: '/foo', returnAnchor: 'bar' }
-      prepareStandaloneManageContactJourney(req, res, next)
-
-      expect(next).toHaveBeenCalledTimes(1)
-      expect(res.locals.journey).toStrictEqual({
-        returnPoint: {
-          url: '/foo',
-          anchor: 'bar',
-        },
-      })
-    })
-
-    it('should set return url only if no anchor', () => {
-      req.query = { returnUrl: '/foo' }
-      prepareStandaloneManageContactJourney(req, res, next)
-
-      expect(next).toHaveBeenCalledTimes(1)
-      expect(res.locals.journey).toStrictEqual({
-        returnPoint: {
-          url: '/foo',
-        },
-      })
-    })
-
-    it('should return to not found page if return url is missing', () => {
-      req.query = {}
-      status.mockReturnValue(res)
-      prepareStandaloneManageContactJourney(req, res, next)
-
-      expect(next).toHaveBeenCalledTimes(0)
-      expect(res.status).toHaveBeenCalledWith(404)
-      expect(res.render).toHaveBeenCalledWith('pages/errors/notFound')
     })
   })
 })

--- a/server/routes/contacts/manage/manageContactsMiddleware.ts
+++ b/server/routes/contacts/manage/manageContactsMiddleware.ts
@@ -27,21 +27,4 @@ const ensureInManageContactsJourney = async (
   return next()
 }
 
-const prepareStandaloneManageContactJourney = async (req: Request, res: Response, next: NextFunction) => {
-  const { returnUrl, returnAnchor } = req.query
-  if (!returnUrl) {
-    logger.warn(`No return url specified for standalone manage contacts journey. ${req.url}`)
-    return res.status(404).render('pages/errors/notFound')
-  }
-  res.locals.journey = {
-    returnPoint: {
-      url: returnUrl as string,
-    },
-  }
-  if (returnAnchor) {
-    res.locals.journey.returnPoint.anchor = returnAnchor as string
-  }
-  return next()
-}
-
-export { ensureInManageContactsJourney, prepareStandaloneManageContactJourney }
+export { ensureInManageContactsJourney }

--- a/server/routes/contacts/manage/manageContactsRoutes.ts
+++ b/server/routes/contacts/manage/manageContactsRoutes.ts
@@ -485,40 +485,40 @@ const ManageContactsRoutes = (
 
   // Edit employments
   get(
-    '/prisoner/:prisonerNumber/contacts/manage/:contactId/update-employments',
+    '/prisoner/:prisonerNumber/contacts/manage/:contactId/relationship/:prisonerContactId/update-employments',
     new UpdateEmploymentsStartController(contactsService),
   )
 
   journeyRoute({
-    path: '/prisoner/:prisonerNumber/contacts/manage/:contactId/update-employments/:journeyId',
+    path: '/prisoner/:prisonerNumber/contacts/manage/:contactId/relationship/:prisonerContactId/update-employments/:journeyId',
     controller: new UpdateEmploymentsController(contactsService),
     journeyEnsurer: ensureInUpdateEmploymentsJourney,
     noValidation: true,
   })
 
   journeyRoute({
-    path: '/prisoner/:prisonerNumber/contacts/manage/:contactId/update-employments/:employmentIdx/organisation-search/:journeyId',
+    path: '/prisoner/:prisonerNumber/contacts/manage/:contactId/relationship/:prisonerContactId/update-employments/:employmentIdx/organisation-search/:journeyId',
     controller: new OrganisationSearchController(organisationsService),
     journeyEnsurer: [ensureInUpdateEmploymentsJourney, ensureValidEmploymentIdx()],
     noValidation: true,
   })
 
   journeyRoute({
-    path: '/prisoner/:prisonerNumber/contacts/manage/:contactId/update-employments/:employmentIdx/check-employer/:journeyId',
+    path: '/prisoner/:prisonerNumber/contacts/manage/:contactId/relationship/:prisonerContactId/update-employments/:employmentIdx/check-employer/:journeyId',
     controller: new CheckEmployerController(organisationsService),
     journeyEnsurer: [ensureInUpdateEmploymentsJourney, ensureValidEmploymentIdx()],
     schema: checkEmployerSchema,
   })
 
   journeyRoute({
-    path: '/prisoner/:prisonerNumber/contacts/manage/:contactId/update-employments/:employmentIdx/employment-status/:journeyId',
+    path: '/prisoner/:prisonerNumber/contacts/manage/:contactId/relationship/:prisonerContactId/update-employments/:employmentIdx/employment-status/:journeyId',
     controller: new EmploymentStatusController(),
     journeyEnsurer: [ensureInUpdateEmploymentsJourney, ensureValidEmploymentIdx(false)],
     schema: employmentStatusSchema,
   })
 
   journeyRoute({
-    path: '/prisoner/:prisonerNumber/contacts/manage/:contactId/update-employments/:employmentIdx/delete-employment/:journeyId',
+    path: '/prisoner/:prisonerNumber/contacts/manage/:contactId/relationship/:prisonerContactId/update-employments/:employmentIdx/delete-employment/:journeyId',
     controller: new DeleteEmploymentController(),
     journeyEnsurer: [ensureInUpdateEmploymentsJourney, ensureValidEmploymentIdx(false)],
     noValidation: true,

--- a/server/routes/contacts/manage/update-employments/check-employer/checkEmployerController.test.ts
+++ b/server/routes/contacts/manage/update-employments/check-employer/checkEmployerController.test.ts
@@ -33,7 +33,6 @@ const generateJourneyData = (): UpdateEmploymentsJourney => ({
   contactId: contact.id,
   contactNames: { ...contact },
   employments: [],
-  returnPoint: { url: '/foo/bar' },
   organisationSearch: { page: 1 },
 })
 const setJourneyData = (data: UpdateEmploymentsJourney) => {
@@ -65,20 +64,20 @@ afterEach(() => {
   jest.resetAllMocks()
 })
 
-describe('GET /contacts/manage/:contactId/update-employments/:employmentIdx/check-employer', () => {
+describe('GET /contacts/manage/:contactId/relationship/:prisonerContactId/update-employments/:employmentIdx/check-employer', () => {
   it('should set organisationId query into session and redirect', async () => {
     // Given
     setJourneyData(generateJourneyData())
 
     // When
     const response = await request(app).get(
-      `/prisoner/${prisonerNumber}/contacts/manage/1/update-employments/new/check-employer/${journeyId}?organisationId=222`,
+      `/prisoner/${prisonerNumber}/contacts/manage/1/relationship/2/update-employments/new/check-employer/${journeyId}?organisationId=222`,
     )
 
     // Then
     expect(response.status).toEqual(302)
     expect(response.headers['location']).toMatch(
-      /contacts\/manage\/1\/update-employments\/new\/check-employer\/[a-f0-9-]{36}/,
+      /contacts\/manage\/1\/relationship\/2\/update-employments\/new\/check-employer\/[a-f0-9-]{36}/,
     )
 
     const journeyData = session.updateEmploymentsJourneys![journeyId]!
@@ -89,6 +88,7 @@ describe('GET /contacts/manage/:contactId/update-employments/:employmentIdx/chec
       correlationId: expect.any(String),
       details: {
         contactId: '1',
+        prisonerContactId: '2',
         prisonerNumber,
         employerId: 'new',
         organisationId: '222',
@@ -102,7 +102,7 @@ describe('GET /contacts/manage/:contactId/update-employments/:employmentIdx/chec
 
     // When
     const response = await request(app).get(
-      `/prisoner/${prisonerNumber}/contacts/manage/1/update-employments/new/check-employer/${journeyId}`,
+      `/prisoner/${prisonerNumber}/contacts/manage/1/relationship/2/update-employments/new/check-employer/${journeyId}`,
     )
 
     // Then
@@ -118,7 +118,7 @@ describe('GET /contacts/manage/:contactId/update-employments/:employmentIdx/chec
 
     // When
     const response = await request(app).get(
-      `/prisoner/${prisonerNumber}/contacts/manage/1/update-employments/new/check-employer/${journeyId}`,
+      `/prisoner/${prisonerNumber}/contacts/manage/1/relationship/2/update-employments/new/check-employer/${journeyId}`,
     )
 
     // Then
@@ -187,7 +187,7 @@ describe('GET /contacts/manage/:contactId/update-employments/:employmentIdx/chec
 
     // When
     const response = await request(app).get(
-      `/prisoner/${prisonerNumber}/contacts/manage/1/update-employments/new/check-employer/${journeyId}`,
+      `/prisoner/${prisonerNumber}/contacts/manage/1/relationship/2/update-employments/new/check-employer/${journeyId}`,
     )
 
     // Then
@@ -198,7 +198,7 @@ describe('GET /contacts/manage/:contactId/update-employments/:employmentIdx/chec
     expect($('.govuk-caption-l').first().text().trim()).toStrictEqual('Edit professional information')
     expect($('[data-qa=breadcrumbs]')).toHaveLength(0)
     expect($('a:contains("Back")').attr('href')).toEqual(
-      `/prisoner/A1234BC/contacts/manage/1/update-employments/new/organisation-search/${journeyId}`,
+      `/prisoner/A1234BC/contacts/manage/1/relationship/2/update-employments/new/organisation-search/${journeyId}`,
     )
     expect($('h1:contains("Check and confirm if this is the correct employer for Jones Mason")').text()).toBeTruthy()
     expect($('dt:contains("Organisation name")').next().text()).toMatch(/Some Corp/)
@@ -252,7 +252,7 @@ it('should render result with minimal mandatory data', async () => {
 
   // When
   const response = await request(app).get(
-    `/prisoner/${prisonerNumber}/contacts/manage/1/update-employments/new/check-employer/${journeyId}`,
+    `/prisoner/${prisonerNumber}/contacts/manage/1/relationship/2/update-employments/new/check-employer/${journeyId}`,
   )
 
   // Then
@@ -300,11 +300,13 @@ it.each([
   })
 
   await request(app)
-    .get(`/prisoner/${prisonerNumber}/contacts/manage/1/update-employments/new/check-employer/${journeyId}`)
+    .get(
+      `/prisoner/${prisonerNumber}/contacts/manage/1/relationship/2/update-employments/new/check-employer/${journeyId}`,
+    )
     .expect(expectedStatus)
 })
 
-describe('POST /contacts/manage/:contactId/update-employments/:employmentIdx/check-employer', () => {
+describe('POST /contacts/manage/:contactId/relationship/:prisonerContactId/update-employments/:employmentIdx/check-employer', () => {
   it('should redirect to update-employment and add new employment record on answer YES', async () => {
     // Given
     const journeyData = generateJourneyData()
@@ -321,7 +323,9 @@ describe('POST /contacts/manage/:contactId/update-employments/:employmentIdx/che
 
     // When
     const response = await request(app)
-      .post(`/prisoner/${prisonerNumber}/contacts/manage/1/update-employments/new/check-employer/${journeyId}`)
+      .post(
+        `/prisoner/${prisonerNumber}/contacts/manage/1/relationship/2/update-employments/new/check-employer/${journeyId}`,
+      )
       .type('form')
       .send({
         isCorrectEmployer: 'YES',
@@ -329,7 +333,9 @@ describe('POST /contacts/manage/:contactId/update-employments/:employmentIdx/che
 
     // Then
     expect(response.status).toEqual(302)
-    expect(response.headers['location']).toMatch(/contacts\/manage\/1\/update-employments\/[a-f0-9-]{36}/)
+    expect(response.headers['location']).toMatch(
+      /contacts\/manage\/1\/relationship\/2\/update-employments\/[a-f0-9-]{36}/,
+    )
     expect(journeyData.employments[0]!.employer).toEqual({
       organisationName: 'Some Corp',
       organisationId: 111,
@@ -367,7 +373,9 @@ describe('POST /contacts/manage/:contactId/update-employments/:employmentIdx/che
 
     // When
     const response = await request(app)
-      .post(`/prisoner/${prisonerNumber}/contacts/manage/1/update-employments/1/check-employer/${journeyId}`)
+      .post(
+        `/prisoner/${prisonerNumber}/contacts/manage/1/relationship/2/update-employments/1/check-employer/${journeyId}`,
+      )
       .type('form')
       .send({
         isCorrectEmployer: 'YES',
@@ -375,7 +383,9 @@ describe('POST /contacts/manage/:contactId/update-employments/:employmentIdx/che
 
     // Then
     expect(response.status).toEqual(302)
-    expect(response.headers['location']).toMatch(/contacts\/manage\/1\/update-employments\/[a-f0-9-]{36}/)
+    expect(response.headers['location']).toMatch(
+      /contacts\/manage\/1\/relationship\/2\/update-employments\/[a-f0-9-]{36}/,
+    )
     expect(journeyData.employments[0]!.employer).toEqual({
       organisationName: 'Some Corp',
       organisationId: 111,
@@ -395,7 +405,9 @@ describe('POST /contacts/manage/:contactId/update-employments/:employmentIdx/che
 
     // When
     const response = await request(app)
-      .post(`/prisoner/${prisonerNumber}/contacts/manage/1/update-employments/new/check-employer/${journeyId}`)
+      .post(
+        `/prisoner/${prisonerNumber}/contacts/manage/1/relationship/2/update-employments/new/check-employer/${journeyId}`,
+      )
       .type('form')
       .send({
         isCorrectEmployer: 'NO',
@@ -404,7 +416,7 @@ describe('POST /contacts/manage/:contactId/update-employments/:employmentIdx/che
     // Then
     expect(response.status).toEqual(302)
     expect(response.headers['location']).toMatch(
-      /contacts\/manage\/1\/update-employments\/new\/organisation-search\/[a-f0-9-]{36}/,
+      /contacts\/manage\/1\/relationship\/2\/update-employments\/new\/organisation-search\/[a-f0-9-]{36}/,
     )
   })
 
@@ -428,7 +440,9 @@ describe('POST /contacts/manage/:contactId/update-employments/:employmentIdx/che
     })
 
     await request(app)
-      .post(`/prisoner/${prisonerNumber}/contacts/manage/1/update-employments/new/check-employer/${journeyId}`)
+      .post(
+        `/prisoner/${prisonerNumber}/contacts/manage/1/relationship/2/update-employments/new/check-employer/${journeyId}`,
+      )
       .type('form')
       .send({ isCorrectEmployer: 'YES' })
       .expect(expectedStatus)

--- a/server/routes/contacts/manage/update-employments/check-employer/checkEmployerController.ts
+++ b/server/routes/contacts/manage/update-employments/check-employer/checkEmployerController.ts
@@ -18,7 +18,7 @@ export default class CheckEmployerController implements PageHandler {
     req: Request<UpdateEmploymentJourneyParams, unknown, unknown, { organisationId: string }>,
     res: Response,
   ) => {
-    const { prisonerNumber, contactId, employmentIdx, journeyId } = req.params
+    const { prisonerNumber, contactId, employmentIdx, journeyId, prisonerContactId } = req.params
     const journey = req.session.updateEmploymentsJourneys![journeyId]!
     const { organisationId } = req.query
 
@@ -28,7 +28,7 @@ export default class CheckEmployerController implements PageHandler {
         journey.changeOrganisationId = orgIdNumber
       }
       return res.redirect(
-        `/prisoner/${prisonerNumber}/contacts/manage/${contactId}/update-employments/${employmentIdx}/check-employer/${journeyId}`,
+        `/prisoner/${prisonerNumber}/contacts/manage/${contactId}/relationship/${prisonerContactId}/update-employments/${employmentIdx}/check-employer/${journeyId}`,
       )
     }
 
@@ -42,7 +42,7 @@ export default class CheckEmployerController implements PageHandler {
 
     return res.render('pages/contacts/manage/employments/checkEmployer/index', {
       navigation: {
-        backLink: `/prisoner/${prisonerNumber}/contacts/manage/${contactId}/update-employments/${employmentIdx}/organisation-search/${journeyId}`,
+        backLink: `/prisoner/${prisonerNumber}/contacts/manage/${contactId}/relationship/${prisonerContactId}/update-employments/${employmentIdx}/organisation-search/${journeyId}`,
       },
       contactNames: journey.contactNames,
       organisation: employer,
@@ -60,13 +60,13 @@ export default class CheckEmployerController implements PageHandler {
   }
 
   POST = async (req: Request<UpdateEmploymentJourneyParams, unknown, IsCorrectEmployerSchema>, res: Response) => {
-    const { prisonerNumber, contactId, employmentIdx, journeyId } = req.params
+    const { prisonerNumber, contactId, employmentIdx, journeyId, prisonerContactId } = req.params
     const journey = req.session.updateEmploymentsJourneys![journeyId]!
 
     if (req.body.isCorrectEmployer === 'NO') {
       delete journey.changeOrganisationId
       return res.redirect(
-        `/prisoner/${prisonerNumber}/contacts/manage/${contactId}/update-employments/${employmentIdx}/organisation-search/${journeyId}`,
+        `/prisoner/${prisonerNumber}/contacts/manage/${contactId}/relationship/${prisonerContactId}/update-employments/${employmentIdx}/organisation-search/${journeyId}`,
       )
     }
 
@@ -85,6 +85,8 @@ export default class CheckEmployerController implements PageHandler {
       journey.employments[idx]!.employer = employerSummary
     }
 
-    return res.redirect(`/prisoner/${prisonerNumber}/contacts/manage/${contactId}/update-employments/${journeyId}`)
+    return res.redirect(
+      `/prisoner/${prisonerNumber}/contacts/manage/${contactId}/relationship/${prisonerContactId}/update-employments/${journeyId}`,
+    )
   }
 }

--- a/server/routes/contacts/manage/update-employments/delete-employment/deleteEmploymentController.test.ts
+++ b/server/routes/contacts/manage/update-employments/delete-employment/deleteEmploymentController.test.ts
@@ -45,7 +45,6 @@ const generateJourneyData = (): UpdateEmploymentsJourney => ({
       isActive: false,
     },
   ],
-  returnPoint: { url: '/foo/bar' },
   organisationSearch: { page: 1 },
 })
 const setJourneyData = (data: UpdateEmploymentsJourney) => {
@@ -76,14 +75,14 @@ afterEach(() => {
   jest.resetAllMocks()
 })
 
-describe('GET /contacts/manage/:contactId/update-employments/:employmentIdx/delete-employment', () => {
+describe('GET /contacts/manage/:contactId/relationship/:prisonerContactId/update-employments/:employmentIdx/delete-employment', () => {
   it('should show error on "new" employment index', async () => {
     // Given
     setJourneyData(generateJourneyData())
 
     // When
     const response = await request(app).get(
-      `/prisoner/${prisonerNumber}/contacts/manage/1/update-employments/new/delete-employment/${journeyId}`,
+      `/prisoner/${prisonerNumber}/contacts/manage/1/relationship/2/update-employments/new/delete-employment/${journeyId}`,
     )
 
     // Then
@@ -100,7 +99,7 @@ describe('GET /contacts/manage/:contactId/update-employments/:employmentIdx/dele
 
     // When
     const response = await request(app).get(
-      `/prisoner/${prisonerNumber}/contacts/manage/1/update-employments/9999/delete-employment/${journeyId}`,
+      `/prisoner/${prisonerNumber}/contacts/manage/1/relationship/2/update-employments/9999/delete-employment/${journeyId}`,
     )
 
     // Then
@@ -117,7 +116,7 @@ describe('GET /contacts/manage/:contactId/update-employments/:employmentIdx/dele
 
     // When
     const response = await request(app).get(
-      `/prisoner/${prisonerNumber}/contacts/manage/1/update-employments/1/delete-employment/${journeyId}`,
+      `/prisoner/${prisonerNumber}/contacts/manage/1/relationship/2/update-employments/1/delete-employment/${journeyId}`,
     )
 
     expect(auditService.logPageView).toHaveBeenCalledWith('MANAGE_CONTACT_DELETE_EMPLOYMENT_PAGE', {
@@ -125,6 +124,7 @@ describe('GET /contacts/manage/:contactId/update-employments/:employmentIdx/dele
       correlationId: expect.any(String),
       details: {
         contactId: '1',
+        prisonerContactId: '2',
         prisonerNumber,
         employerId: '1',
       },
@@ -138,10 +138,10 @@ describe('GET /contacts/manage/:contactId/update-employments/:employmentIdx/dele
     expect($('.govuk-caption-l').first().text().trim()).toStrictEqual('Edit professional information')
     expect($('[data-qa=breadcrumbs]')).toHaveLength(0)
     expect($('a:contains("Back")').attr('href')).toEqual(
-      `/prisoner/A1234BC/contacts/manage/1/update-employments/${journeyId}`,
+      `/prisoner/A1234BC/contacts/manage/1/relationship/2/update-employments/${journeyId}`,
     )
     expect($('a:contains("No, do not delete")').attr('href')).toEqual(
-      `/prisoner/A1234BC/contacts/manage/1/update-employments/${journeyId}`,
+      `/prisoner/A1234BC/contacts/manage/1/relationship/2/update-employments/${journeyId}`,
     )
     expect($('h1:contains("Are you sure you want to delete this employer")').text()).toBeTruthy()
     expect($('dt:contains("Employer name")').next().text()).toMatch(/Big Corp/)
@@ -161,12 +161,14 @@ describe('GET /contacts/manage/:contactId/update-employments/:employmentIdx/dele
 
     // When
     await request(app)
-      .get(`/prisoner/${prisonerNumber}/contacts/manage/1/update-employments/1/delete-employment/${journeyId}`)
+      .get(
+        `/prisoner/${prisonerNumber}/contacts/manage/1/relationship/2/update-employments/1/delete-employment/${journeyId}`,
+      )
       .expect(expectedStatus)
   })
 })
 
-describe('POST /contacts/manage/:contactId/update-employments/:employmentIdx/delete-employment', () => {
+describe('POST /contacts/manage/:contactId/relationship/:prisonerContactId/update-employments/:employmentIdx/delete-employment', () => {
   it('should mark employment for deletion and redirect', async () => {
     // Given
     const journeyData = generateJourneyData()
@@ -174,13 +176,17 @@ describe('POST /contacts/manage/:contactId/update-employments/:employmentIdx/del
 
     // When
     const response = await request(app)
-      .post(`/prisoner/${prisonerNumber}/contacts/manage/1/update-employments/1/delete-employment/${journeyId}`)
+      .post(
+        `/prisoner/${prisonerNumber}/contacts/manage/1/relationship/2/update-employments/1/delete-employment/${journeyId}`,
+      )
       .type('form')
       .send({})
 
     // Then
     expect(response.status).toEqual(302)
-    expect(response.headers['location']).toMatch(/contacts\/manage\/1\/update-employments\/[a-f0-9-]{36}/)
+    expect(response.headers['location']).toMatch(
+      /contacts\/manage\/1\/relationship\/2\/update-employments\/[a-f0-9-]{36}/,
+    )
     expect(journeyData.employments.length).toEqual(0)
     expect(journeyData.employmentIdsToDelete?.length).toEqual(1)
     expect(journeyData.employmentIdsToDelete).toContain(1234)
@@ -194,7 +200,9 @@ describe('POST /contacts/manage/:contactId/update-employments/:employmentIdx/del
 
     // When
     await request(app)
-      .post(`/prisoner/${prisonerNumber}/contacts/manage/1/update-employments/1/delete-employment/${journeyId}`)
+      .post(
+        `/prisoner/${prisonerNumber}/contacts/manage/1/relationship/2/update-employments/1/delete-employment/${journeyId}`,
+      )
       .type('form')
       .send({})
 
@@ -213,7 +221,9 @@ describe('POST /contacts/manage/:contactId/update-employments/:employmentIdx/del
     setJourneyData(journeyData)
 
     await request(app)
-      .post(`/prisoner/${prisonerNumber}/contacts/manage/1/update-employments/1/delete-employment/${journeyId}`)
+      .post(
+        `/prisoner/${prisonerNumber}/contacts/manage/1/relationship/2/update-employments/1/delete-employment/${journeyId}`,
+      )
       .type('form')
       .send({})
       .expect(expectedStatus)

--- a/server/routes/contacts/manage/update-employments/delete-employment/deleteEmploymentController.ts
+++ b/server/routes/contacts/manage/update-employments/delete-employment/deleteEmploymentController.ts
@@ -10,13 +10,13 @@ export default class DeleteEmploymentController implements PageHandler {
   public REQUIRED_PERMISSION = Permission.MANAGE_CONTACTS
 
   GET = async (req: Request<UpdateEmploymentJourneyParams>, res: Response) => {
-    const { prisonerNumber, contactId, employmentIdx, journeyId } = req.params
+    const { prisonerNumber, contactId, employmentIdx, journeyId, prisonerContactId } = req.params
     const journey = req.session.updateEmploymentsJourneys![journeyId]!
     const employment = journey.employments[Number(employmentIdx) - 1]
 
     return res.render('pages/contacts/manage/employments/deleteEmployment/index', {
       navigation: {
-        backLink: `/prisoner/${prisonerNumber}/contacts/manage/${contactId}/update-employments/${journeyId}`,
+        backLink: `/prisoner/${prisonerNumber}/contacts/manage/${contactId}/relationship/${prisonerContactId}/update-employments/${journeyId}`,
       },
       contactNames: journey.contactNames,
       employment,
@@ -24,7 +24,7 @@ export default class DeleteEmploymentController implements PageHandler {
   }
 
   POST = async (req: Request<UpdateEmploymentJourneyParams>, res: Response) => {
-    const { prisonerNumber, contactId, employmentIdx, journeyId } = req.params
+    const { prisonerNumber, contactId, employmentIdx, journeyId, prisonerContactId } = req.params
     const journey = req.session.updateEmploymentsJourneys![journeyId]!
 
     const idx = Number(employmentIdx) - 1
@@ -35,6 +35,8 @@ export default class DeleteEmploymentController implements PageHandler {
     }
     journey.employments.splice(idx, 1)
 
-    return res.redirect(`/prisoner/${prisonerNumber}/contacts/manage/${contactId}/update-employments/${journeyId}`)
+    return res.redirect(
+      `/prisoner/${prisonerNumber}/contacts/manage/${contactId}/relationship/${prisonerContactId}/update-employments/${journeyId}`,
+    )
   }
 }

--- a/server/routes/contacts/manage/update-employments/employment-status/employmentStatusController.test.ts
+++ b/server/routes/contacts/manage/update-employments/employment-status/employmentStatusController.test.ts
@@ -45,7 +45,6 @@ const generateJourneyData = (): UpdateEmploymentsJourney => ({
       isActive: false,
     },
   ],
-  returnPoint: { url: '/foo/bar' },
   organisationSearch: { page: 1 },
 })
 const setJourneyData = (data: UpdateEmploymentsJourney) => {
@@ -76,14 +75,14 @@ afterEach(() => {
   jest.resetAllMocks()
 })
 
-describe('GET /contacts/manage/:contactId/update-employments/:employmentIdx/employment-status', () => {
+describe('GET /contacts/manage/:contactId/relationship/:prisonerContactId/update-employments/:employmentIdx/employment-status', () => {
   it('should show error on "new" employment index', async () => {
     // Given
     setJourneyData(generateJourneyData())
 
     // When
     const response = await request(app).get(
-      `/prisoner/${prisonerNumber}/contacts/manage/1/update-employments/new/employment-status/${journeyId}`,
+      `/prisoner/${prisonerNumber}/contacts/manage/1/relationship/2/update-employments/new/employment-status/${journeyId}`,
     )
 
     // Then
@@ -100,7 +99,7 @@ describe('GET /contacts/manage/:contactId/update-employments/:employmentIdx/empl
 
     // When
     const response = await request(app).get(
-      `/prisoner/${prisonerNumber}/contacts/manage/1/update-employments/9999/organisation-search/${journeyId}`,
+      `/prisoner/${prisonerNumber}/contacts/manage/1/relationship/2/update-employments/9999/organisation-search/${journeyId}`,
     )
 
     // Then
@@ -117,7 +116,7 @@ describe('GET /contacts/manage/:contactId/update-employments/:employmentIdx/empl
 
     // When
     const response = await request(app).get(
-      `/prisoner/${prisonerNumber}/contacts/manage/1/update-employments/1/employment-status/${journeyId}`,
+      `/prisoner/${prisonerNumber}/contacts/manage/1/relationship/2/update-employments/1/employment-status/${journeyId}`,
     )
 
     // Then
@@ -126,6 +125,7 @@ describe('GET /contacts/manage/:contactId/update-employments/:employmentIdx/empl
       correlationId: expect.any(String),
       details: {
         contactId: '1',
+        prisonerContactId: '2',
         prisonerNumber,
         employerId: '1',
       },
@@ -137,7 +137,7 @@ describe('GET /contacts/manage/:contactId/update-employments/:employmentIdx/empl
     expect($('.govuk-caption-l').first().text().trim()).toStrictEqual('Edit professional information')
     expect($('[data-qa=breadcrumbs]')).toHaveLength(0)
     expect($('a:contains("Back")').attr('href')).toEqual(
-      `/prisoner/A1234BC/contacts/manage/1/update-employments/${journeyId}`,
+      `/prisoner/A1234BC/contacts/manage/1/relationship/2/update-employments/${journeyId}`,
     )
     expect($('h1:contains("What is the current employment status")').text()).toBeTruthy()
     expect($('label:contains("Active")').prev('input').attr('checked')).toBeFalsy()
@@ -153,7 +153,7 @@ describe('GET /contacts/manage/:contactId/update-employments/:employmentIdx/empl
 
     // When
     const response = await request(app).get(
-      `/prisoner/${prisonerNumber}/contacts/manage/1/update-employments/1/employment-status/${journeyId}`,
+      `/prisoner/${prisonerNumber}/contacts/manage/1/relationship/2/update-employments/1/employment-status/${journeyId}`,
     )
 
     // Then
@@ -173,12 +173,14 @@ describe('GET /contacts/manage/:contactId/update-employments/:employmentIdx/empl
 
     // When
     await request(app)
-      .get(`/prisoner/${prisonerNumber}/contacts/manage/1/update-employments/1/employment-status/${journeyId}`)
+      .get(
+        `/prisoner/${prisonerNumber}/contacts/manage/1/relationship/2/update-employments/1/employment-status/${journeyId}`,
+      )
       .expect(expectedStatus)
   })
 })
 
-describe('POST /contacts/manage/:contactId/update-employments/:employmentIdx/employment-status', () => {
+describe('POST /contacts/manage/:contactId/relationship/:prisonerContactId/update-employments/:employmentIdx/employment-status', () => {
   it('should update employment status in session and redirect', async () => {
     // Given
     const journeyData = generateJourneyData()
@@ -187,7 +189,9 @@ describe('POST /contacts/manage/:contactId/update-employments/:employmentIdx/emp
 
     // When
     const response = await request(app)
-      .post(`/prisoner/${prisonerNumber}/contacts/manage/1/update-employments/1/employment-status/${journeyId}`)
+      .post(
+        `/prisoner/${prisonerNumber}/contacts/manage/1/relationship/2/update-employments/1/employment-status/${journeyId}`,
+      )
       .type('form')
       .send({
         isActive: 'true',
@@ -195,7 +199,9 @@ describe('POST /contacts/manage/:contactId/update-employments/:employmentIdx/emp
 
     // Then
     expect(response.status).toEqual(302)
-    expect(response.headers['location']).toMatch(/contacts\/manage\/1\/update-employments\/[a-f0-9-]{36}/)
+    expect(response.headers['location']).toMatch(
+      /contacts\/manage\/1\/relationship\/2\/update-employments\/[a-f0-9-]{36}/,
+    )
     expect(journeyData.employments[0]!.isActive).toBeTruthy()
   })
 
@@ -210,7 +216,9 @@ describe('POST /contacts/manage/:contactId/update-employments/:employmentIdx/emp
     setJourneyData(journeyData)
 
     await request(app)
-      .post(`/prisoner/${prisonerNumber}/contacts/manage/1/update-employments/1/employment-status/${journeyId}`)
+      .post(
+        `/prisoner/${prisonerNumber}/contacts/manage/1/relationship/2/update-employments/1/employment-status/${journeyId}`,
+      )
       .type('form')
       .send({
         isActive: 'true',

--- a/server/routes/contacts/manage/update-employments/employment-status/employmentStatusController.ts
+++ b/server/routes/contacts/manage/update-employments/employment-status/employmentStatusController.ts
@@ -11,13 +11,13 @@ export default class EmploymentStatusController implements PageHandler {
   public REQUIRED_PERMISSION = Permission.MANAGE_CONTACTS
 
   GET = async (req: Request<UpdateEmploymentJourneyParams>, res: Response) => {
-    const { prisonerNumber, contactId, employmentIdx, journeyId } = req.params
+    const { prisonerNumber, contactId, employmentIdx, journeyId, prisonerContactId } = req.params
     const journey = req.session.updateEmploymentsJourneys![journeyId]!
     const employment = journey.employments[Number(employmentIdx) - 1]!
 
     return res.render('pages/contacts/manage/employments/employmentStatus/index', {
       navigation: {
-        backLink: `/prisoner/${prisonerNumber}/contacts/manage/${contactId}/update-employments/${journeyId}`,
+        backLink: `/prisoner/${prisonerNumber}/contacts/manage/${contactId}/relationship/${prisonerContactId}/update-employments/${journeyId}`,
       },
       contactNames: journey.contactNames,
       employerName: employment.employer.organisationName,
@@ -26,11 +26,13 @@ export default class EmploymentStatusController implements PageHandler {
   }
 
   POST = async (req: Request<UpdateEmploymentJourneyParams, unknown, IsActiveEmploymentSchema>, res: Response) => {
-    const { prisonerNumber, contactId, employmentIdx, journeyId } = req.params
+    const { prisonerNumber, contactId, employmentIdx, journeyId, prisonerContactId } = req.params
     const journey = req.session.updateEmploymentsJourneys![journeyId]!
 
     journey.employments[Number(employmentIdx) - 1]!.isActive = req.body.isActive
 
-    return res.redirect(`/prisoner/${prisonerNumber}/contacts/manage/${contactId}/update-employments/${journeyId}`)
+    return res.redirect(
+      `/prisoner/${prisonerNumber}/contacts/manage/${contactId}/relationship/${prisonerContactId}/update-employments/${journeyId}`,
+    )
   }
 }

--- a/server/routes/contacts/manage/update-employments/organisation-search/organisationSearchController.test.ts
+++ b/server/routes/contacts/manage/update-employments/organisation-search/organisationSearchController.test.ts
@@ -47,7 +47,6 @@ const generateJourneyData = (): UpdateEmploymentsJourney => ({
       isActive: false,
     },
   ],
-  returnPoint: { url: '/foo/bar' },
   organisationSearch: { page: 1 },
 })
 const setJourneyData = (data: UpdateEmploymentsJourney) => {
@@ -79,14 +78,14 @@ afterEach(() => {
   jest.resetAllMocks()
 })
 
-describe('GET /contacts/manage/:contactId/update-employments/:employmentIdx/organisation-search', () => {
+describe('GET /contacts/manage/:contactId/relationship/:prisonerContactId/update-employments/:employmentIdx/organisation-search', () => {
   it('should show error on invalid employment index', async () => {
     // Given
     setJourneyData(generateJourneyData())
 
     // When
     const response = await request(app).get(
-      `/prisoner/${prisonerNumber}/contacts/manage/1/update-employments/invalid-employment-index/organisation-search/${journeyId}`,
+      `/prisoner/${prisonerNumber}/contacts/manage/1/relationship/2/update-employments/invalid-employment-index/organisation-search/${journeyId}`,
     )
 
     // Then
@@ -103,7 +102,7 @@ describe('GET /contacts/manage/:contactId/update-employments/:employmentIdx/orga
 
     // When
     const response = await request(app).get(
-      `/prisoner/${prisonerNumber}/contacts/manage/1/update-employments/9999/organisation-search/${journeyId}`,
+      `/prisoner/${prisonerNumber}/contacts/manage/1/relationship/2/update-employments/9999/organisation-search/${journeyId}`,
     )
 
     // Then
@@ -120,13 +119,13 @@ describe('GET /contacts/manage/:contactId/update-employments/:employmentIdx/orga
 
     // When
     const response = await request(app).get(
-      `/prisoner/${prisonerNumber}/contacts/manage/1/update-employments/1/organisation-search/${journeyId}?page=2`,
+      `/prisoner/${prisonerNumber}/contacts/manage/1/relationship/2/update-employments/1/organisation-search/${journeyId}?page=2`,
     )
 
     // Then
     expect(response.status).toEqual(302)
     expect(response.headers['location']).toMatch(
-      /contacts\/manage\/1\/update-employments\/1\/organisation-search\/[a-f0-9-]{36}/,
+      /contacts\/manage\/1\/relationship\/2\/update-employments\/1\/organisation-search\/[a-f0-9-]{36}/,
     )
 
     const journeyData = session.updateEmploymentsJourneys![journeyId]!
@@ -145,13 +144,13 @@ describe('GET /contacts/manage/:contactId/update-employments/:employmentIdx/orga
 
     // When
     const response = await request(app).get(
-      `/prisoner/${prisonerNumber}/contacts/manage/1/update-employments/1/organisation-search/${journeyId}?sort=organisationName,desc`,
+      `/prisoner/${prisonerNumber}/contacts/manage/1/relationship/2/update-employments/1/organisation-search/${journeyId}?sort=organisationName,desc`,
     )
 
     // Then
     expect(response.status).toEqual(302)
     expect(response.headers['location']).toMatch(
-      /contacts\/manage\/1\/update-employments\/1\/organisation-search\/[a-f0-9-]{36}/,
+      /contacts\/manage\/1\/relationship\/2\/update-employments\/1\/organisation-search\/[a-f0-9-]{36}/,
     )
 
     expect(journeyData.organisationSearch.sort).toEqual('organisationName,desc')
@@ -180,7 +179,7 @@ describe('GET /contacts/manage/:contactId/update-employments/:employmentIdx/orga
 
     // When
     const response = await request(app).get(
-      `/prisoner/${prisonerNumber}/contacts/manage/2/update-employments/1/organisation-search/${journeyId}`,
+      `/prisoner/${prisonerNumber}/contacts/manage/2/relationship/3/update-employments/1/organisation-search/${journeyId}`,
     )
 
     // Then
@@ -189,6 +188,7 @@ describe('GET /contacts/manage/:contactId/update-employments/:employmentIdx/orga
       correlationId: expect.any(String),
       details: {
         contactId: '2',
+        prisonerContactId: '3',
         prisonerNumber,
         employerId: '1',
       },
@@ -198,7 +198,7 @@ describe('GET /contacts/manage/:contactId/update-employments/:employmentIdx/orga
     expect($('.govuk-caption-l').first().text().trim()).toStrictEqual('Edit professional information')
     expect($('[data-qa=breadcrumbs]')).toHaveLength(0)
     expect($('a:contains("Back to employment information")').attr('href')).toEqual(
-      `/prisoner/A1234BC/contacts/manage/2/update-employments/${journeyId}`,
+      `/prisoner/A1234BC/contacts/manage/2/relationship/3/update-employments/${journeyId}`,
     )
     expect($('input#organisationName').val()).toEqual('test')
     expect($('h1').text()).toEqual('Search for Jones Mason’s employer')
@@ -209,7 +209,7 @@ describe('GET /contacts/manage/:contactId/update-employments/:employmentIdx/orga
     const checkEmployerLink = $('a:contains("Check if this is the")')
     expect(checkEmployerLink.text()).toEqual('Check if this is the correct employer (Some Corp)')
     expect(checkEmployerLink.attr('href')).toEqual(
-      `/prisoner/A1234BC/contacts/manage/2/update-employments/1/check-employer/${journeyId}?organisationId=111`,
+      `/prisoner/A1234BC/contacts/manage/2/relationship/3/update-employments/1/check-employer/${journeyId}?organisationId=111`,
     )
     expect($('.moj-pagination__list').text()).toBeTruthy()
   })
@@ -236,7 +236,7 @@ describe('GET /contacts/manage/:contactId/update-employments/:employmentIdx/orga
 
     // When
     const response = await request(app).get(
-      `/prisoner/${prisonerNumber}/contacts/manage/1/update-employments/1/organisation-search/${journeyId}`,
+      `/prisoner/${prisonerNumber}/contacts/manage/1/relationship/2/update-employments/1/organisation-search/${journeyId}`,
     )
 
     // Then
@@ -261,7 +261,7 @@ describe('GET /contacts/manage/:contactId/update-employments/:employmentIdx/orga
 
     // When
     const response = await request(app).get(
-      `/prisoner/${prisonerNumber}/contacts/manage/1/update-employments/1/organisation-search/${journeyId}`,
+      `/prisoner/${prisonerNumber}/contacts/manage/1/relationship/2/update-employments/1/organisation-search/${journeyId}`,
     )
 
     // Then
@@ -284,7 +284,7 @@ describe('GET /contacts/manage/:contactId/update-employments/:employmentIdx/orga
 
     // When
     const response = await request(app).get(
-      `/prisoner/${prisonerNumber}/contacts/manage/1/update-employments/1/organisation-search/${journeyId}`,
+      `/prisoner/${prisonerNumber}/contacts/manage/1/relationship/2/update-employments/1/organisation-search/${journeyId}`,
     )
 
     // Then
@@ -310,19 +310,23 @@ describe('GET /contacts/manage/:contactId/update-employments/:employmentIdx/orga
     })
 
     await request(app)
-      .get(`/prisoner/${prisonerNumber}/contacts/manage/1/update-employments/1/organisation-search/${journeyId}`)
+      .get(
+        `/prisoner/${prisonerNumber}/contacts/manage/1/relationship/2/update-employments/1/organisation-search/${journeyId}`,
+      )
       .expect(expectedStatus)
   })
 })
 
-describe('POST /contacts/manage/:contactId/update-employments/:employmentIdx/organisation-search', () => {
+describe('POST /contacts/manage/:contactId/relationship/:prisonerContactId/update-employments/:employmentIdx/organisation-search', () => {
   it('should set searchTerm into session and redirect', async () => {
     // Given
     setJourneyData(generateJourneyData())
 
     // When
     const response = await request(app)
-      .post(`/prisoner/${prisonerNumber}/contacts/manage/1/update-employments/1/organisation-search/${journeyId}`)
+      .post(
+        `/prisoner/${prisonerNumber}/contacts/manage/1/relationship/2/update-employments/1/organisation-search/${journeyId}`,
+      )
       .type('form')
       .send({
         organisationName: 'te %st',
@@ -331,7 +335,7 @@ describe('POST /contacts/manage/:contactId/update-employments/:employmentIdx/org
     // Then
     expect(response.status).toEqual(302)
     expect(response.headers['location']).toMatch(
-      /contacts\/manage\/1\/update-employments\/1\/organisation-search\/[a-f0-9-]{36}/,
+      /contacts\/manage\/1\/relationship\/2\/update-employments\/1\/organisation-search\/[a-f0-9-]{36}/,
     )
 
     const journeyData = session.updateEmploymentsJourneys![journeyId]!
@@ -347,7 +351,9 @@ describe('POST /contacts/manage/:contactId/update-employments/:employmentIdx/org
     setJourneyData(generateJourneyData())
 
     await request(app)
-      .post(`/prisoner/${prisonerNumber}/contacts/manage/1/update-employments/1/organisation-search/${journeyId}`)
+      .post(
+        `/prisoner/${prisonerNumber}/contacts/manage/1/relationship/2/update-employments/1/organisation-search/${journeyId}`,
+      )
       .type('form')
       .send({ organisationName: 'te %st' })
       .expect(expectedStatus)

--- a/server/routes/contacts/manage/update-employments/organisation-search/organisationSearchController.ts
+++ b/server/routes/contacts/manage/update-employments/organisation-search/organisationSearchController.ts
@@ -20,7 +20,7 @@ export default class OrganisationSearchController implements PageHandler {
     req: Request<UpdateEmploymentJourneyParams, unknown, unknown, { page?: string; sort?: string }>,
     res: Response,
   ) => {
-    const { prisonerNumber, contactId, employmentIdx, journeyId } = req.params
+    const { prisonerNumber, contactId, employmentIdx, journeyId, prisonerContactId } = req.params
     const journey = req.session.updateEmploymentsJourneys![journeyId]!
     const { page, sort } = req.query
 
@@ -28,14 +28,14 @@ export default class OrganisationSearchController implements PageHandler {
       journey.organisationSearch.sort = sort
       journey.organisationSearch.page = 1
       return res.redirect(
-        `/prisoner/${prisonerNumber}/contacts/manage/${contactId}/update-employments/${employmentIdx}/organisation-search/${journeyId}#pagination`,
+        `/prisoner/${prisonerNumber}/contacts/manage/${contactId}/relationship/${prisonerContactId}/update-employments/${employmentIdx}/organisation-search/${journeyId}#pagination`,
       )
     }
     if (page) {
       const pageNumber = Number(page)
       journey.organisationSearch.page = Number.isNaN(pageNumber) ? 1 : pageNumber
       return res.redirect(
-        `/prisoner/${prisonerNumber}/contacts/manage/${contactId}/update-employments/${employmentIdx}/organisation-search/${journeyId}#pagination`,
+        `/prisoner/${prisonerNumber}/contacts/manage/${contactId}/relationship/${prisonerContactId}/update-employments/${employmentIdx}/organisation-search/${journeyId}#pagination`,
       )
     }
 
@@ -63,9 +63,9 @@ export default class OrganisationSearchController implements PageHandler {
     return res.render('pages/contacts/manage/employments/organisationSearch/index', {
       navigation: {
         backLinkLabel: 'Back to employment information',
-        backLink: `/prisoner/${prisonerNumber}/contacts/manage/${contactId}/update-employments/${journeyId}`,
+        backLink: `/prisoner/${prisonerNumber}/contacts/manage/${contactId}/relationship/${prisonerContactId}/update-employments/${journeyId}`,
       },
-      baseEmploymentLink: `/prisoner/${prisonerNumber}/contacts/manage/${contactId}/update-employments/${employmentIdx}/`,
+      baseEmploymentLink: `/prisoner/${prisonerNumber}/contacts/manage/${contactId}/relationship/${prisonerContactId}/update-employments/${employmentIdx}/`,
       ...req.params,
       contact: journey.contactNames,
       organisationName: journey.organisationSearch.searchTerm,

--- a/server/routes/contacts/manage/update-employments/start/updateEmploymentsStartController.test.ts
+++ b/server/routes/contacts/manage/update-employments/start/updateEmploymentsStartController.test.ts
@@ -66,12 +66,14 @@ describe('GET /contacts/manage/:contactId/update-employments', () => {
 
     // When
     const response = await request(app).get(
-      `/prisoner/${prisonerNumber}/contacts/manage/1/update-employments?returnUrl=/foo/bar`,
+      `/prisoner/${prisonerNumber}/contacts/manage/1/relationship/2/update-employments`,
     )
 
     // Then
     expect(response.status).toEqual(302)
-    expect(response.headers['location']).toMatch(/contacts\/manage\/1\/update-employments\/[a-f0-9-]{36}/)
+    expect(response.headers['location']).toMatch(
+      /contacts\/manage\/1\/relationship\/2\/update-employments\/[a-f0-9-]{36}/,
+    )
     const responseJourneyId = response.headers['location']!.split('/').slice(-1)[0]
     const journeyData = session.updateEmploymentsJourneys![responseJourneyId!]!
 
@@ -81,7 +83,6 @@ describe('GET /contacts/manage/:contactId/update-employments', () => {
     expect(journeyData.contactNames!.lastName).toEqual(contact.lastName)
     expect(journeyData.contactNames!.title).toEqual(contact.titleCode)
     expect(journeyData.employments[0]).toEqual(employment)
-    expect(journeyData.returnPoint!.url).toEqual('/foo/bar')
   })
 
   it.each([
@@ -93,7 +94,7 @@ describe('GET /contacts/manage/:contactId/update-employments', () => {
     contactsService.getContact.mockResolvedValue(TestData.contact())
 
     await request(app)
-      .get(`/prisoner/${prisonerNumber}/contacts/manage/1/update-employments?returnUrl=/foo/bar`)
+      .get(`/prisoner/${prisonerNumber}/contacts/manage/1/relationship/2/update-employments`)
       .expect(expectedStatus)
   })
 })

--- a/server/routes/contacts/manage/update-employments/start/updateEmploymentsStartController.ts
+++ b/server/routes/contacts/manage/update-employments/start/updateEmploymentsStartController.ts
@@ -1,4 +1,4 @@
-import { NextFunction, Request, Response } from 'express'
+import { Request, Response } from 'express'
 import { v4 as uuidv4 } from 'uuid'
 import { ContactsService } from '../../../../../services'
 import { UpdateEmploymentsJourney } from '../../../../../@types/journeys'
@@ -16,11 +16,10 @@ export default class UpdateEmploymentsStartController implements PageHandler {
   private MAX_JOURNEYS = 5
 
   GET = async (
-    req: Request<{ contactId: string; prisonerNumber: string }, unknown, unknown, { returnUrl: string }>,
+    req: Request<{ contactId: string; prisonerNumber: string; prisonerContactId: string }, unknown, unknown>,
     res: Response,
-    next: NextFunction,
   ) => {
-    const { prisonerNumber, contactId } = req.params
+    const { prisonerNumber, contactId, prisonerContactId } = req.params
     const contact = await this.contactsService.getContact(Number(req.params.contactId), res.locals.user)
     const journey: UpdateEmploymentsJourney = {
       id: uuidv4(),
@@ -33,7 +32,6 @@ export default class UpdateEmploymentsStartController implements PageHandler {
         middleNames: contact.middleNames,
       },
       employments: contact.employments,
-      returnPoint: { url: req.query.returnUrl },
       organisationSearch: { page: 1 },
     }
 
@@ -52,6 +50,8 @@ export default class UpdateEmploymentsStartController implements PageHandler {
         .forEach(journeyToRemove => delete req.session.updateEmploymentsJourneys![journeyToRemove.id])
     }
 
-    res.redirect(`/prisoner/${prisonerNumber}/contacts/manage/${contactId}/update-employments/${journey.id}`)
+    res.redirect(
+      `/prisoner/${prisonerNumber}/contacts/manage/${contactId}/relationship/${prisonerContactId}/update-employments/${journey.id}`,
+    )
   }
 }

--- a/server/routes/contacts/manage/update-employments/updateEmploymentsController.test.ts
+++ b/server/routes/contacts/manage/update-employments/updateEmploymentsController.test.ts
@@ -40,7 +40,6 @@ const generateJourneyData = (): UpdateEmploymentsJourney => ({
   contactId: contact.id,
   contactNames: { ...contact },
   employments: [],
-  returnPoint: { url: '/foo/bar' },
   organisationSearch: { page: 1 },
 })
 const setJourneyData = (data: UpdateEmploymentsJourney) => {
@@ -72,7 +71,7 @@ afterEach(() => {
   jest.resetAllMocks()
 })
 
-describe('GET /contacts/manage/:contactId/update-employments/:journeyId', () => {
+describe('GET /contacts/manage/:contactId/relationship/:prisonerContactId/update-employments/:journeyId', () => {
   it('should render employment records with change links', async () => {
     // Given
     setJourneyData({
@@ -96,7 +95,7 @@ describe('GET /contacts/manage/:contactId/update-employments/:journeyId', () => 
 
     // When
     const response = await request(app).get(
-      `/prisoner/${prisonerNumber}/contacts/manage/1/update-employments/${journeyId}`,
+      `/prisoner/${prisonerNumber}/contacts/manage/1/relationship/2/update-employments/${journeyId}`,
     )
 
     // Then
@@ -105,6 +104,7 @@ describe('GET /contacts/manage/:contactId/update-employments/:journeyId', () => 
       correlationId: expect.any(String),
       details: {
         contactId: '1',
+        prisonerContactId: '2',
         prisonerNumber,
       },
     })
@@ -113,25 +113,27 @@ describe('GET /contacts/manage/:contactId/update-employments/:journeyId', () => 
     expect($('.govuk-caption-l').first().text().trim()).toStrictEqual('Edit professional information')
     expect($('h1').text()).toStrictEqual('Edit employment information for Jones Mason')
     expect($('[data-qa=breadcrumbs]')).toHaveLength(0)
-    expect($('a:contains("Back to contact record")').attr('href')).toEqual('/foo/bar')
+    expect($('a:contains("Back to contact record")').attr('href')).toEqual(
+      '/prisoner/A1234BC/contacts/manage/1/relationship/2',
+    )
     expect($('dt:contains("Employer name")').next().text()).toMatch(/Big Corp/)
     expect($('dt:contains("Employer’s primary address")').next().text()).toMatch(/Some House(\s+)England/)
     expect($('dt:contains("Business phone number at primary address")').next().text()).toMatch(/60511, ext\. 123/)
     expect($('dt:contains("Employment status")').next().text()).toMatch(/Inactive/)
 
     expect($('a:contains("Delete employer (Past employer: Big Corp)")').attr('href')).toEqual(
-      `/prisoner/A1234BC/contacts/manage/1/update-employments/1/delete-employment/${journeyId}`,
+      `/prisoner/A1234BC/contacts/manage/1/relationship/2/update-employments/1/delete-employment/${journeyId}`,
     )
     expect($('a:contains("Change organisation (Past employer: Big Corp)")').attr('href')).toEqual(
-      `/prisoner/A1234BC/contacts/manage/1/update-employments/1/organisation-search/${journeyId}`,
+      `/prisoner/A1234BC/contacts/manage/1/relationship/2/update-employments/1/organisation-search/${journeyId}`,
     )
     expect($('a:contains("Change status of the employment with (Past employer: Big Corp)")').attr('href')).toEqual(
-      `/prisoner/A1234BC/contacts/manage/1/update-employments/1/employment-status/${journeyId}`,
+      `/prisoner/A1234BC/contacts/manage/1/relationship/2/update-employments/1/employment-status/${journeyId}`,
     )
     expect($('a:contains("Add another employer")').attr('href')).toEqual(
-      `/prisoner/A1234BC/contacts/manage/1/update-employments/new/organisation-search/${journeyId}`,
+      `/prisoner/A1234BC/contacts/manage/1/relationship/2/update-employments/new/organisation-search/${journeyId}`,
     )
-    expect($('a:contains("Cancel")').attr('href')).toEqual('/foo/bar')
+    expect($('a:contains("Cancel")').attr('href')).toEqual('/prisoner/A1234BC/contacts/manage/1/relationship/2')
     expect($('p:contains("To change details such as the employer name")').text()).toBeTruthy()
   })
 
@@ -144,14 +146,14 @@ describe('GET /contacts/manage/:contactId/update-employments/:journeyId', () => 
 
     // When
     const response = await request(app).get(
-      `/prisoner/${prisonerNumber}/contacts/manage/1/update-employments/${journeyId}`,
+      `/prisoner/${prisonerNumber}/contacts/manage/1/relationship/2/update-employments/${journeyId}`,
     )
 
     // Then
     const $ = cheerio.load(response.text)
     expect($('h1:contains("Edit employment information")').parent().next().text()).toContain('No employers recorded.')
     expect($('a:contains("Add employer")').attr('href')).toEqual(
-      `/prisoner/A1234BC/contacts/manage/1/update-employments/new/organisation-search/${journeyId}`,
+      `/prisoner/A1234BC/contacts/manage/1/relationship/2/update-employments/new/organisation-search/${journeyId}`,
     )
     expect($('p:contains("To change details such as the employer name")').text()).toBeFalsy()
   })
@@ -175,7 +177,7 @@ describe('GET /contacts/manage/:contactId/update-employments/:journeyId', () => 
 
     // When
     const response = await request(app).get(
-      `/prisoner/${prisonerNumber}/contacts/manage/1/update-employments/${journeyId}`,
+      `/prisoner/${prisonerNumber}/contacts/manage/1/relationship/2/update-employments/${journeyId}`,
     )
 
     // Then
@@ -196,12 +198,12 @@ describe('GET /contacts/manage/:contactId/update-employments/:journeyId', () => 
     })
 
     await request(app)
-      .get(`/prisoner/${prisonerNumber}/contacts/manage/1/update-employments/${journeyId}`)
+      .get(`/prisoner/${prisonerNumber}/contacts/manage/1/relationship/2/update-employments/${journeyId}`)
       .expect(expectedStatus)
   })
 })
 
-describe('POST /contacts/manage/:contactId/update-employments/:journeyId', () => {
+describe('POST /contacts/manage/:contactId/relationship/:prisonerContactId/update-employments/:journeyId', () => {
   it('should send PATCH employments API call, then redirect with success message', async () => {
     // Given
     setJourneyData({
@@ -230,7 +232,7 @@ describe('POST /contacts/manage/:contactId/update-employments/:journeyId', () =>
 
     // When
     const response = await request(app).post(
-      `/prisoner/${prisonerNumber}/contacts/manage/1/update-employments/${journeyId}`,
+      `/prisoner/${prisonerNumber}/contacts/manage/1/relationship/2/update-employments/${journeyId}`,
     )
 
     // Then
@@ -262,7 +264,7 @@ describe('POST /contacts/manage/:contactId/update-employments/:journeyId', () =>
     )
 
     expect(response.status).toEqual(302)
-    expect(response.headers['location']).toMatch(/\/foo\/bar/)
+    expect(response.headers['location']).toStrictEqual('/prisoner/A1234BC/contacts/manage/1/relationship/2')
   })
 
   it('should handle request with only CREATE', async () => {
@@ -283,7 +285,7 @@ describe('POST /contacts/manage/:contactId/update-employments/:journeyId', () =>
 
     // When
     const response = await request(app).post(
-      `/prisoner/${prisonerNumber}/contacts/manage/1/update-employments/${journeyId}`,
+      `/prisoner/${prisonerNumber}/contacts/manage/1/relationship/2/update-employments/${journeyId}`,
     )
 
     // Then
@@ -324,7 +326,7 @@ describe('POST /contacts/manage/:contactId/update-employments/:journeyId', () =>
 
     // When
     const response = await request(app).post(
-      `/prisoner/${prisonerNumber}/contacts/manage/1/update-employments/${journeyId}`,
+      `/prisoner/${prisonerNumber}/contacts/manage/1/relationship/2/update-employments/${journeyId}`,
     )
 
     // Then
@@ -357,7 +359,7 @@ describe('POST /contacts/manage/:contactId/update-employments/:journeyId', () =>
 
     // When
     const response = await request(app).post(
-      `/prisoner/${prisonerNumber}/contacts/manage/1/update-employments/${journeyId}`,
+      `/prisoner/${prisonerNumber}/contacts/manage/1/relationship/2/update-employments/${journeyId}`,
     )
 
     // Then
@@ -405,7 +407,7 @@ describe('POST /contacts/manage/:contactId/update-employments/:journeyId', () =>
     })
 
     await request(app)
-      .post(`/prisoner/${prisonerNumber}/contacts/manage/1/update-employments/${journeyId}`)
+      .post(`/prisoner/${prisonerNumber}/contacts/manage/1/relationship/2/update-employments/${journeyId}`)
       .expect(expectedStatus)
   })
 })

--- a/server/routes/restrictions/start-add/startAddRestrictionJourneyController.test.ts
+++ b/server/routes/restrictions/start-add/startAddRestrictionJourneyController.test.ts
@@ -76,7 +76,7 @@ describe('GET /prisoner/:prisonerNumber/contacts/:contactId/relationship/:prison
 
       // When
       const response = await request(app).get(
-        `/prisoner/${prisonerNumber}/contacts/${contactId}/relationship/${prisonerContactId}/restriction/add/${restrictionClass}/start?returnUrl=/foo`,
+        `/prisoner/${prisonerNumber}/contacts/${contactId}/relationship/${prisonerContactId}/restriction/add/${restrictionClass}/start`,
       )
 
       // Then
@@ -117,7 +117,7 @@ describe('GET /prisoner/:prisonerNumber/contacts/:contactId/relationship/:prison
 
     // When
     const response = await request(app).get(
-      `/prisoner/${prisonerNumber}/contacts/${contactId}/relationship/${prisonerContactId}/restriction/add/PRISONER_CONTACT/start?returnUrl=/foo`,
+      `/prisoner/${prisonerNumber}/contacts/${contactId}/relationship/${prisonerContactId}/restriction/add/PRISONER_CONTACT/start`,
     )
     const { location } = response.headers
 
@@ -197,7 +197,7 @@ describe('GET /prisoner/:prisonerNumber/contacts/:contactId/relationship/:prison
 
     // When
     const response = await request(app).get(
-      `/prisoner/${prisonerNumber}/contacts/${contactId}/relationship/${prisonerContactId}/restriction/add/PRISONER_CONTACT/start?returnUrl=/foo`,
+      `/prisoner/${prisonerNumber}/contacts/${contactId}/relationship/${prisonerContactId}/restriction/add/PRISONER_CONTACT/start`,
     )
     const { location } = response.headers
 
@@ -218,7 +218,7 @@ describe('GET /prisoner/:prisonerNumber/contacts/:contactId/relationship/:prison
     currentUser = user
     await request(app)
       .get(
-        `/prisoner/${prisonerNumber}/contacts/${contactId}/relationship/${prisonerContactId}/restriction/add/PRISONER_CONTACT/start?returnUrl=/foo`,
+        `/prisoner/${prisonerNumber}/contacts/${contactId}/relationship/${prisonerContactId}/restriction/add/PRISONER_CONTACT/start`,
       )
       .expect(expectedStatus)
   })

--- a/server/services/contactsService.test.ts
+++ b/server/services/contactsService.test.ts
@@ -74,7 +74,6 @@ describe('contactsService', () => {
           lastTouched: new Date().toISOString(),
           prisonerNumber,
           isCheckingAnswers: false,
-          returnPoint: { url: '/foo-bar' },
           names: {
             title: 'Mr',
             lastName: 'last',
@@ -182,7 +181,6 @@ describe('contactsService', () => {
           lastTouched: new Date().toISOString(),
           prisonerNumber,
           isCheckingAnswers: false,
-          returnPoint: { url: '/foo-bar' },
           names: {
             lastName: 'last',
             firstName: 'first',
@@ -243,7 +241,6 @@ describe('contactsService', () => {
           lastTouched: new Date().toISOString(),
           prisonerNumber,
           isCheckingAnswers: false,
-          returnPoint: { url: '/foo-bar' },
           names: {
             lastName: 'last',
             firstName: 'first',
@@ -299,7 +296,6 @@ describe('contactsService', () => {
         lastTouched: new Date().toISOString(),
         prisonerNumber,
         isCheckingAnswers: false,
-        returnPoint: { url: '/foo-bar' },
         names: {
           lastName: 'last',
           firstName: 'first',
@@ -346,7 +342,6 @@ describe('contactsService', () => {
             lastTouched: new Date().toISOString(),
             prisonerNumber,
             isCheckingAnswers: false,
-            returnPoint: { url: '/foo-bar' },
             names: { firstName: 'first', lastName: 'last' },
             dateOfBirth: { isKnown: 'NO' },
             relationship: {
@@ -469,7 +464,6 @@ describe('contactsService', () => {
           lastTouched: new Date().toISOString(),
           prisonerNumber,
           isCheckingAnswers: false,
-          returnPoint: { url: '/foo-bar' },
           names: {
             title: 'Mr',
             lastName: 'last',
@@ -531,7 +525,6 @@ describe('contactsService', () => {
         lastTouched: new Date().toISOString(),
         prisonerNumber,
         isCheckingAnswers: false,
-        returnPoint: { url: '/foo-bar' },
         names: {
           lastName: 'last',
           firstName: 'first',
@@ -576,7 +569,6 @@ describe('contactsService', () => {
             lastTouched: new Date().toISOString(),
             prisonerNumber,
             isCheckingAnswers: false,
-            returnPoint: { url: '/foo-bar' },
             names: { firstName: 'first', lastName: 'last' },
             dateOfBirth: { isKnown: 'NO' },
             relationship: {

--- a/server/views/pages/contacts/manage/contactDetails/details/editContactDetails.njk
+++ b/server/views/pages/contacts/manage/contactDetails/details/editContactDetails.njk
@@ -16,7 +16,6 @@
         <span class="govuk-caption-l">Manage contacts</span>
         <h1 class="govuk-heading-l">Edit contact details for {{ contact | formatNameFirstNameFirst }}</h1>
       </div>
-      {% set returnUrl = '/prisoner/' + prisonerNumber + '/contacts/manage/' + contactId + '/relationship/' + prisonerContactId + '/edit-contact-details' %}
 
       {{ personalInformationCard({
           contact: contact,
@@ -40,7 +39,6 @@
           contact: contact,
           prisonerNumber: prisonerNumber,
           prisonerContactId: prisonerContactId,
-          returnUrl: returnUrl,
           showActions: true
         })
       }}
@@ -49,7 +47,6 @@
           contact: contact,
           prisonerNumber: prisonerNumber,
           prisonerContactId: prisonerContactRelationship.prisonerContactId,
-          returnUrl: returnUrl,
           showActions: true
         })
       }}

--- a/server/views/pages/contacts/manage/contactDetails/details/professionalInformationTab.njk
+++ b/server/views/pages/contacts/manage/contactDetails/details/professionalInformationTab.njk
@@ -8,7 +8,7 @@
     </div>
     <div class="moj-page-header-actions__actions">
       <div class="moj-button-group moj-button-group--inline">
-      <a class="govuk-link govuk-link--no-visited-state" href="{{ "/prisoner/" + prisonerDetails.prisonerNumber + "/contacts/manage/" + contact.id + "/update-employments?returnUrl=" + manageContactRelationshipUrl }}">Edit employers</a>
+      <a class="govuk-link govuk-link--no-visited-state" href="{{ "/prisoner/" + prisonerNumber + "/contacts/manage/" + contactId + "/relationship/" + prisonerContactId + "/update-employments" }}">Edit employers</a>
       </div>
     </div>
   </div>

--- a/server/views/partials/contactDetails/additionalInformationCard.njk
+++ b/server/views/partials/contactDetails/additionalInformationCard.njk
@@ -4,7 +4,6 @@
 
   {% set contact = opts.contact %}
   {% set showActions = opts.showActions %}
-  {% set returnUrl = opts.returnUrl %}
   {% set prisonerNumber = opts.prisonerNumber %}
   {% set prisonerContactId = opts.prisonerContactId %}
 

--- a/server/views/partials/contactDetails/identityDocumentationCard.njk
+++ b/server/views/partials/contactDetails/identityDocumentationCard.njk
@@ -4,7 +4,6 @@
 
   {% set contact = opts.contact %}
   {% set showActions = opts.showActions %}
-  {% set returnUrl = opts.returnUrl %}
   {% set prisonerNumber = opts.prisonerNumber %}
   {% set prisonerContactId = opts.prisonerContactId %}
 


### PR DESCRIPTION
This was not actually required any more as all URLs are hardcoded but because it got rendered into links with the templates it was actually an XSS attack vector. This is the easy one to fix.