### PR TITLE
PRC-735: Show inactive contacts by default

### DIFF
--- a/integration_tests/e2e/listContactsAsAdmin.cy.ts
+++ b/integration_tests/e2e/listContactsAsAdmin.cy.ts
@@ -41,6 +41,7 @@ context('List contacts with Contacts Administrator or Authoriser roles', () => {
   const contactTen = aContact(10, 'Ten', 'Contact')
   const contactEleven = aContact(11, 'Eleven', 'Contact')
   const contactTwelve = aContact(12, 'Twelve', 'Contact')
+  const contactInactive = aContact(13, 'Inactive', 'Contact')
 
   function aContact(id: number, lastName: string, firstName: string): PrisonerContactSummary {
     return { ...minimalContact, contactId: id, prisonerContactId: id + 100000, lastName, firstName }
@@ -55,8 +56,19 @@ context('List contacts with Contacts Administrator or Authoriser roles', () => {
 
   it('should maintain filters when paging but applying a sort returns you to page one', () => {
     const initialPage: PagedModelPrisonerContactSummary = {
-      content: [contactOne, contactTwo, contactThree, contactFour, contactFive],
-      page: { totalElements: 5, totalPages: 1, size: 10, number: 0 },
+      content: [
+        contactInactive,
+        contactOne,
+        contactTwo,
+        contactThree,
+        contactFour,
+        contactFive,
+        contactSix,
+        contactSeven,
+        contactEight,
+        contactNine,
+      ],
+      page: { totalElements: 13, totalPages: 2, size: 10, number: 0 },
     }
 
     const pageOne: PagedModelPrisonerContactSummary = {
@@ -83,12 +95,13 @@ context('List contacts with Contacts Administrator or Authoriser roles', () => {
     const filtered = {
       relationshipType: { equalTo: 'S' },
       emergencyContactOrNextOfKin: { equalTo: 'true' },
+      active: { equalTo: 'true' },
     }
 
     cy.task('stubFilteredContactList', {
       prisonerNumber: prisoner.prisonerNumber,
       page: initialPage,
-      matchQueryParams: { active: { equalTo: 'true' } },
+      matchQueryParams: { active: { absent: true } },
     })
 
     cy.task('stubFilteredContactList', {
@@ -106,11 +119,22 @@ context('List contacts with Contacts Administrator or Authoriser roles', () => {
     cy.signIn({ startUrl: `/prisoner/${prisoner.prisonerNumber}/contacts/list` })
 
     Page.verifyOnPage(ListContactsPage, 'Test Prisoner')
-      .expectNames(['One, Contact', 'Two, Contact', 'Three, Contact', 'Four, Contact', 'Five, Contact'])
+      .expectNames([
+        'Inactive, Contact',
+        'One, Contact',
+        'Two, Contact',
+        'Three, Contact',
+        'Four, Contact',
+        'Five, Contact',
+        'Six, Contact',
+        'Seven, Contact',
+        'Eight, Contact',
+        'Nine, Contact',
+      ])
       .clickSocialContacts()
       .clickNextOfKin()
       .clickEmergencyContact()
-      .clickIncludeInactive()
+      .clickActiveOnly()
       .clickButtonTo('Apply filters', ListContactsPage, 'Test Prisoner')
       .expectNames([
         'One, Contact',
@@ -127,14 +151,14 @@ context('List contacts with Contacts Administrator or Authoriser roles', () => {
       .hasSocialContacts()
       .hasNextOfKin()
       .hasEmergencyContact()
-      .hasIncludeInactive()
+      .hasActiveOnly()
       .clickIndexedLinkTo(0, 'Page 2 of 2', ListContactsPage, 'Test Prisoner')
       .expectNames(['Eleven, Contact', 'Twelve, Contact'])
       .clickLinkTo('Contact name and person ID', ListContactsPage, 'Test Prisoner')
       .hasSocialContacts()
       .hasNextOfKin()
       .hasEmergencyContact()
-      .hasIncludeInactive()
+      .hasActiveOnly()
       .expectNames([
         'One, Contact',
         'Two, Contact',

--- a/integration_tests/e2e/listContactsAsReadOnlyUser.cy.ts
+++ b/integration_tests/e2e/listContactsAsReadOnlyUser.cy.ts
@@ -45,7 +45,7 @@ context('List contacts with a read only set of roles', () => {
     cy.task('stubFilteredContactList', {
       prisonerNumber: prisoner.prisonerNumber,
       page: initialPage,
-      matchQueryParams: { active: { equalTo: 'true' } },
+      matchQueryParams: { active: { absent: true } },
     })
 
     cy.signIn({ startUrl: `/prisoner/${prisoner.prisonerNumber}/contacts/list` })

--- a/integration_tests/mockApis/contactsApi.ts
+++ b/integration_tests/mockApis/contactsApi.ts
@@ -85,7 +85,7 @@ export default {
   stubFilteredContactList: (args: {
     prisonerNumber: string
     page: PagedModelPrisonerContactSummary
-    matchQueryParams: { [key: string]: { equalTo: string } }
+    matchQueryParams: { [key: string]: { equalTo?: string; absent?: boolean } }
   }): SuperAgentRequest => {
     const queryParameters = {
       ...args.matchQueryParams,

--- a/integration_tests/pages/listContacts.ts
+++ b/integration_tests/pages/listContacts.ts
@@ -68,6 +68,11 @@ export default class ListContactsPage extends Page {
     return this
   }
 
+  clickActiveOnly(): ListContactsPage {
+    this.activeOnly().check()
+    return this
+  }
+
   clickIncludeInactive(): ListContactsPage {
     this.includeInactive().check()
     return this
@@ -75,6 +80,11 @@ export default class ListContactsPage extends Page {
 
   hasIncludeInactive(): ListContactsPage {
     this.includeInactive().should('be.checked')
+    return this
+  }
+
+  hasActiveOnly(): ListContactsPage {
+    this.activeOnly().should('be.checked')
     return this
   }
 
@@ -87,4 +97,6 @@ export default class ListContactsPage extends Page {
   private nextOfKin = (): PageElement => cy.get('#flagsNextOfKin')
 
   private includeInactive = (): PageElement => cy.get(`.govuk-radios__input[value='ACTIVE_AND_INACTIVE']`)
+
+  private activeOnly = (): PageElement => cy.get(`.govuk-radios__input[value='ACTIVE_ONLY']`)
 }

--- a/server/@types/contactsApi/index.d.ts
+++ b/server/@types/contactsApi/index.d.ts
@@ -6824,7 +6824,7 @@ export interface components {
       isActive: boolean
     }
     PagedModelPrisonerContactSummary: {
-      content?: components['schemas']['c'][]
+      content?: components['schemas']['PrisonerContactSummary'][]
       page?: components['schemas']['PageMetadata']
     }
     /** @description Describes the details of a prisoner's contact */

--- a/server/routes/contacts/manage/list/listContactsController.test.ts
+++ b/server/routes/contacts/manage/list/listContactsController.test.ts
@@ -516,14 +516,14 @@ describe('listContactsController', () => {
       expect(response.status).toEqual(200)
       expect(contactsService.filterPrisonerContacts).toHaveBeenCalledWith(
         prisonerNumber,
-        { active: true },
+        {},
         { page: 0, size: 10, sort: expectDefaultSort },
         basicPrisonUser,
       )
     })
 
     it.each([
-      [`/prisoner/${prisonerNumber}/contacts/list`, { active: true }, { page: 0, size: 10, sort: expectDefaultSort }],
+      [`/prisoner/${prisonerNumber}/contacts/list`, {}, { page: 0, size: 10, sort: expectDefaultSort }],
       [
         `/prisoner/${prisonerNumber}/contacts/list?relationshipStatus=ACTIVE_ONLY&sort=name,asc&page=2`,
         { active: true },
@@ -651,7 +651,7 @@ describe('listContactsController', () => {
         },
       ],
     ])(
-      'should search using correct query parameters and defaults %s',
+      'should search using correct query parameters and defaults (%s)',
       async (url, expectedFilter, expectedPagination) => {
         // Given
         contactsService.filterPrisonerContacts.mockResolvedValue({
@@ -685,7 +685,7 @@ describe('listContactsController', () => {
 
       // Then
       const $ = cheerio.load(response.text)
-      expect($('input[type=radio]:checked').val()).toStrictEqual('ACTIVE_ONLY')
+      expect($('input[type=radio]:checked').val()).toStrictEqual('ACTIVE_AND_INACTIVE')
       expect($('#relationshipTypeSocial').attr('checked')).toBeUndefined()
       expect($('#relationshipTypeOfficial').attr('checked')).toBeUndefined()
       expect($('#flagsEmergencyContact').attr('checked')).toBeUndefined()
@@ -724,7 +724,9 @@ describe('listContactsController', () => {
         })
 
         // When
-        const response = await request(app).get(`/prisoner/${prisonerNumber}/contacts/list`)
+        const response = await request(app).get(
+          `/prisoner/${prisonerNumber}/contacts/list?relationshipStatus=ACTIVE_ONLY`,
+        )
 
         // Then
         const $ = cheerio.load(response.text)
@@ -762,7 +764,9 @@ describe('listContactsController', () => {
       })
 
       // When
-      const response = await request(app).get(`/prisoner/${prisonerNumber}/contacts/list`)
+      const response = await request(app).get(
+        `/prisoner/${prisonerNumber}/contacts/list?relationshipStatus=ACTIVE_ONLY`,
+      )
 
       // Then
       const $ = cheerio.load(response.text)
@@ -834,7 +838,9 @@ describe('listContactsController', () => {
           })
 
         // When
-        const response = await request(app).get(`/prisoner/${prisonerNumber}/contacts/list`)
+        const response = await request(app).get(
+          `/prisoner/${prisonerNumber}/contacts/list?relationshipStatus=ACTIVE_ONLY`,
+        )
 
         // Then
         const $ = cheerio.load(response.text)
@@ -911,7 +917,7 @@ describe('listContactsController', () => {
         expect(contactsService.filterPrisonerContacts).toHaveBeenNthCalledWith(
           1,
           prisonerNumber,
-          { active: true, emergencyContact: true },
+          { emergencyContact: true },
           { page: 0, size: 10, sort: expectDefaultSort },
           currentUser,
         )

--- a/server/routes/contacts/manage/list/listContactsController.ts
+++ b/server/routes/contacts/manage/list/listContactsController.ts
@@ -157,7 +157,7 @@ export default class ListContactsController implements PageHandler {
     const relationshipStatus =
       filter.relationshipStatus && allowedRelationshipStatus.includes(filter.relationshipStatus)
         ? filter.relationshipStatus
-        : 'ACTIVE_ONLY'
+        : 'ACTIVE_AND_INACTIVE'
     const relationshipType = this.toSafeArray(filter.relationshipType, allowedRelationshipTypes) as RelationshipType[]
     const flag = this.toSafeArray(filter.flag, allowedFlags) as Flag[]
     return { relationshipStatus, relationshipType, flag }


### PR DESCRIPTION
We recently discovered that a lot of the contacts added by prisons are inactive. This is due to how adding contacts from the visitor screen in NOMIS works and may not be intentional. It may be that the active flag is not really used in day-to-day operations.  Show all contacts by default to allow more research to take place.