### PR TITLE
PRC-649: Show border under phase banner

### DIFF
--- a/assets/scss/components/_header-bar.scss
+++ b/assets/scss/components/_header-bar.scss
@@ -139,8 +139,3 @@
     display: none;
   }
 }
-
-.govuk-phase-banner {
-  @include govuk-width-container;
-  border: none;
-}


### PR DESCRIPTION
For some reason there was a custom style imported from the template project that has a custom header for the phase banner.