### PR TITLE
PRC-619: Limit title width on contact list

### DIFF
--- a/server/views/pages/contacts/manage/listContacts.njk
+++ b/server/views/pages/contacts/manage/listContacts.njk
@@ -14,7 +14,7 @@
 
 {% block content %}
   <div class="moj-page-header-actions contact-record-banner-bottom">
-    <div class="moj-page-header-actions__title">
+    <div class="moj-page-header-actions__title govuk-!-width-two-thirds">
       {% if user | hasPermission('MANAGE_CONTACTS') %}
         <h1 class="govuk-heading-l">View and manage contacts linked to {{ prisonerDetails | formatNameFirstNameFirst(excludeMiddleNames = true) }}</h1>
       {% else %}


### PR DESCRIPTION
Prevent button from wrapping underneath of medium size screens. It still wraps on smaller screens.