### PR TITLE
PRC-772: Contact image signposting

### DIFF
--- a/server/routes/contacts/manage/contact-details/contactDetailsController.test.ts
+++ b/server/routes/contacts/manage/contact-details/contactDetailsController.test.ts
@@ -108,7 +108,7 @@ describe('GET /contacts/manage/:contactId/relationship/:prisonerContactId', () =
       expect($('[data-qa=back-link]')).toHaveLength(0)
     })
 
-    it('should render contact details page for living contact', async () => {
+    it('should render contact details page for deceased contact', async () => {
       prisonerSearchService.getByPrisonerNumber.mockResolvedValue(TestData.prisoner())
       contactsService.getContact.mockResolvedValue({
         ...TestData.contact(),
@@ -133,6 +133,22 @@ describe('GET /contacts/manage/:contactId/relationship/:prisonerContactId', () =
 
       expect($('[data-qa=cancel-button]')).toHaveLength(0)
       expect($('[data-qa=back-link]')).toHaveLength(0)
+    })
+
+    it('should show a warning about contact images', async () => {
+      // Given
+      prisonerSearchService.getByPrisonerNumber.mockResolvedValue(TestData.prisoner())
+      contactsService.getContact.mockResolvedValue(TestData.contact())
+
+      // When
+      const response = await request(app).get(`/prisoner/${prisonerNumber}/contacts/manage/1/relationship/99`)
+
+      // Then
+      const $ = cheerio.load(response.text)
+      const warningText = $('[data-qa=image-warning]').text().trim()
+      expect(response.status).toEqual(200)
+      expect(warningText).toMatch(/Contact images are not yet available in DPS/)
+      expect(warningText).toMatch(/You still need to use NOMIS to view and manage contact images./)
     })
 
     it('should not show comments when theres no comments', async () => {

--- a/server/views/pages/contacts/manage/contactDetails/details/contactDetailsTab.njk
+++ b/server/views/pages/contacts/manage/contactDetails/details/contactDetailsTab.njk
@@ -4,6 +4,7 @@
 {% from "partials/contactDetails/relationshipToPrisonerCard.njk" import relationshipToPrisonerCard %}
 {% from "partials/contactDetails/identityDocumentationCard.njk" import identityDocumentationCard %}
 {% from "partials/contactDetails/additionalInformationCard.njk" import additionalInformationCard %}
+{% from "moj/components/alert/macro.njk" import mojAlert %}
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
@@ -21,6 +22,15 @@
 </div>
 <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
+
+      {{ mojAlert({
+        variant: "warning",
+        title: "Contact images are not yet available in DPS",
+        showTitleAsHeading: true,
+        dismissible: false,
+        html: 'You still need to use NOMIS to view and manage contact images.',
+        attributes: { "data-qa": "image-warning" }
+      }) }}
 
       {{  personalInformationCard({
         prisonerNumber: prisonerNumber,


### PR DESCRIPTION
Add a warning that contact images are not supported in DPS and you need to look in NOMIS to see them.