### PR TITLE
PRC-781: Telemetry on soft validation of dupes

### DIFF
--- a/server/data/index.ts
+++ b/server/data/index.ts
@@ -8,7 +8,7 @@ import applicationInfoSupplier from '../applicationInfo'
 
 const applicationInfo = applicationInfoSupplier()
 initialiseAppInsights()
-buildAppInsightsClient(applicationInfo)
+const applicationInsightsClient = buildAppInsightsClient(applicationInfo)
 
 import config from '../config'
 import HmppsAuditClient from './hmppsAuditClient'
@@ -24,6 +24,7 @@ export const dataAccess = () => ({
   contactsApiClient: new ContactsApiClient(),
   prisonApiClient: new PrisonApiClient(),
   organisationsApiClient: new OrganisationsApiClient(),
+  applicationInsightsClient,
 })
 
 export { HmppsAuditClient, PrisonerSearchApiClient, ContactsApiClient, PrisonApiClient, OrganisationsApiClient }

--- a/server/routes/contacts/add/addContactRoutes.ts
+++ b/server/routes/contacts/add/addContactRoutes.ts
@@ -71,6 +71,7 @@ import AddContactHandleDuplicateController from './handle-duplicate/addContactHa
 import PossibleExistingRecordsController from './possible-existing-records/possibleExistingRecordsController'
 import PossibleExistingRecordMatchController from './possible-existing-record-match/possibleExistingRecordMatchController'
 import { possibleExistingRecordMatchSchema } from './possible-existing-record-match/possibleExistingRecordMatchSchema'
+import TelemetryService from '../../../services/telemetryService'
 
 const AddContactRoutes = (
   auditService: AuditService,
@@ -80,6 +81,7 @@ const AddContactRoutes = (
   restrictionsService: RestrictionsService,
   prisonerAddressService: PrisonerAddressService,
   organisationsService: OrganisationsService,
+  telemetryService: TelemetryService,
 ) => {
   const router = Router({ mergeParams: true })
   const { get, post } = routerMethods(router, auditService)
@@ -175,13 +177,18 @@ const AddContactRoutes = (
 
   journeyRoute({
     path: '/prisoner/:prisonerNumber/contacts/create/possible-existing-records/:journeyId',
-    controller: new PossibleExistingRecordsController(contactsService),
+    controller: new PossibleExistingRecordsController(contactsService, telemetryService),
     noValidation: true,
   })
 
   journeyRoute({
     path: '/prisoner/:prisonerNumber/contacts/create/possible-existing-record-match/:matchingContactId/:journeyId',
-    controller: new PossibleExistingRecordMatchController(contactsService, restrictionsService, referenceDataService),
+    controller: new PossibleExistingRecordMatchController(
+      contactsService,
+      restrictionsService,
+      referenceDataService,
+      telemetryService,
+    ),
     schema: possibleExistingRecordMatchSchema,
   })
 

--- a/server/routes/contacts/add/possible-existing-records/possibleExistingRecordsController.test.ts
+++ b/server/routes/contacts/add/possible-existing-records/possibleExistingRecordsController.test.ts
@@ -15,11 +15,13 @@ jest.mock('../../../../services/auditService')
 jest.mock('../../../../services/referenceDataService')
 jest.mock('../../../../services/prisonerSearchService')
 jest.mock('../../../../services/contactsService')
+jest.mock('../../../../services/telemetryService')
 
 const auditService = MockedService.AuditService()
 const referenceDataService = MockedService.ReferenceDataService()
 const prisonerSearchService = MockedService.PrisonerSearchService()
 const contactsService = MockedService.ContactsService()
+const telemetryService = MockedService.TelemetryService()
 
 let app: Express
 let session: Partial<SessionData>
@@ -44,6 +46,7 @@ beforeEach(() => {
       referenceDataService,
       prisonerSearchService,
       contactsService,
+      telemetryService,
     },
     userSupplier: () => currentUser,
     sessionReceiver: (receivedSession: Partial<SessionData>) => {
@@ -115,6 +118,11 @@ describe('GET /prisoner/:prisonerNumber/contacts/create/possible-existing-record
     expect($('[data-qa=add-contact-654321-link]').first().attr('href')).toStrictEqual(
       `/prisoner/${prisonerNumber}/contacts/create/possible-existing-record-match/654321/${journeyId}`,
     )
+    expect(telemetryService.trackEvent).toHaveBeenCalledWith('POSSIBLE_EXISTING_RECORDS_FOUND', adminUser, {
+      journeyId,
+      numberOfMatches: 2,
+      prisonerNumber,
+    })
   })
 
   it('should render possible existing records if there was a dob and only one match', async () => {
@@ -184,6 +192,7 @@ describe('GET /prisoner/:prisonerNumber/contacts/create/possible-existing-record
     expect(matchCounts.first().text().trim()).toStrictEqual('Showing 1 to 2 of 2 results')
 
     expect(contactsService.searchContact).not.toHaveBeenCalled()
+    expect(telemetryService.trackEvent).not.toHaveBeenCalled()
   })
 
   it('should not search again if the possible matches exist already even if they are empty', async () => {

--- a/server/routes/index.ts
+++ b/server/routes/index.ts
@@ -16,6 +16,7 @@ export default function routes({
   restrictionsService,
   prisonerAddressService,
   organisationsService,
+  telemetryService,
 }: Services): Router {
   const router = Router({ mergeParams: true })
 
@@ -29,6 +30,7 @@ export default function routes({
       restrictionsService,
       prisonerAddressService,
       organisationsService,
+      telemetryService,
     ),
   )
   router.use(

--- a/server/services/index.ts
+++ b/server/services/index.ts
@@ -7,6 +7,7 @@ import ReferenceDataService from './referenceDataService'
 import RestrictionsService from './restrictionsService'
 import PrisonerAddressService from './prisonerAddressService'
 import OrganisationsService from './organisationsService'
+import TelemetryService from './telemetryService'
 
 export const services = () => {
   const {
@@ -16,11 +17,13 @@ export const services = () => {
     contactsApiClient,
     prisonApiClient,
     organisationsApiClient,
+    applicationInsightsClient,
   } = dataAccess()
 
   const auditService = new AuditService(hmppsAuditClient)
+  const telemetryService = new TelemetryService(applicationInsightsClient)
   const prisonerSearchService = new PrisonerSearchService(prisonerSearchApiClient)
-  const contactsService = new ContactsService(contactsApiClient, auditService)
+  const contactsService = new ContactsService(contactsApiClient, auditService, telemetryService)
   const prisonerImageService = new PrisonerImageService(prisonApiClient)
   const referenceDataService = new ReferenceDataService(contactsApiClient)
   const restrictionsService = new RestrictionsService(contactsApiClient, auditService)
@@ -37,6 +40,7 @@ export const services = () => {
     restrictionsService,
     prisonerAddressService,
     organisationsService,
+    telemetryService,
   }
 }
 

--- a/server/services/telemetryService.test.ts
+++ b/server/services/telemetryService.test.ts
@@ -1,0 +1,52 @@
+import { TelemetryClient } from 'applicationinsights'
+import TelemetryService from './telemetryService'
+import { HmppsUser } from '../interfaces/hmppsUser'
+
+jest.mock('applicationinsights')
+
+describe('telemetryService', () => {
+  const telemetryClient = new TelemetryClient() as jest.Mocked<TelemetryClient>
+  const telemetryService = new TelemetryService(telemetryClient)
+  const user: HmppsUser = {
+    name: 'User',
+    userId: 'user_id',
+    token: 'token',
+    username: 'username',
+    displayName: 'User',
+    authSource: 'nomis',
+    staffId: 4567,
+    userRoles: ['CONTACTS_ADMINISTRATOR'],
+    activeCaseLoad: {
+      caseLoadId: 'BXI',
+      currentlyActive: true,
+      description: '',
+      type: '',
+      caseloadFunction: '',
+    },
+  }
+
+  it('should send event with all properties', () => {
+    telemetryService.trackEvent('FOO', user, { foo: 'bar', x: 0, y: null })
+
+    expect(telemetryClient.trackEvent).toHaveBeenCalledWith({
+      name: 'FOO',
+      properties: {
+        foo: 'bar',
+        x: 0,
+        y: null,
+        username: 'username',
+        activeCaseLoadId: 'BXI',
+      },
+    })
+  })
+
+  it('should not blow up if the telemetry service fails', () => {
+    telemetryClient.trackEvent.mockImplementation(() => {
+      throw Error('Bang')
+    })
+
+    telemetryService.trackEvent('FOO', user, { foo: 'bar', x: 0, y: null })
+
+    expect(telemetryClient.trackEvent).toHaveBeenCalled()
+  })
+})

--- a/server/services/telemetryService.ts
+++ b/server/services/telemetryService.ts
@@ -1,0 +1,25 @@
+import { TelemetryClient } from 'applicationinsights'
+import { HmppsUser } from '../interfaces/hmppsUser'
+import logger from '../../logger'
+
+export default class TelemetryService {
+  // nullable in environments without app insights
+  constructor(private readonly applicationInsightsClient: TelemetryClient | null) {}
+
+  trackEvent(name: string, user: HmppsUser, properties?: { [key: string]: string | number | null | undefined }) {
+    if (this.applicationInsightsClient) {
+      try {
+        this.applicationInsightsClient.trackEvent({
+          name,
+          properties: {
+            ...properties,
+            username: user.username,
+            activeCaseLoadId: user.activeCaseLoad?.caseLoadId,
+          },
+        })
+      } catch (error) {
+        logger.error('Error sending telemetry event, ', error)
+      }
+    }
+  }
+}

--- a/server/testutils/mockedServices.ts
+++ b/server/testutils/mockedServices.ts
@@ -4,6 +4,7 @@ import PrisonerSearchService from '../services/prisonerSearchService'
 import RestrictionsService from '../services/restrictionsService'
 import ContactsService from '../services/contactsService'
 import OrganisationsService from '../services/organisationsService'
+import TelemetryService from '../services/telemetryService'
 
 export const MockedService = {
   // @ts-expect-error passing null param into mock service
@@ -18,4 +19,5 @@ export const MockedService = {
   ContactsService: () => new ContactsService(null) as jest.Mocked<ContactsService>,
   // @ts-expect-error passing null param into mock service
   OrganisationsService: () => new OrganisationsService(null) as jest.Mocked<OrganisationsService>,
+  TelemetryService: () => new TelemetryService(null) as jest.Mocked<TelemetryService>,
 }


### PR DESCRIPTION
Added a telemetry service and some custom events for app insights that will give us a clue about who has seen the new page and what they ended up doing.