### PR TITLE
PRC-787: Dupe protection screen fixes

### DIFF
--- a/assets/scss/local.scss
+++ b/assets/scss/local.scss
@@ -141,22 +141,17 @@ div.moj-action-bar__filter::after { content: none !important; }
 
 #prisoner-contact-list {
   tr {
-    // make the name and person id as small as possible
-    th:first-child {
-      width: 5%;
-    }
-
-    // and ensure DOB doesn't wrap
+    // ensure DOB doesn't wrap
     th:nth-child(2) {
       min-width: 130px;
     }
 
-    // and make the restrictions column no wider than non-contact visit tag
-    th:nth-child(4) {
-      max-width: 215px;
+    // allow breaking of words in long address lines
+    td:nth-child(4) {
+      word-break: break-word;
     }
 
-    // and make the restrictions column no wider than non-contact visit tag
+    // make the restrictions column no wider than non-contact visit tag
     th:nth-child(6) {
       max-width: 185px;
     }

--- a/server/routes/contacts/add/handle-duplicate/addContactHandleDuplicateController.test.ts
+++ b/server/routes/contacts/add/handle-duplicate/addContactHandleDuplicateController.test.ts
@@ -160,7 +160,7 @@ describe(`GET /prisoner/:prisonerNumber/contacts/add/handle-duplicate/:journeyId
     expect($('[data-qa=multiple-relationships-warning]')).toHaveLength(1)
   })
 
-  it('hide multi relationship warning if there is only one existing relationship', async () => {
+  it('hide multi relationship warning if there is only one existing relationship and show different go to dupe label', async () => {
     // Given
     existingJourney.relationship!.relationshipToPrisoner = 'BRO'
     contactsService.getAllSummariesForPrisonerAndContact.mockResolvedValue([
@@ -181,6 +181,9 @@ describe(`GET /prisoner/:prisonerNumber/contacts/add/handle-duplicate/:journeyId
 
     const $ = cheerio.load(response.text)
     expect($('[data-qa=multiple-relationships-warning]')).toHaveLength(0)
+    expect($('#duplicateActionGoToDupe').next().text().trim()).toStrictEqual(
+      `Go to the existing record of the relationship`,
+    )
   })
 
   it.each([

--- a/server/views/pages/contacts/manage/contactDetails/relationship/handleDuplicateRelationship.njk
+++ b/server/views/pages/contacts/manage/contactDetails/relationship/handleDuplicateRelationship.njk
@@ -43,6 +43,11 @@
     <div class="govuk-grid-column-two-thirds">
       <form method='POST'>
         <input type="hidden" name="_csrf" value="{{ csrfToken }}" />
+        {% if existingRelationships.length and existingRelationships.length > 1 %}
+          {% set goToDupeLabel = 'Go to the existing record of the ‘' + relationshipTypeDescription + '’ relationship' %}
+        {% else %}
+          {% set goToDupeLabel = 'Go to the existing record of the relationship' %}
+        {% endif %}
         {{ govukRadios({
           name: "duplicateAction",
           errorMessage: validationErrors | findError('duplicateAction'),
@@ -57,7 +62,7 @@
           items: [
             {
               value: 'GO_TO_DUPE',
-              text: 'Go to the existing record of the ‘' + relationshipTypeDescription + '’ relationship',
+              text: goToDupeLabel,
               id: 'duplicateActionGoToDupe'
             },
             {


### PR DESCRIPTION
Now shows different label for continuing to the duplicate record when there is only one existing relationship.

Also further styling tweaks to the prisoner contact summary list.