### PR TITLE
PRC-787: Existing records alert on match

### DIFF
--- a/integration_tests/e2e/addExistingContactAsAdmin.cy.ts
+++ b/integration_tests/e2e/addExistingContactAsAdmin.cy.ts
@@ -70,6 +70,11 @@ context('Add existing contact as admin user so cannot set visit approval', () =>
       middleNames: '',
       dateOfBirth: '',
     })
+    cy.task('stubAllSummariesForAPrisonerAndContact', {
+      prisonerNumber,
+      contactId,
+      items: [],
+    })
 
     cy.signIn({ startUrl: `/prisoner/${prisonerNumber}/contacts/list` })
 

--- a/integration_tests/e2e/addExistingContactAsAuthoriser.cy.ts
+++ b/integration_tests/e2e/addExistingContactAsAuthoriser.cy.ts
@@ -71,6 +71,12 @@ context('Add existing contact as authorising user so can set visit approval', ()
       dateOfBirth: '',
     })
 
+    cy.task('stubAllSummariesForAPrisonerAndContact', {
+      prisonerNumber,
+      contactId,
+      items: [],
+    })
+
     cy.signIn({ startUrl: `/prisoner/${prisonerNumber}/contacts/list` })
 
     Page.verifyOnPage(ListContactsPage, 'John Smith') //

--- a/integration_tests/e2e/addExistingContactCheckAnswers.cy.ts
+++ b/integration_tests/e2e/addExistingContactCheckAnswers.cy.ts
@@ -63,6 +63,12 @@ context('Add existing contact check answers including authoriser fields', () => 
       dateOfBirth: '1990-01-14',
     })
 
+    cy.task('stubAllSummariesForAPrisonerAndContact', {
+      prisonerNumber,
+      contactId,
+      items: [],
+    })
+
     cy.signIn({ startUrl: `/prisoner/${prisonerNumber}/contacts/list` })
 
     Page.verifyOnPage(ListContactsPage, 'John Smith') //

--- a/integration_tests/e2e/addExistingContactCheckAnswersChangeRelationship.cy.ts
+++ b/integration_tests/e2e/addExistingContactCheckAnswersChangeRelationship.cy.ts
@@ -62,6 +62,12 @@ context('Add Existing Contact Check Answers', () => {
       dateOfBirth: '1990-01-14',
     })
 
+    cy.task('stubAllSummariesForAPrisonerAndContact', {
+      prisonerNumber,
+      contactId,
+      items: [],
+    })
+
     cy.signIn({ startUrl: `/prisoner/${prisonerNumber}/contacts/list` })
 
     Page.verifyOnPage(ListContactsPage, 'John Smith') //

--- a/integration_tests/e2e/addExistingContactReviewExistingRelationships.cy.ts
+++ b/integration_tests/e2e/addExistingContactReviewExistingRelationships.cy.ts
@@ -170,6 +170,45 @@ context('Add existing contact when search reveals some existing relationships', 
     )
   })
 
+  it('Can review the existing contact records from the match screen and continue to add a contact', () => {
+    Page.verifyOnPage(SearchContactPage) //
+      .enterLastName('Contact')
+      .clickSearchButton()
+
+    Page.verifyOnPage(SearchContactPage) //
+      .clickLinkTo('Check if this is the correct contact', ContactMatchPage, 'Existing Contact', 'John Smith')
+      .clickLinkTo('View existing record', ReviewExistingRelationshipsPage)
+      .clickLinkTo('Back to contact search', SearchContactPage)
+      .clickLinkTo('Check if this is the correct contact', ContactMatchPage, 'Existing Contact', 'John Smith')
+      .selectIsTheRightPersonYesRadio()
+      .continueTo(SelectRelationshipTypePage, 'Existing Contact', 'John Smith')
+      .selectRelationshipType('S')
+      .continueTo(SelectRelationshipPage, 'Existing Contact', 'John Smith')
+      .selectRelationship('MOT')
+      .continueTo(SelectEmergencyContactOrNextOfKinPage, 'Existing Contact', 'John Smith', true, 'John Smith', true) //
+      .continueTo(RelationshipCommentsPage, 'Existing Contact', 'John Smith', true) //
+      .continueTo(LinkExistingContactCYAPage)
+      .continueTo(AddContactSuccessPage)
+
+    cy.verifyLastAPICall(
+      {
+        method: 'POST',
+        urlPath: `/prisoner-contact`,
+      },
+      {
+        contactId,
+        relationship: {
+          prisonerNumber: 'A1234BC',
+          relationshipTypeCode: 'S',
+          relationshipToPrisonerCode: 'MOT',
+          isNextOfKin: false,
+          isEmergencyContact: false,
+          isApprovedVisitor: false,
+        },
+      },
+    )
+  })
+
   it('Should be able to go back to the contact list', () => {
     Page.verifyOnPage(SearchContactPage) //
       .enterLastName('Contact')
@@ -188,5 +227,16 @@ context('Add existing contact when search reveals some existing relationships', 
     Page.verifyOnPage(SearchContactPage) //
       .clickLinkTo('View existing record', ReviewExistingRelationshipsPage)
       .clickLinkTo('Contact, Existing', ManageContactDetailsPage, 'Existing Contact')
+  })
+
+  it('Can review the existing contact records from the match screen and then continue back to the contact list', () => {
+    Page.verifyOnPage(SearchContactPage) //
+      .enterLastName('Contact')
+      .clickSearchButton()
+
+    Page.verifyOnPage(SearchContactPage) //
+      .clickLinkTo('Check if this is the correct contact', ContactMatchPage, 'Existing Contact', 'John Smith')
+      .selectIsTheRightPersonNoGoToContactList()
+      .continueTo(ListContactsPage, 'John Smith')
   })
 })

--- a/integration_tests/e2e/contactConfirmationPage.cy.ts
+++ b/integration_tests/e2e/contactConfirmationPage.cy.ts
@@ -52,6 +52,11 @@ context('Contact confirmation', () => {
       middleNames: '',
       dateOfBirth: '',
     })
+    cy.task('stubAllSummariesForAPrisonerAndContact', {
+      prisonerNumber,
+      contactId,
+      items: [],
+    })
 
     cy.signIn({ startUrl: `/prisoner/${prisonerNumber}/contacts/search/${journeyId}` })
 

--- a/integration_tests/pages/contactMatchPage.ts
+++ b/integration_tests/pages/contactMatchPage.ts
@@ -28,6 +28,12 @@ export default class ContactMatchPage extends Page {
     return this
   }
 
+  selectIsTheRightPersonNoGoToContactList(): ContactMatchPage {
+    // this replaces the no create new button when there are existing matches
+    this.checkRadio(2).check()
+    return this
+  }
+
   clickRestrictionsTab() {
     this.getRestrictionsTab().should('contain.text', 'Restrictions (1)').click()
     return this

--- a/server/@types/journeys/index.d.ts
+++ b/server/@types/journeys/index.d.ts
@@ -15,7 +15,7 @@ export interface AddContactJourney {
         sort?: string
       }
     | undefined
-  isContactMatched?: 'YES' | 'NO_SEARCH_AGAIN' | 'NO_CREATE_NEW'
+  isContactMatched?: 'YES' | 'NO_SEARCH_AGAIN' | 'NO_CREATE_NEW' | 'NO_GO_BACK_TO_CONTACT_LIST'
   isPossibleExistingRecordMatched?: 'YES' | 'NO_GO_BACK_TO_POSSIBLE_EXISTING_RECORDS' | 'NO_CONTINUE_ADDING_CONTACT'
   names?: ContactNames
   dateOfBirth?: DateOfBirth

--- a/server/routes/contacts/add/contact-match/contactMatchSchema.ts
+++ b/server/routes/contacts/add/contact-match/contactMatchSchema.ts
@@ -4,7 +4,7 @@ import { createSchema } from '../../../../middleware/validationMiddleware'
 const SELECT_IS_THE_RIGHT_PERSON_MESSAGE = 'Select if this is the correct contact or not'
 
 export const contactMatchSchema = createSchema({
-  isContactMatched: z.enum(['YES', 'NO_SEARCH_AGAIN', 'NO_CREATE_NEW'], {
+  isContactMatched: z.enum(['YES', 'NO_SEARCH_AGAIN', 'NO_CREATE_NEW', 'NO_GO_BACK_TO_CONTACT_LIST'], {
     message: SELECT_IS_THE_RIGHT_PERSON_MESSAGE,
   }),
 })

--- a/server/views/pages/contacts/add/existing/match.njk
+++ b/server/views/pages/contacts/add/existing/match.njk
@@ -2,12 +2,28 @@
 {% from "govuk/components/radios/macro.njk" import govukRadios %}
 {% from "govuk/components/button/macro.njk" import govukButton %}
 {% from "partials/matchContactContent.njk" import matchContactContent %}
+{% from "moj/components/alert/macro.njk" import mojAlert %}
 {% set pageTitle = "Check and confirm if you want to link a contact to a prisoner - Manage contacts - DPS" %}
 {% set title = 'Check and confirm if you want to link contact ' + (contact | formatNameFirstNameFirst ) +' to prisoner ' + (prisonerDetails | formatNameFirstNameFirst(excludeMiddleNames = true)) %}
 
 {% block content %}
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds govuk-!-margin-bottom-6">
+      <span class="govuk-caption-l">Link a contact to a prisoner</span>
+      <h1 class="govuk-heading-l" data-qa="confim-title-value-top">{{ title }}</h1>
+      {% if existingRelationshipSummaries and existingRelationshipSummaries.length > 0 %}
+        {% set reviewUrl = '/prisoner/' + prisonerDetails.prisonerNumber + '/contacts/create/review-existing-relationships/' + contact.id + '/' + journey.id %}
+        {{ mojAlert({
+          variant: "information",
+          title: (contact | formatNameFirstNameFirst) + ' (' + contact.id + ') is already linked to the prisoner',
+          dismissible: false,
+          html: (contact | formatNameFirstNameFirst) + ' (' + contact.id + ') is already linked to prisoner ' + (prisonerDetails | formatNameFirstNameFirst(excludeMiddleNames = true)) + '. <br/><a href="' + reviewUrl + '" class="govuk-link" data-qa="view-existing-record-link">View existing record' +  ('s' if existingRelationshipSummaries.length > 1) + '</a>'
+        }) }}
+      {% endif %}
+      <p class="govuk-body">If this is the correct contact record but their information needs to be updated, you can make updates after you link the record to the prisoner. </p>
+    </div>
+  </div>
   {{ matchContactContent({
-    title: title,
     contact: contact,
     prisonerDetails: prisonerDetails,
     globalRestrictions: globalRestrictions,
@@ -20,11 +36,16 @@
     <div class="govuk-grid-column-two-thirds">
       <form method='POST'>
         <input type="hidden" name="_csrf" value="{{ csrfToken }}" />
+        {% if existingRelationshipSummaries and existingRelationshipSummaries.length > 0 %}
+          {% set actionQuestion = 'Do you want to create another relationship link between this contact and ' + (prisonerDetails | formatNameFirstNameFirst(excludeMiddleNames = true)) + '?' %}
+        {% else %}
+          {% set actionQuestion = 'Is this the correct contact to link to ' + (prisonerDetails | formatNameFirstNameFirst(excludeMiddleNames = true)) + '?'%}
+        {% endif %}
         {{ govukRadios({
           name: "isContactMatched",
           fieldset: {
             legend: {
-              text: 'Is this the correct contact to link to ' + (prisonerDetails | formatNameFirstNameFirst(excludeMiddleNames = true)) + '?',
+              text: actionQuestion,
               isPageHeading: false,
               classes: "govuk-fieldset__legend--m"
             },
@@ -34,18 +55,27 @@
             {
               value: "YES",
               text: "Yes",
-              checked: journey.isContactMatched === 'YES'
+              checked: journey.isContactMatched === 'YES',
+              id: 'contactMatchActionYes'
             },
             {
               value: "NO_SEARCH_AGAIN",
               text: "No, take me back to contact search to try again",
-              checked: journey.isContactMatched === 'NO_SEARCH_AGAIN'
+              checked: journey.isContactMatched === 'NO_SEARCH_AGAIN',
+              id: 'contactMatchActionNoSearchAgain'
             },
             {
               value: "NO_CREATE_NEW",
               text: "No, I need to add a new contact onto the system",
-              checked: journey.isContactMatched === 'NO_CREATE_NEW'
-            }
+              checked: journey.isContactMatched === 'NO_CREATE_NEW',
+              id: 'contactMatchActionNoCreateNew'
+            } if existingRelationshipSummaries and existingRelationshipSummaries.length == 0,
+            {
+              value: "NO_GO_BACK_TO_CONTACT_LIST",
+              text: "No, take me back to the prisoner’s contact list without making any changes",
+              checked: journey.isContactMatched === 'NO_GO_BACK_TO_CONTACT_LIST',
+              id: 'contactMatchActionNoGoToContactList'
+            } if existingRelationshipSummaries and existingRelationshipSummaries.length > 0
           ],
           errorMessage: validationErrors | findError('isContactMatched')
         }) }}

--- a/server/views/pages/contacts/add/existing/matchPossibleExistingRecord.njk
+++ b/server/views/pages/contacts/add/existing/matchPossibleExistingRecord.njk
@@ -6,8 +6,14 @@
 {% set title = 'Check and confirm if you want to link contact ' + (contact | formatNameFirstNameFirst ) +' to prisoner ' + (prisonerDetails | formatNameFirstNameFirst(excludeMiddleNames = true)) %}
 
 {% block content %}
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds govuk-!-margin-bottom-6">
+      <span class="govuk-caption-l">Link a contact to a prisoner</span>
+      <h1 class="govuk-heading-l" data-qa="confim-title-value-top">{{ title }}</h1>
+      <p class="govuk-body">If this is the correct contact record but their information needs to be updated, you can make updates after you link the record to the prisoner. </p>
+    </div>
+  </div>
   {{ matchContactContent({
-    title: title,
     contact: contact,
     prisonerDetails: prisonerDetails,
     globalRestrictions: globalRestrictions,

--- a/server/views/pages/contacts/manage/contactSearch.njk
+++ b/server/views/pages/contacts/manage/contactSearch.njk
@@ -168,14 +168,13 @@
                 }
               ]), contactRows) %}
               {% if hasExistingRelationships %}
-                {% set title = (contact | formatNameFirstNameFirst) + ' (' + contact.id + ') is already linked to prisoner' %}
                 {% set reviewUrl = '/prisoner/' + prisonerDetails.prisonerNumber + '/contacts/create/review-existing-relationships/' + contact.id + '/' + journey.id %}
                 {% set alertHtml %}
                   {{ mojAlert({
                     variant: "information",
-                    title: title,
+                    title: (contact | formatNameFirstNameFirst) + ' (' + contact.id + ') is already linked to the prisoner',
                     dismissible: false,
-                    html: title + ' ' + (prisonerDetails | formatNameFirstNameFirst(excludeMiddleNames = true)) + '. <br/><a href="' + reviewUrl + '" class="govuk-link">View existing record' +  ('s' if contact.existingRelationships.length > 1) + '</a>',
+                    html: (contact | formatNameFirstNameFirst) + ' (' + contact.id + ') is already linked to prisoner ' + (prisonerDetails | formatNameFirstNameFirst(excludeMiddleNames = true)) + '. <br/><a href="' + reviewUrl + '" class="govuk-link">View existing record' +  ('s' if contact.existingRelationships.length > 1) + '</a>',
                     classes: 'govuk-!-margin-bottom-0'
                   }) }}
                 {% endset %}

--- a/server/views/partials/matchContactContent.njk
+++ b/server/views/partials/matchContactContent.njk
@@ -12,7 +12,6 @@
 
 {% macro matchContactContent(opts) %}
 
-  {% set title = opts.title %}
   {% set contact = opts.contact %}
   {% set prisonerDetails = opts.prisonerDetails %}
   {% set globalRestrictions = opts.globalRestrictions %}
@@ -21,13 +20,6 @@
   {% set phoneTypeOrderDictionary = opts.phoneTypeOrderDictionar %}
   {% set paginationParams = opts.paginationParams %}
 
-  <div class="govuk-grid-row">
-    <div class="govuk-grid-column-two-thirds govuk-!-margin-bottom-6">
-      <span class="govuk-caption-l">Link a contact to a prisoner</span>
-      <h1 class="govuk-heading-l" data-qa="confim-title-value-top">{{ title }}</h1>
-      <p class="govuk-body">If this is the correct contact record but their information needs to be updated, you can make updates after you link the record to the prisoner. </p>
-    </div>
-  </div>
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-full">
       <div class="govuk-tabs" data-module="govuk-tabs">


### PR DESCRIPTION
Show the existing records alert on match screen.

Also change the option to create a new contact into one that returns to the prisoner contact list only if there are existing records.