### PR TITLE
Hide delete relationship link

### DIFF
--- a/integration_tests/e2e/deleteRelationship.cy.ts
+++ b/integration_tests/e2e/deleteRelationship.cy.ts
@@ -82,7 +82,7 @@ context('Delete Relationship', () => {
     })
   })
 
-  it('Can delete if the relationship has no restrictions', () => {
+  xit('Can delete if the relationship has no restrictions', () => {
     cy.task('stubGetPrisonerContactRestrictions', {
       prisonerContactId,
       response: {
@@ -115,7 +115,7 @@ context('Delete Relationship', () => {
     )
   })
 
-  it('Cannot delete the relationship if it has relationship restrictions, return to contact list', () => {
+  xit('Cannot delete the relationship if it has relationship restrictions, return to contact list', () => {
     cy.task('stubGetPrisonerContactRestrictions', {
       prisonerContactId,
       response: {
@@ -148,7 +148,7 @@ context('Delete Relationship', () => {
     )
   })
 
-  it('Cannot delete the relationship if it has relationship restrictions, return to contact record', () => {
+  xit('Cannot delete the relationship if it has relationship restrictions, return to contact record', () => {
     cy.task('stubGetPrisonerContactRestrictions', {
       prisonerContactId,
       response: {
@@ -181,7 +181,7 @@ context('Delete Relationship', () => {
     )
   })
 
-  it('Back link goes back to which ever page you came from', () => {
+  xit('Back link goes back to which ever page you came from', () => {
     cy.task('stubGetPrisonerContactRestrictions', {
       prisonerContactId,
       response: {
@@ -213,7 +213,7 @@ context('Delete Relationship', () => {
       .backTo(EditContactDetailsPage, 'First Middle Names Last')
   })
 
-  it('Cancel goes back to manage contact', () => {
+  xit('Cancel goes back to manage contact', () => {
     cy.task('stubGetPrisonerContactRestrictions', {
       prisonerContactId,
       response: {

--- a/server/routes/contacts/manage/contact-details/contactDetailsController.test.ts
+++ b/server/routes/contacts/manage/contact-details/contactDetailsController.test.ts
@@ -604,9 +604,9 @@ describe('GET /contacts/manage/:contactId/relationship/:prisonerContactId', () =
         ).toStrictEqual('Some comments')
         expect($('.next-of-kin-tag')).toHaveLength(1)
         expect($('.emergency-contact-tag')).toHaveLength(1)
-        expect($('a:contains("Delete relationship")').attr('href')).toStrictEqual(
-          `/prisoner/${prisonerNumber}/contacts/manage/22/relationship/99/delete?backTo=contact-details`,
-        )
+        // expect($('a:contains("Delete relationship")').attr('href')).toStrictEqual(
+        //   `/prisoner/${prisonerNumber}/contacts/manage/22/relationship/99/delete?backTo=contact-details`,
+        // )
       })
 
       it('should render without optional relationship details', async () => {

--- a/server/routes/contacts/manage/edit-contact-details/editContactDetailsController.test.ts
+++ b/server/routes/contacts/manage/edit-contact-details/editContactDetailsController.test.ts
@@ -302,9 +302,9 @@ describe('GET /contacts/manage/:contactId/relationship/:prisonerContactId/edit-c
         '/prisoner/A1234BC/contacts/manage/22/relationship/99/relationship-comments',
         'Change the comments on the relationship (Relationship to prisoner Incarcerated Individual)',
       )
-      expect($('a:contains("Delete relationship")').attr('href')).toStrictEqual(
-        `/prisoner/${prisonerNumber}/contacts/manage/22/relationship/99/delete?backTo=edit-contact-details`,
-      )
+      // expect($('a:contains("Delete relationship")').attr('href')).toStrictEqual(
+      //   `/prisoner/${prisonerNumber}/contacts/manage/22/relationship/99/delete?backTo=edit-contact-details`,
+      // )
     })
 
     it('should render without optional relationship details as authorising user', async () => {

--- a/server/views/partials/contactDetails/relationshipToPrisonerCard.njk
+++ b/server/views/partials/contactDetails/relationshipToPrisonerCard.njk
@@ -19,16 +19,6 @@
       classes: 'summary-card-wider-key-column',
       title: {
         text: 'Relationship to prisoner ' + prisonerDetails | formatNameFirstNameFirst(excludeMiddleNames = true)
-      },
-      actions: {
-        items: [
-          {
-            href: "/prisoner/" + prisonerDetails.prisonerNumber + "/contacts/manage/" + contact.id + "/relationship/"  + relationship.prisonerContactId + "/delete?backTo=" + ('edit-contact-details' if showActions else 'contact-details'),
-            text: "Delete relationship",
-            attributes: {"data-qa": "delete-relationship-link"},
-            classes: "govuk-link--no-visited-state"
-          }
-        ]
       }
     },
     rows: [


### PR DESCRIPTION
Sync from DPS to NOMIS is not currently working so hiding the link until it can be resolved.