### PR TITLE
PRC-821 : add a hint text and guidance when changing the contact relationship status,

### DIFF
--- a/integration_tests/e2e/manageRelationshipStatus.cy.ts
+++ b/integration_tests/e2e/manageRelationshipStatus.cy.ts
@@ -109,7 +109,7 @@ context('Manage contact update relationship status active', () => {
 
     Page.verifyOnPage(SelectRelationshipStatusPage, 'First Middle Names Last', 'John Smith') //
       .verifyHintText(
-        'Setting the relationship status to inactive will not remove First Middle Names Last from the prisoner’s approved visitors list in the visits booking service. If you no longer want this contact to be listed in the visits booking service, a DPS user with Contacts Authoriser access will need to remove visits approval.',
+        'Setting the relationship status to inactive will not remove First Middle Names Last from the prisoner’s approved visitors list in the visits booking service.If you no longer want this contact to be listed in the visits booking service, a DPS user with Contacts Authoriser access will need to remove visits approval.',
       )
   })
 })

--- a/integration_tests/e2e/manageRelationshipStatusByAuthoriser.cy.ts
+++ b/integration_tests/e2e/manageRelationshipStatusByAuthoriser.cy.ts
@@ -4,7 +4,7 @@ import ManageContactDetailsPage from '../pages/manageContactDetails'
 import SelectRelationshipStatusPage from '../pages/contact-details/relationship/selectRelationshipStatusPage'
 import EditContactDetailsPage from '../pages/editContactDetailsPage'
 
-context('Manage contact update relationship status active', () => {
+context('Manage contact update relationship status active with Authoriser role', () => {
   const contactId = 654321
   const prisonerContactId = 987654
   const contact = TestData.contact({
@@ -17,7 +17,7 @@ context('Manage contact update relationship status active', () => {
   beforeEach(() => {
     cy.task('reset')
     cy.task('stubComponentsMeta')
-    cy.task('stubSignIn', { roles: ['PRISON', 'CONTACTS_ADMINISTRATOR'] })
+    cy.task('stubSignIn', { roles: ['CONTACTS_ADMINISTRATOR', 'CONTACTS_AUTHORISER'] })
     cy.task('stubTitlesReferenceData')
     cy.task('stubPhoneTypeReferenceData')
     cy.task('stubPrisonerById', TestData.prisoner())
@@ -47,49 +47,7 @@ context('Manage contact update relationship status active', () => {
     Page.verifyOnPage(ManageContactDetailsPage, 'First Middle Names Last')
   })
 
-  it('Can update relationship status active', () => {
-    Page.verifyOnPage(ManageContactDetailsPage, 'First Middle Names Last') //
-      .clickEditContactDetailsLink()
-
-    Page.verifyOnPage(EditContactDetailsPage, 'First Middle Names Last') //
-      .verifyShowRelationshipStatusAs('Active')
-      .clickChangeRelationshipStatusLink()
-
-    Page.verifyOnPage(SelectRelationshipStatusPage, 'First Middle Names Last', 'John Smith') //
-      .selectIsRelationshipActive('NO')
-      .clickContinue()
-
-    Page.verifyOnPage(ManageContactDetailsPage, 'First Middle Names Last').hasSuccessBanner(
-      'You’ve updated the relationship information for contact First Middle Names Last and prisoner John Smith.',
-    )
-
-    cy.verifyLastAPICall(
-      {
-        method: 'PATCH',
-        urlPath: `/prisoner-contact/${prisonerContactId}`,
-      },
-      { isRelationshipActive: false },
-    )
-  })
-
-  it('goes to correct page on Back or Cancel', () => {
-    Page.verifyOnPage(ManageContactDetailsPage, 'First Middle Names Last') //
-      .clickEditContactDetailsLink()
-
-    Page.verifyOnPage(EditContactDetailsPage, 'First Middle Names Last') //
-      .clickChangeRelationshipStatusLink()
-
-    // Back to Edit Contact Details
-    Page.verifyOnPage(SelectRelationshipStatusPage, 'First Middle Names Last', 'John Smith') //
-      .backTo(EditContactDetailsPage, 'First Middle Names Last')
-      .clickChangeRelationshipStatusLink()
-
-    // Cancel to Contact Details page
-    Page.verifyOnPage(SelectRelationshipStatusPage, 'First Middle Names Last', 'John Smith') //
-      .cancelTo(ManageContactDetailsPage, 'First Middle Names Last')
-  })
-
-  it('should show hint text when contact is an approved visitor with active relationship', () => {
+  it('should show hint text for CONTACTS_AUTHORISER when contact is an approved visitor with active relationship', () => {
     // Stub the relationship to be active and approved visitor
     cy.task('stubGetPrisonerContactRelationshipById', {
       id: prisonerContactId,
@@ -109,7 +67,7 @@ context('Manage contact update relationship status active', () => {
 
     Page.verifyOnPage(SelectRelationshipStatusPage, 'First Middle Names Last', 'John Smith') //
       .verifyHintText(
-        'Setting the relationship status to inactive will not remove First Middle Names Last from the prisoner’s approved visitors list in the visits booking service. If you no longer want this contact to be listed in the visits booking service, a DPS user with Contacts Authoriser access will need to remove visits approval.',
+        'Setting the relationship status to inactive will not remove First Middle Names Last from John Smith’s approved visitors list in the visits booking service. If this contact should not be on the prisoner’s approved visitor list, you’ll need to remove visits approval.',
       )
   })
 })

--- a/integration_tests/e2e/manageRelationshipStatusByAuthoriser.cy.ts
+++ b/integration_tests/e2e/manageRelationshipStatusByAuthoriser.cy.ts
@@ -67,7 +67,7 @@ context('Manage contact update relationship status active with Authoriser role',
 
     Page.verifyOnPage(SelectRelationshipStatusPage, 'First Middle Names Last', 'John Smith') //
       .verifyHintText(
-        'Setting the relationship status to inactive will not remove First Middle Names Last from John Smith’s approved visitors list in the visits booking service. If this contact should not be on the prisoner’s approved visitor list, you’ll need to remove visits approval.',
+        'Setting the relationship status to inactive will not remove First Middle Names Last from John Smith’s approved visitors list in the visits booking service.If this contact should not be on the prisoner’s approved visitor list, you’ll need to remove visits approval.',
       )
   })
 })

--- a/integration_tests/pages/contact-details/relationship/selectRelationshipStatusPage.ts
+++ b/integration_tests/pages/contact-details/relationship/selectRelationshipStatusPage.ts
@@ -10,5 +10,12 @@ export default class SelectRelationshipStatusPage extends Page {
     return this
   }
 
+  verifyHintText(expected: string): SelectRelationshipStatusPage {
+    this.getRelationshipHintText().should('contain.text', expected)
+    return this
+  }
+
+  private getRelationshipHintText = (): PageElement => cy.get('#relationshipStatus-hint')
+
   private radio = (value: 'YES' | 'NO'): PageElement => cy.get(`.govuk-radios__input[value='${value}']`)
 }

--- a/server/routes/contacts/manage/relationship/status/manageRelationshipStatusController.test.ts
+++ b/server/routes/contacts/manage/relationship/status/manageRelationshipStatusController.test.ts
@@ -46,9 +46,9 @@ afterEach(() => {
 
 describe('GET /prisoner/:prisonerNumber/contacts/manage/:contactId/relationship/:prisonerContactId/relationship-status', () => {
   const INACTIVE_RELATIONSHIP_HINT_AUTHORISER =
-    'Setting the relationship status to inactive will not remove Jones Mason from John Smith’s approved visitors list in the visits booking service. If this contact should not be on the prisoner’s approved visitor list, you’ll need to remove visits approval.'
+    'Setting the relationship status to inactive will not remove Jones Mason from John Smith’s approved visitors list in the visits booking service.If this contact should not be on the prisoner’s approved visitor list, you’ll need to remove visits approval.'
   const INACTIVE_RELATIONSHIP_HINT_ADMINISTRATOR =
-    'Setting the relationship status to inactive will not remove Jones Mason from the prisoner’s approved visitors list in the visits booking service. If you no longer want this contact to be listed in the visits booking service, a DPS user with Contacts Authoriser access will need to remove visits approval.'
+    'Setting the relationship status to inactive will not remove Jones Mason from the prisoner’s approved visitors list in the visits booking service.If you no longer want this contact to be listed in the visits booking service, a DPS user with Contacts Authoriser access will need to remove visits approval.'
 
   const tests = [
     {

--- a/server/routes/contacts/manage/relationship/status/manageRelationshipStatusController.test.ts
+++ b/server/routes/contacts/manage/relationship/status/manageRelationshipStatusController.test.ts
@@ -1,7 +1,13 @@
 import type { Express } from 'express'
 import request from 'supertest'
 import * as cheerio from 'cheerio'
-import { adminUser, appWithAllRoutes, authorisingUser, basicPrisonUser } from '../../../../testutils/appSetup'
+import {
+  adminUser,
+  appWithAllRoutes,
+  authorisingUser,
+  basicPrisonUser,
+  userWithMultipleRoles,
+} from '../../../../testutils/appSetup'
 import { Page } from '../../../../../services/auditService'
 import TestData from '../../../../testutils/testData'
 import { MockedService } from '../../../../../testutils/mockedServices'
@@ -39,6 +45,91 @@ afterEach(() => {
 })
 
 describe('GET /prisoner/:prisonerNumber/contacts/manage/:contactId/relationship/:prisonerContactId/relationship-status', () => {
+  const INACTIVE_RELATIONSHIP_HINT_AUTHORISER =
+    'Setting the relationship status to inactive will not remove Jones Mason from John Smith’s approved visitors list in the visits booking service. If this contact should not be on the prisoner’s approved visitor list, you’ll need to remove visits approval.'
+  const INACTIVE_RELATIONSHIP_HINT_ADMINISTRATOR =
+    'Setting the relationship status to inactive will not remove Jones Mason from the prisoner’s approved visitors list in the visits booking service. If you no longer want this contact to be listed in the visits booking service, a DPS user with Contacts Authoriser access will need to remove visits approval.'
+
+  const tests = [
+    {
+      user: adminUser,
+      expectedHint: INACTIVE_RELATIONSHIP_HINT_ADMINISTRATOR,
+    },
+    {
+      user: authorisingUser,
+      expectedHint: INACTIVE_RELATIONSHIP_HINT_AUTHORISER,
+    },
+    {
+      user: userWithMultipleRoles,
+      expectedHint: INACTIVE_RELATIONSHIP_HINT_AUTHORISER,
+    },
+  ]
+
+  tests.forEach(({ user, expectedHint }) => {
+    it(`should render manage relationship status page with correct hint text for user with roles ${user.userRoles}`, async () => {
+      // Given
+      currentUser = user
+      contactsService.getContact.mockResolvedValue(TestData.contact())
+      prisonerSearchService.getByPrisonerNumber.mockResolvedValue(TestData.prisoner())
+      contactsService.getPrisonerContactRelationship.mockResolvedValue({
+        isRelationshipActive: true,
+        isApprovedVisitor: true,
+      } as PrisonerContactRelationshipDetails)
+
+      // When
+      const response = await request(app).get(
+        `/prisoner/${prisonerNumber}/contacts/manage/${contactId}/relationship/${prisonerContactId}/relationship-status`,
+      )
+
+      // Then
+      expect(response.status).toEqual(200)
+      const $ = cheerio.load(response.text)
+      expect($('.govuk-hint').text().trim()).toContain(expectedHint)
+    })
+  })
+
+  it('should render manage relationship status page with no hint text when relationship is not active', async () => {
+    // Given
+    currentUser = adminUser
+    contactsService.getContact.mockResolvedValue(TestData.contact())
+    prisonerSearchService.getByPrisonerNumber.mockResolvedValue(TestData.prisoner())
+    contactsService.getPrisonerContactRelationship.mockResolvedValue({
+      isRelationshipActive: false,
+      isApprovedVisitor: true,
+    } as PrisonerContactRelationshipDetails)
+
+    // When
+    const response = await request(app).get(
+      `/prisoner/${prisonerNumber}/contacts/manage/${contactId}/relationship/${prisonerContactId}/relationship-status`,
+    )
+
+    // Then
+    expect(response.status).toEqual(200)
+    const $ = cheerio.load(response.text)
+    expect($('.govuk-hint').length).toEqual(0)
+  })
+
+  it('should render manage relationship status page with no hint text when contact is not approved visitor', async () => {
+    // Given
+    currentUser = adminUser
+    contactsService.getContact.mockResolvedValue(TestData.contact())
+    prisonerSearchService.getByPrisonerNumber.mockResolvedValue(TestData.prisoner())
+    contactsService.getPrisonerContactRelationship.mockResolvedValue({
+      isRelationshipActive: true,
+      isApprovedVisitor: false,
+    } as PrisonerContactRelationshipDetails)
+
+    // When
+    const response = await request(app).get(
+      `/prisoner/${prisonerNumber}/contacts/manage/${contactId}/relationship/${prisonerContactId}/relationship-status`,
+    )
+
+    // Then
+    expect(response.status).toEqual(200)
+    const $ = cheerio.load(response.text)
+    expect($('.govuk-hint').length).toEqual(0)
+  })
+
   it('should render manage relationship status active status page', async () => {
     // Given
     contactsService.getContact.mockResolvedValue(TestData.contact())

--- a/server/routes/contacts/manage/relationship/status/manageRelationshipStatusController.ts
+++ b/server/routes/contacts/manage/relationship/status/manageRelationshipStatusController.ts
@@ -34,6 +34,7 @@ export default class ManageRelationshipStatusController implements PageHandler {
       contact,
       prisonerContactId,
       isRelationshipActive: relationship.isRelationshipActive,
+      isApprovedVisitor: relationship.isApprovedVisitor,
       navigation,
     })
   }

--- a/server/routes/testutils/appSetup.ts
+++ b/server/routes/testutils/appSetup.ts
@@ -51,6 +51,17 @@ export const authorisingUser: HmppsUser = {
   userRoles: ['CONTACTS_AUTHORISER'],
 }
 
+export const userWithMultipleRoles: HmppsUser = {
+  name: 'CONTACTS MULTIPLE ROLES',
+  userId: 'contacts_multi_role_user_id',
+  token: 'token',
+  username: 'contacts_multi_role_user',
+  displayName: 'Contacts Multiple Roles',
+  authSource: 'nomis',
+  staffId: 6789,
+  userRoles: ['CONTACTS_AUTHORISER', 'CONTACTS_ADMINISTRATOR', 'ROLE_PRISON'],
+}
+
 export const flashProvider = jest.fn()
 
 function appSetup(

--- a/server/utils/nunjucksSetup.ts
+++ b/server/utils/nunjucksSetup.ts
@@ -32,7 +32,7 @@ import sortRestrictions from './sortRestrictions'
 import { convertToSortableColumns } from './convertToSortableColumns'
 import { sortPhoneNumbers } from './sortPhoneNumbers'
 import { ContactAddressDetails } from '../@types/contactsApiClient'
-import { hasPermission } from './permissionsUtils'
+import { hasPermission, hasRole } from './permissionsUtils'
 
 export default function nunjucksSetup(app: express.Express): void {
   app.set('view engine', 'njk')
@@ -151,4 +151,5 @@ export default function nunjucksSetup(app: express.Express): void {
   njkEnv.addFilter('sortRestrictions', sortRestrictions)
   njkEnv.addFilter('sortPhoneNumbers', sortPhoneNumbers)
   njkEnv.addFilter('hasPermission', hasPermission)
+  njkEnv.addFilter('hasRole', hasRole)
 }

--- a/server/utils/permissionsUtils.test.ts
+++ b/server/utils/permissionsUtils.test.ts
@@ -1,5 +1,5 @@
 import Permission from '../enumeration/permission'
-import { hasPermission, permissionsFromRoles } from './permissionsUtils'
+import { hasPermission, permissionsFromRoles, hasRole } from './permissionsUtils'
 import { HmppsUser } from '../interfaces/hmppsUser'
 
 describe('permissionUtils', () => {
@@ -59,5 +59,21 @@ describe('permissionUtils', () => {
         expect(hasPermission(user, permission)).toStrictEqual(expected)
       },
     )
+  })
+
+  describe('hasRole', () => {
+    it.each([
+      [['ROLE_PRISON'], 'ROLE_PRISON', true],
+      [['ROLE_PRISON'], 'ROLE_CONTACTS_ADMINISTRATOR', false],
+      [['ROLE_PRISON', 'ROLE_CONTACTS_ADMINISTRATOR'], 'ROLE_CONTACTS_ADMINISTRATOR', true],
+      [['ROLE_PRISON', 'ROLE_CONTACTS_ADMINISTRATOR'], 'ROLE_CONTACTS_AUTHORISER', false],
+      [['ROLE_PRISON', 'ROLE_CONTACTS_ADMINISTRATOR', 'ROLE_CONTACTS_AUTHORISER'], 'ROLE_CONTACTS_AUTHORISER', true],
+    ])('should return correct role for roles (%s, %s)', (userRoles: string[], role: string, expected: boolean) => {
+      const user = {
+        username: 'foo',
+        userRoles,
+      } as unknown as HmppsUser
+      expect(hasRole(user, role)).toStrictEqual(expected)
+    })
   })
 })

--- a/server/utils/permissionsUtils.ts
+++ b/server/utils/permissionsUtils.ts
@@ -26,4 +26,9 @@ function hasPermission(user: HmppsUser, permission: Permission): boolean {
   return permissionsFromRoles(user.userRoles).includes(permission)
 }
 
-export { permissionsFromRoles, hasPermission }
+function hasRole(user: HmppsUser, role: string): boolean {
+  if (!user) return false
+  return user.userRoles.includes(role)
+}
+
+export { permissionsFromRoles, hasPermission, hasRole }

--- a/server/views/pages/contacts/manage/contactDetails/relationship/manageRelationshipStatus.njk
+++ b/server/views/pages/contacts/manage/contactDetails/relationship/manageRelationshipStatus.njk
@@ -18,9 +18,9 @@
             {% set showRelationshipStatusHint = isApprovedVisitor and isRelationshipActive %}
             {% if showRelationshipStatusHint %}
               {% if user | hasRole('CONTACTS_AUTHORISER') %}
-                {% set relationshipStatusHint = "Setting the relationship status to inactive will not remove " + (contact | formatNameFirstNameFirst) + " from " + (prisonerDetails | formatNameFirstNameFirst(possessiveSuffix = true, excludeMiddleNames = true)) + " approved visitors list in the visits booking service. If this contact should not be on the prisoner’s approved visitor list, you’ll need to remove visits approval." %}
+                {% set relationshipStatusHint = "Setting the relationship status to inactive will not remove " + (contact | formatNameFirstNameFirst) + " from " + (prisonerDetails | formatNameFirstNameFirst(possessiveSuffix = true, excludeMiddleNames = true)) + " approved visitors list in the visits booking service.<br><br>If this contact should not be on the prisoner’s approved visitor list, you’ll need to remove visits approval." %}
               {% elif user | hasRole('CONTACTS_ADMINISTRATOR') %}
-                {% set relationshipStatusHint = "Setting the relationship status to inactive will not remove " + (contact | formatNameFirstNameFirst) + " from the prisoner’s approved visitors list in the visits booking service. If you no longer want this contact to be listed in the visits booking service, a DPS user with Contacts Authoriser access will need to remove visits approval." %}
+                {% set relationshipStatusHint = "Setting the relationship status to inactive will not remove " + (contact | formatNameFirstNameFirst) + " from the prisoner’s approved visitors list in the visits booking service.<br><br>If you no longer want this contact to be listed in the visits booking service, a DPS user with Contacts Authoriser access will need to remove visits approval." %}
               {% endif %}
             {% endif %}
 
@@ -33,7 +33,7 @@
                 }
               },
               hint: {
-                text: relationshipStatusHint
+                text: relationshipStatusHint | safe
               } if showRelationshipStatusHint else undefined,
               errorMessage: validationErrors | findError('relationshipStatus'),
               name: "relationshipStatus",

--- a/server/views/pages/contacts/manage/contactDetails/relationship/manageRelationshipStatus.njk
+++ b/server/views/pages/contacts/manage/contactDetails/relationship/manageRelationshipStatus.njk
@@ -14,6 +14,16 @@
         <form method='POST'>
             <input type="hidden" name="_csrf" value="{{ csrfToken }}" />
 
+            {% set relationshipStatusHint = "" %}
+            {% set showRelationshipStatusHint = isApprovedVisitor and isRelationshipActive %}
+            {% if showRelationshipStatusHint %}
+              {% if user | hasRole('CONTACTS_AUTHORISER') %}
+                {% set relationshipStatusHint = "Setting the relationship status to inactive will not remove " + (contact | formatNameFirstNameFirst) + " from " + (prisonerDetails | formatNameFirstNameFirst(possessiveSuffix = true, excludeMiddleNames = true)) + " approved visitors list in the visits booking service. If this contact should not be on the prisoner’s approved visitor list, you’ll need to remove visits approval." %}
+              {% elif user | hasRole('CONTACTS_ADMINISTRATOR') %}
+                {% set relationshipStatusHint = "Setting the relationship status to inactive will not remove " + (contact | formatNameFirstNameFirst) + " from the prisoner’s approved visitors list in the visits booking service. If you no longer want this contact to be listed in the visits booking service, a DPS user with Contacts Authoriser access will need to remove visits approval." %}
+              {% endif %}
+            {% endif %}
+
             {{ govukRadios({
               fieldset: {
                 legend: {
@@ -22,6 +32,9 @@
                   classes: "govuk-fieldset__legend--l govuk-!-margin-bottom-6 main-heading"
                 }
               },
+              hint: {
+                text: relationshipStatusHint
+              } if showRelationshipStatusHint else undefined,
               errorMessage: validationErrors | findError('relationshipStatus'),
               name: "relationshipStatus",
                     items: [


### PR DESCRIPTION
Add hint text guidance https://dsdmoj.atlassian.net/browse/PRC-821

Test evidence:
Authoriser
<img width="937" height="900" alt="image" src="https://github.com/user-attachments/assets/4bfa6c35-7b3d-4806-9996-2bbb53ac8ce7" />


Administrator
<img width="979" height="850" alt="image" src="https://github.com/user-attachments/assets/de76ee50-63c6-4a68-b8a4-1a87aee9ba95" />

Inactive relationship - no hint text
<img width="951" height="676" alt="image" src="https://github.com/user-attachments/assets/3078249c-15cb-45a3-b1a6-07fcd631e103" />

Active relationship - not approved to visit, no hint text
<img width="861" height="761" alt="image" src="https://github.com/user-attachments/assets/11e22fa5-1b2a-4862-b759-6df78d0569a5" />


 