### PR TITLE
PRC-828 : Change to existing “Add visits approval” add hint text to the screen after the “Skip this question"

### DIFF
--- a/server/routes/contacts/add/approved-to-visit/approvedToVisitController.test.ts
+++ b/server/routes/contacts/add/approved-to-visit/approvedToVisitController.test.ts
@@ -90,6 +90,22 @@ describe('GET /prisoner/:prisonerNumber/contacts/create/approved-to-visit/:journ
       )
       expect($('[data-qa=cancel-button]')).toHaveLength(0)
       expect($('[data-qa=breadcrumbs]')).toHaveLength(0)
+
+      // Assert hint text and details are present
+      const hintHtml = $('.govuk-hint').html()
+      expect(hintHtml).toContain('Skip this question if:')
+      expect(hintHtml).toContain('the contact has not yet been checked and approved for visits to this prisoner')
+      expect(hintHtml).toContain(
+        'for any other reason, you’re not sure whether the contact is approved to visit the prisoner or not',
+      )
+      // Check details summary
+      expect(hintHtml).toContain('Procedures for approving visitors')
+      expect(hintHtml).toContain('Check your local procedures when approving visitors for prisoners.')
+      expect(hintHtml).toContain('person posing a risk to children (PPRC)')
+      expect(hintHtml).toContain('harassment offence (including stalking)')
+      expect(hintHtml).toContain('public protection contact restrictions')
+      expect(hintHtml).toContain('domestic abuse perpetrator')
+      expect(hintHtml).toContain('Sex Offences Act 2003')
     },
   )
 

--- a/server/routes/contacts/manage/relationship/approved-to-visit/manageApprovedToVisitController.test.ts
+++ b/server/routes/contacts/manage/relationship/approved-to-visit/manageApprovedToVisitController.test.ts
@@ -74,6 +74,8 @@ describe('GET /prisoner/:prisonerNumber/contacts/manage/:contactId/relationship/
     )
     expect($('[data-qa=breadcrumbs]')).toHaveLength(0)
     expect($('[data-qa=continue-button]').first().text().trim()).toStrictEqual('Confirm and save')
+    // Assert hint text and details are NOT present
+    expect($('.govuk-hint').length).toBe(0)
 
     expect(auditService.logPageView).toHaveBeenCalledWith(Page.MANAGE_CONTACT_UPDATE_APPROVED_TO_VISIT_PAGE, {
       who: authorisingUser.username,

--- a/server/views/pages/contacts/manage/contactDetails/relationship/manageApprovedToVisit.njk
+++ b/server/views/pages/contacts/manage/contactDetails/relationship/manageApprovedToVisit.njk
@@ -31,6 +31,16 @@
         <li>for any other reason, you’re not sure whether the contact is approved to visit the prisoner or not</li>
       </ul>
     </div>
+    <details class="govuk-details">
+      <summary class="govuk-details__summary">
+        <span class="govuk-details__summary-text">
+          Procedures for approving visitors
+        </span>
+      </summary>
+      <div class="govuk-details__text">
+        <div class="govuk-body"><p>Check your local procedures when approving visitors for prisoners.</p><p>You must also check prisoner alerts and contact the OMU before approving a visitor if the prisoner has been:</p><ul class="govuk-list govuk-list--bullet"><li>identified as a person posing a risk to children (PPRC) or a potential PPRC</li><li>convicted or remanded for a harassment offence (including stalking)</li><li>subject to public protection contact restrictions, including victim contact restrictions, court order restriction, victim or witness contact restriction (remand cases) or no-contact requests</li><li>identified as a domestic abuse perpetrator</li><li>cautioned, convicted, or otherwise dealt with in respect of a sexual offence listed in Schedule 3 of the Sex Offences Act 2003</li></ul></div>
+      </div>
+    </details>
   {% endset -%}
 
   <div class="govuk-grid-row">


### PR DESCRIPTION
**AC**

- Change to existing “Add visits approval” screen after the “Skip this question if:” section- add hint / guidance text as per the [prototype](https://www.figma.com/design/mfIjofNa89Pk9Ca0JmuXZS/Contacts-prototyping?node-id=6107-81984&t=LBMDHIO7UiEvNrjm-4) 

- Default state of details reveal in **minimised**

**Test evidence**

- Default on page load

<img width="950" height="734" alt="image" src="https://github.com/user-attachments/assets/faaf1863-24ac-4abb-af20-be5cac1d635f" />

- Hint text

<img width="832" height="840" alt="image" src="https://github.com/user-attachments/assets/0c63e704-e4d1-4075-82d4-d147865778c9" />
