### PR TITLE
PRC-865 Skip dob on create new contact CYA page

### DIFF
--- a/server/routes/contacts/add/check-answers/createContactCheckAnswersController.test.ts
+++ b/server/routes/contacts/add/check-answers/createContactCheckAnswersController.test.ts
@@ -110,6 +110,20 @@ describe('GET /prisoner/:prisonerNumber/contacts/create/check-answers/:journeyId
     expect($('strong:contains("Only record data when it is necessary to do so.")').text()).toBeTruthy()
   })
 
+  it('should render check answers page without dob for mode NEW if relationship is for internal contact', async () => {
+    // Given
+    journey.mode = 'NEW'
+    journey.relationship!.relationshipToPrisoner = 'CA'
+
+    // When
+    const response = await request(app).get(`/prisoner/${prisonerNumber}/contacts/create/check-answers/${journeyId}`)
+
+    // Then
+    expect(response.status).toEqual(200)
+    const $ = cheerio.load(response.text)
+    expect($('.check-answers-dob-value').first().text()).toBeFalsy()
+  })
+
   it('should render alternative check answers page for mode EXISTING', async () => {
     // Given
     journey.mode = 'EXISTING'

--- a/server/routes/contacts/add/check-answers/createContactCheckAnswersController.ts
+++ b/server/routes/contacts/add/check-answers/createContactCheckAnswersController.ts
@@ -46,7 +46,7 @@ export default class CreateContactCheckAnswersController implements PageHandler 
     delete journey.pendingEmployments
     delete journey.pendingAddresses
     let dateOfBirth
-    if (journey.dateOfBirth!.isKnown === 'YES') {
+    if (journey.dateOfBirth?.isKnown === 'YES') {
       dateOfBirth = new Date(`${journey.dateOfBirth!.year}-${journey.dateOfBirth!.month}-${journey.dateOfBirth!.day}Z`)
     }
     const relationshipTypeDescription = await this.referenceDataService.getReferenceDescriptionForCode(

--- a/server/services/contactsService.ts
+++ b/server/services/contactsService.ts
@@ -37,6 +37,7 @@ import {
 import { stripNullishAddressLines } from '../routes/contacts/add/addresses/common/utils'
 import TelemetryService from './telemetryService'
 import { HmppsUser } from '../interfaces/hmppsUser'
+import { isInternalContact } from '../utils/utils'
 
 export default class ContactsService extends AuditedService {
   constructor(
@@ -76,7 +77,7 @@ export default class ContactsService extends AuditedService {
         ...(journey?.relationship?.comments === undefined ? {} : { comments: journey.relationship.comments }),
       },
     }
-    if (journey.dateOfBirth?.isKnown === 'YES') {
+    if (journey.dateOfBirth?.isKnown === 'YES' && !isInternalContact(journey.relationship!.relationshipToPrisoner!)) {
       request.dateOfBirth = new Date(
         `${journey.dateOfBirth.year}-${journey.dateOfBirth.month}-${journey.dateOfBirth.day}Z`,
       )

--- a/server/views/pages/contacts/add/new/checkAnswers.njk
+++ b/server/views/pages/contacts/add/new/checkAnswers.njk
@@ -83,7 +83,7 @@
                                 }
                             ]
                         }
-                    },
+                    } if not (journey.relationship.relationshipToPrisoner | isInternalContact),
                     {
                       key: {
                         text: "Gender"


### PR DESCRIPTION
for create new contact check-answer page,
1. skip date of birth row if it is for an internal contact
2. if dob is entered and then relationship is changed to an "internal contact" option, dob will still not be shown on CYA and not sent in API call