### PR TITLE
PRC-911 : remove banner for Brewyn and Lewes

### DIFF
--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -21,7 +21,7 @@ generic-service:
     ENVIRONMENT_NAME: DEV
     SENTRY_ENVIRONMENT: DEV
     AUDIT_ENABLED: 'true'
-    FEATURE_ENABLED_PRISONS: 'KMI,GNI,SPI,LGI,DWI,HOI,WWI,LEI'
+    FEATURE_ENABLED_PRISONS: 'KMI,GNI,SPI,LGI,DWI,HOI,WWI,LEI,LWI,BWI'
 
 generic-prometheus-alerts:
   alertSeverity: hmpps-contacts-ui-dev

--- a/helm_deploy/values-preprod.yaml
+++ b/helm_deploy/values-preprod.yaml
@@ -21,7 +21,7 @@ generic-service:
     ENVIRONMENT_NAME: PRE-PRODUCTION
     SENTRY_ENVIRONMENT: PRE-PRODUCTION
     AUDIT_ENABLED: 'false'
-    FEATURE_ENABLED_PRISONS: 'KMI,GNI,SPI,LGI,DWI,HOI,WWI,LEI'
+    FEATURE_ENABLED_PRISONS: 'KMI,GNI,SPI,LGI,DWI,HOI,WWI,LEI,LWI,BWI'
 
 generic-prometheus-alerts:
   alertSeverity: hmpps-contacts-ui-non-prod

--- a/helm_deploy/values-prod.yaml
+++ b/helm_deploy/values-prod.yaml
@@ -17,7 +17,7 @@ generic-service:
     ORGANISATIONS_API_URL: 'https://organisations-api.hmpps.service.justice.gov.uk'
     COMMON_COMPONENTS_ENABLED: true
     SENTRY_ENVIRONMENT: PRODUCTION
-    FEATURE_ENABLED_PRISONS: 'KMI,GNI,SPI,LGI,DWI,HOI,WWI,LEI'
+    FEATURE_ENABLED_PRISONS: 'KMI,GNI,SPI,LGI,DWI,HOI,WWI,LEI,LWI,BWI'
     AUDIT_ENABLED: 'false'
 
 generic-prometheus-alerts:


### PR DESCRIPTION
Acceptance criteria

- On Monday **8th September**, HMP **Lewes** no longer has the alert banner on the prisoner contact list.
- On Monday **8th September**, HMP **Berwyn** no longer has the alert banner on the prisoner contact list.