### PR TITLE
PRC-928 : add fuzzy search (#571)

### DIFF
--- a/server/@types/contactsApiClient/index.d.ts
+++ b/server/@types/contactsApiClient/index.d.ts
@@ -66,4 +66,5 @@ export type ContactSearchRequest = {
   middleNames?: string | undefined
   dateOfBirth?: string | null
   includeAnyExistingRelationshipsToPrisoner?: string | undefined
+  soundsLike?: boolean | undefined
 }

--- a/server/@types/journeys/index.d.ts
+++ b/server/@types/journeys/index.d.ts
@@ -9,6 +9,7 @@ export interface AddContactJourney {
   mode?: 'EXISTING' | 'NEW' | undefined
   searchContact?:
     | {
+        soundsLike?: boolean | undefined
         contact?: Partial<ContactNames>
         dateOfBirth?: Partial<DateOfBirth>
         page?: number
@@ -88,6 +89,7 @@ export interface ManageContactsJourney {
   searchContact?: {
     contact?: Partial<ContactNames>
     dateOfBirth?: Partial<DateOfBirth>
+    soundsLike?: boolean
   }
   contactId?: number
   activateListPage?: number

--- a/server/data/contactsApiClient.ts
+++ b/server/data/contactsApiClient.ts
@@ -152,6 +152,7 @@ export default class ContactsApiClient extends RestClient {
           middleNames: contactSearchRequest.middleNames,
           dateOfBirth: contactSearchRequest.dateOfBirth,
           includeAnyExistingRelationshipsToPrisoner: contactSearchRequest.includeAnyExistingRelationshipsToPrisoner,
+          soundsLike: contactSearchRequest.soundsLike,
           ...paginationParameters,
         },
       },

--- a/server/routes/contacts/add/contact-search/contactSearchController.test.ts
+++ b/server/routes/contacts/add/contact-search/contactSearchController.test.ts
@@ -86,6 +86,7 @@ describe('GET /prisoner/:prisonerNumber/contacts/search/:journeyId', () => {
     expect($('.govuk-form-group .govuk-label').eq(1).text()).toContain('Middle names')
     expect($('.govuk-form-group .govuk-label').eq(2).text()).toContain('Last name')
     expect($('.govuk-fieldset__legend:contains("Date of birth")').text()).toBeFalsy()
+    expect($('label[for="soundsLike"]').text().trim()).toBe('Sounds like search')
     expect($('[data-qa=search-button]').text()).toContain('Search')
     expect($('[data-qa=back-link]').first().attr('href')).toStrictEqual(`/prisoner/${prisonerNumber}/contacts/list`)
     expect($('[data-qa=back-link]').first().text()).toStrictEqual('Back to prisoner’s contact list')
@@ -158,6 +159,26 @@ describe('POST /prisoner/:prisonerNumber/contacts/search/:journeyId', () => {
         lastName: 'last',
       },
       page: 1,
+      soundsLike: false,
+    })
+  })
+
+  it('should pass the sounds like when it is enabled', async () => {
+    await request(app)
+      .post(`/prisoner/${prisonerNumber}/contacts/search/${journeyId}`)
+      .type('form')
+      .send({ lastName: 'last', middleNames: '', firstName: '', soundsLike: 'true' })
+      .expect(302)
+      .expect('Location', `/prisoner/${prisonerNumber}/contacts/search/${journeyId}#`)
+
+    expect(session.addContactJourneys![journeyId]!.searchContact).toStrictEqual({
+      contact: {
+        firstName: undefined,
+        middleNames: undefined,
+        lastName: 'last',
+      },
+      page: 1,
+      soundsLike: true,
     })
   })
 
@@ -176,6 +197,7 @@ describe('POST /prisoner/:prisonerNumber/contacts/search/:journeyId', () => {
         lastName: undefined,
       },
       page: 1,
+      soundsLike: false,
     })
   })
 
@@ -207,6 +229,7 @@ describe('POST /prisoner/:prisonerNumber/contacts/search/:journeyId', () => {
     expect(session.addContactJourneys![journeyId]!.searchContact).toStrictEqual({
       contact: expectedContact,
       page: 1,
+      soundsLike: false,
     })
     expect(contactsService.searchContact).not.toHaveBeenCalled()
   })

--- a/server/routes/contacts/add/contact-search/contactSearchController.ts
+++ b/server/routes/contacts/add/contact-search/contactSearchController.ts
@@ -65,6 +65,7 @@ export default class ContactSearchController implements PageHandler {
         middleNames: journey.searchContact.contact.middleNames,
         dateOfBirth: formatDateForApi(journey.searchContact.dateOfBirth),
         includeAnyExistingRelationshipsToPrisoner: journey.prisonerNumber,
+        soundsLike: journey.searchContact.soundsLike,
       }
 
       results = await this.contactsService.searchContact(
@@ -103,7 +104,7 @@ export default class ContactSearchController implements PageHandler {
   }
 
   POST = async (req: Request<{ journeyId: string }, ContactSearchSchemaType>, res: Response): Promise<void> => {
-    const { lastName, firstName, middleNames, day, month, year } = req.body
+    const { lastName, firstName, middleNames, day, month, year, soundsLike } = req.body
     const { journeyId } = req.params
     const journey = req.session.addContactJourneys![journeyId]!
 
@@ -114,10 +115,11 @@ export default class ContactSearchController implements PageHandler {
           middleNames: middleNames || undefined,
           firstName: firstName || undefined,
         },
+        soundsLike: Boolean(soundsLike),
         page: 1,
       }
     } else if (lastName === '' && firstName === '' && middleNames === '') {
-      journey.searchContact = { page: 1 }
+      journey.searchContact = { page: 1, soundsLike: Boolean(soundsLike) }
     } else if (day && month && year && journey.searchContact?.contact?.lastName) {
       journey.searchContact.dateOfBirth = { day, month, year }
       journey.searchContact.page = 1

--- a/server/routes/contacts/add/contact-search/contactSearchSchema.ts
+++ b/server/routes/contacts/add/contact-search/contactSearchSchema.ts
@@ -10,6 +10,10 @@ export const contactSearchSchema = createDateInputSchema({
     lastName: z.string().optional(),
     middleNames: z.string().optional(),
     firstName: z.string().optional(),
+    soundsLike: z
+      .union([z.literal('true'), z.literal('false')])
+      .optional()
+      .transform(v => (v ? v === 'true' : undefined)),
   },
 })
 

--- a/server/views/pages/contacts/manage/contactSearch.njk
+++ b/server/views/pages/contacts/manage/contactSearch.njk
@@ -2,6 +2,7 @@
 {% from "govuk/components/input/macro.njk" import govukInput %}
 {% from "govuk/components/select/macro.njk" import govukSelect %}
 {% from "govuk/components/button/macro.njk" import govukButton %}
+{% from "govuk/components/checkboxes/macro.njk" import govukCheckboxes %}
 {% from "govuk/components/date-input/macro.njk" import govukDateInput %}
 {% from "govuk/components/table/macro.njk" import govukTable %}
 {% from "govuk/components/warning-text/macro.njk" import govukWarningText %}
@@ -59,32 +60,40 @@
               label: { text: "Last name" },
               value: lastName
             }) }}
+        </div>
+          <div class="govuk-!-width-three-quarters">
+              {% set advancedSearchInstructions %}
+                <div class="govuk-!-width-three-quarters govuk-!-margin-top-4">
+                  {{ govukCheckboxes({
+                    idPrefix: "soundsLike",
+                    name: "soundsLike",
+                    classes: "govuk-!-margin-bottom-4",
+                    items: [
+                      {
+                        value: "true",
+                        text: "Sounds like search"
+                      }
+                    ]
+                  }) }}
+                </div>
+              {% endset %}
 
-            {{ govukButton({
-              classes: "moj-search__button",
-              text: "Search",
-              attributes: {"data-qa": "search-button"},
-              preventDoubleClick: true
-            }) }}
-          </form>
-          {% set advancedSearchInstructions %}
-            <div class="govuk-!-width-three-quarters">
-              <p class="govuk-body">This service currently allows search by name or partial name, with filtering by exact date of birth. </p>
-              <p class="govuk-body">You still need to use NOMIS for advanced search and filters such as:</p>
-              <ul class="govuk-list govuk-list--bullet">
-                <li>‘sounds like’ name search</li>
-                <li>identity document search</li>
-                <li>person ID search (the unique number given to each contact record)</li>
-                <li>filter by gender</li>
-                <li>filter by year of birth and a range of years either side of that date</li>
-              </ul>
+              {{ govukDetails({
+                classes: "govuk-!-margin-top-6 govuk-!-margin-bottom-0",
+                summaryText: "Show advanced filters",
+                html: advancedSearchInstructions
+              }) }}
+
+            <div class="govuk-details govuk-!-margin-top-6 govuk-!-margin-bottom-0">
+              {{ govukButton({
+                classes: "moj-search__button",
+                text: "Search",
+                attributes: {"data-qa": "search-button"},
+                preventDoubleClick: true
+              }) }}
             </div>
-          {% endset %}
-          {{ govukDetails({
-            classes: "govuk-!-margin-top-6 govuk-!-margin-bottom-0",
-            summaryText: "How to use advanced search and filters",
-            html: advancedSearchInstructions
-          }) }}
+          </form>
+
         </div>
       </div>
 

--- a/server/views/pages/contacts/manage/contactSearch.njk
+++ b/server/views/pages/contacts/manage/contactSearch.njk
@@ -67,7 +67,7 @@
                   {{ govukCheckboxes({
                     idPrefix: "soundsLike",
                     name: "soundsLike",
-                    classes: "govuk-!-margin-bottom-4",
+                    classes: "govuk-checkboxes--small",
                     items: [
                       {
                         value: "true",


### PR DESCRIPTION
Acceptance criteria

The ‘normal’ search reverts back to the ‘normal’ search that is currently in Production

There exists a toggle ‘Sounds like’ toggle

When this is clicked, the current dev search applies to the search

The content matches the [Figma](https://www.figma.com/design/mfIjofNa89Pk9Ca0JmuXZS/Contacts-prototyping?node-id=6933-17973&t=o2HA7M4qhH2Q39hc-4)

Test evidence: shows the small text box

<img width="793" height="381" alt="image" src="https://github.com/user-attachments/assets/ae3b9181-e75f-40d5-a498-08bd39ff7ed1" />
