### PR TITLE
PRC-954 : Inform Contact Admins that they cannot approve a contact to visit

### DIFF
--- a/server/routes/contacts/add/contact-match/contactMatchControllerAuthoriserRole.test.ts
+++ b/server/routes/contacts/add/contact-match/contactMatchControllerAuthoriserRole.test.ts
@@ -1,0 +1,97 @@
+import type { Express } from 'express'
+import request from 'supertest'
+import { SessionData } from 'express-session'
+import { v4 as uuidv4 } from 'uuid'
+import * as cheerio from 'cheerio'
+import { appWithAllRoutes, authorisingUser, authorisingUserPermissions } from '../../../testutils/appSetup'
+import TestData from '../../../testutils/testData'
+import { MockedService } from '../../../../testutils/mockedServices'
+import { mockedReferenceData } from '../../../testutils/stubReferenceData'
+import { AddContactJourney } from '../../../../@types/journeys'
+import { HmppsUser } from '../../../../interfaces/hmppsUser'
+import mockPermissions from '../../../testutils/mockPermissions'
+
+jest.mock('@ministryofjustice/hmpps-prison-permissions-lib')
+jest.mock('../../../../services/auditService')
+jest.mock('../../../../services/prisonerSearchService')
+jest.mock('../../../../services/contactsService')
+jest.mock('../../../../services/referenceDataService')
+jest.mock('../../../../services/restrictionsService')
+
+const auditService = MockedService.AuditService()
+const prisonerSearchService = MockedService.PrisonerSearchService()
+const contactsService = MockedService.ContactsService()
+const referenceDataService = MockedService.ReferenceDataService()
+const restrictionsService = MockedService.RestrictionsService()
+
+let app: Express
+let session: Partial<SessionData>
+const journeyId: string = uuidv4()
+const prisonerNumber = 'A1234BC'
+let existingJourney: AddContactJourney
+let currentUser: HmppsUser
+
+beforeEach(() => {
+  currentUser = authorisingUser
+  existingJourney = {
+    id: journeyId,
+    lastTouched: new Date().toISOString(),
+    prisonerNumber,
+    isCheckingAnswers: false,
+    mode: 'EXISTING',
+  }
+  app = appWithAllRoutes({
+    services: {
+      auditService,
+      prisonerSearchService,
+      contactsService,
+      referenceDataService,
+      restrictionsService,
+    },
+    userSupplier: () => currentUser,
+    sessionReceiver: (receivedSession: Partial<SessionData>) => {
+      session = receivedSession
+      session.addContactJourneys = {}
+      session.addContactJourneys[journeyId] = existingJourney
+    },
+  })
+
+  mockPermissions(app, authorisingUserPermissions)
+
+  referenceDataService.getReferenceData.mockImplementation(mockedReferenceData)
+  referenceDataService.getReferenceDescriptionForCode.mockResolvedValue('Mr')
+  restrictionsService.getGlobalRestrictions.mockResolvedValue([])
+  contactsService.getLinkedPrisoners.mockResolvedValue({ content: [], page: { totalElements: 0 } })
+})
+
+afterEach(() => {
+  jest.resetAllMocks()
+})
+describe('Contact details', () => {
+  beforeEach(() => {
+    prisonerSearchService.getByPrisonerNumber.mockResolvedValue(TestData.prisoner())
+    contactsService.getContact.mockResolvedValue(TestData.contact())
+    contactsService.getPrisonerContactRelationship.mockResolvedValue(TestData.prisonerContactRelationship())
+  })
+  describe('Common header area with authoriser role', () => {
+    it('should render common header area when prisoner restrictions are present and logged in as authoriser', async () => {
+      restrictionsService.getGlobalRestrictions.mockResolvedValue([TestData.getContactRestrictionDetails()])
+      // When
+      const response = await request(app).get(`/prisoner/${prisonerNumber}/contacts/add/match/22/${journeyId}`)
+
+      // Then
+      expect(response.status).toEqual(200)
+      const $ = cheerio.load(response.text)
+
+      expect($('.govuk-caption-l').text()).toStrictEqual('Link a contact to a prisoner')
+      expect($('[data-qa=confim-title-value-top]').text().trim()).toStrictEqual(
+        'Check and confirm if you want to link contact Jones Mason to prisoner John Smith',
+      )
+      expect($('[data-qa=authoriser-permission-warning]')).toHaveLength(0)
+      expect($('.moj-badge').text().trim()).toStrictEqual('Active restrictions in place')
+      expect($('p.govuk-body.govuk-\\!-margin-top-3').text().trim()).toStrictEqual(
+        'If this is the correct contact record but their information needs to be updated, you can make updates after you link the record to the prisoner.',
+      )
+    })
+  })
+})

--- a/server/routes/contacts/add/enter-name/createContactEnterNameController.test.ts
+++ b/server/routes/contacts/add/enter-name/createContactEnterNameController.test.ts
@@ -91,7 +91,7 @@ describe('GET /prisoner/:prisonerNumber/contacts/create/enter-name', () => {
     )
     const warningText = $('[data-qa=authoriser-permission-warning]').text().trim()
     expect(warningText).toContain(
-      "As a Contacts Administrator, you cannot approve this contact's visit to John Smith. If you need to do this, ask for the Contacts Authoriser",
+      'As a Contacts Administrator, you cannot approve this contact’s visit to John Smith. If you need to do this, ask for the Contacts Authoriser',
     )
     expect($('.govuk-caption-l').first().text().trim()).toStrictEqual('Add a contact and link to a prisoner')
     expect($('[data-qa=continue-button]').first().text().trim()).toStrictEqual('Continue')

--- a/server/routes/contacts/add/enter-name/createContactEnterNameController.test.ts
+++ b/server/routes/contacts/add/enter-name/createContactEnterNameController.test.ts
@@ -3,7 +3,14 @@ import request from 'supertest'
 import { SessionData } from 'express-session'
 import { v4 as uuidv4 } from 'uuid'
 import * as cheerio from 'cheerio'
-import { appWithAllRoutes, flashProvider, adminUser, adminUserPermissions } from '../../../testutils/appSetup'
+import {
+  appWithAllRoutes,
+  flashProvider,
+  adminUser,
+  adminUserPermissions,
+  authorisingUser,
+  authorisingUserPermissions,
+} from '../../../testutils/appSetup'
 import { Page } from '../../../../services/auditService'
 import { mockedReferenceData, STUBBED_TITLE_OPTIONS } from '../../../testutils/stubReferenceData'
 import TestData from '../../../testutils/testData'
@@ -82,6 +89,58 @@ describe('GET /prisoner/:prisonerNumber/contacts/create/enter-name', () => {
     expect($('[data-qa=main-heading]').first().text().trim()).toStrictEqual(
       'What’s the name of the contact you want to link to John Smith?',
     )
+    const warningText = $('[data-qa=authoriser-permission-warning]').text().trim()
+    expect(warningText).toContain(
+      "As a Contacts Administrator, you cannot approve this contact's visit to John Smith. If you need to do this, ask for the Contacts Authoriser",
+    )
+    expect($('.govuk-caption-l').first().text().trim()).toStrictEqual('Add a contact and link to a prisoner')
+    expect($('[data-qa=continue-button]').first().text().trim()).toStrictEqual('Continue')
+    expect($('[data-qa=cancel-button]')).toHaveLength(0)
+    expect($('[data-qa=breadcrumbs]')).toHaveLength(0)
+  })
+
+  it('should render enter name page with no contact authoriser role', async () => {
+    currentUser = authorisingUser
+    existingJourney = {
+      id: journeyId,
+      lastTouched: new Date().toISOString(),
+      prisonerNumber,
+      isCheckingAnswers: false,
+      mode: 'NEW',
+    }
+    app = appWithAllRoutes({
+      services: {
+        auditService,
+        referenceDataService,
+        prisonerSearchService,
+      },
+      userSupplier: () => currentUser,
+      sessionReceiver: (receivedSession: Partial<SessionData>) => {
+        session = receivedSession
+        session.addContactJourneys = {}
+        session.addContactJourneys[journeyId] = existingJourney
+      },
+    })
+
+    mockPermissions(app, authorisingUserPermissions)
+
+    // When
+    const response = await request(app).get(`/prisoner/${prisonerNumber}/contacts/create/enter-name/${journeyId}`)
+
+    // Then
+    expect(response.status).toEqual(200)
+
+    const $ = cheerio.load(response.text)
+    expect($('title').text()).toStrictEqual(
+      'What’s the name of the contact you want to link to the prisoner? - Add a contact - DPS',
+    )
+    expect($('a:contains("Back to contact search")').attr('href')).toEqual(
+      `/prisoner/A1234BC/contacts/search/${journeyId}`,
+    )
+    expect($('[data-qa=main-heading]').first().text().trim()).toStrictEqual(
+      'What’s the name of the contact you want to link to John Smith?',
+    )
+    expect($('[data-qa=authoriser-permission-warning]')).toHaveLength(0)
     expect($('.govuk-caption-l').first().text().trim()).toStrictEqual('Add a contact and link to a prisoner')
     expect($('[data-qa=continue-button]').first().text().trim()).toStrictEqual('Continue')
     expect($('[data-qa=cancel-button]')).toHaveLength(0)

--- a/server/views/pages/contacts/add/existing/match.njk
+++ b/server/views/pages/contacts/add/existing/match.njk
@@ -4,6 +4,7 @@
 {% from "govuk/components/button/macro.njk" import govukButton %}
 {% from "partials/matchContactContent.njk" import matchContactContent %}
 {% from "moj/components/alert/macro.njk" import mojAlert %}
+{% from "govuk/components/warning-text/macro.njk" import govukWarningText %}
 {% set pageTitle = "Check and confirm if you want to link a contact to a prisoner - Manage contacts - DPS" %}
 {% set title = 'Check and confirm if you want to link contact ' + (contact | formatNameFirstNameFirst ) +' to prisoner ' + (prisonerDetails | formatNameFirstNameFirst(excludeMiddleNames = true)) %}
 
@@ -29,6 +30,14 @@
         }) }}
       {% endif %}
       <p class="govuk-body govuk-!-margin-top-3">If this is the correct contact record but their information needs to be updated, you can make updates after you link the record to the prisoner. </p>
+
+      {% if not isGranted(PersonalRelationshipsPermission.edit_contact_restrictions, prisonerPermissions) %}
+       {{ govukWarningText({
+          html: 'As a Contacts Administrator, you cannot approve ' + (contact | formatNameFirstNameFirst) + ' to visit ' + ( prisonerDetails | formatNameFirstNameFirst(excludeMiddleNames = true) ) + ' . If you need to do this, ask for the Contacts Authoriser role.',
+          iconFallbackText: "Warning",
+          attributes: {"data-qa": "authoriser-permission-warning"}
+        }) }}
+      {% endif %}
     </div>
   </div>
   {{ matchContactContent({

--- a/server/views/pages/contacts/add/new/enterName.njk
+++ b/server/views/pages/contacts/add/new/enterName.njk
@@ -14,8 +14,7 @@
             <h1 class="govuk-heading-l" data-qa="main-heading">{{ title }}</h1>
             {% if not isGranted(PersonalRelationshipsPermission.edit_contact_restrictions, prisonerPermissions) %}
              {{ govukWarningText({
-                html: "As a Contacts Administrator, you cannot approve this contact's visit to " + (prisonerDetails | formatNameFirstNameFirst(excludeMiddleNames = true)) + ". If you need to do this, ask for the Contacts Authoriser role.",
-                iconFallbackText: "Warning",
+                html: "As a Contacts Administrator, you cannot approve this contact’s visit to " + (prisonerDetails | formatNameFirstNameFirst(excludeMiddleNames = true)) + ". If you need to do this, ask for the Contacts Authoriser role.",                iconFallbackText: "Warning",
                 attributes: {"data-qa": "authoriser-permission-warning"}
               }) }}
             {% endif %}

--- a/server/views/pages/contacts/add/new/enterName.njk
+++ b/server/views/pages/contacts/add/new/enterName.njk
@@ -2,6 +2,7 @@
 {% from "govuk/components/input/macro.njk" import govukInput %}
 {% from "govuk/components/select/macro.njk" import govukSelect %}
 {% from "govuk/components/button/macro.njk" import govukButton %}
+{% from "govuk/components/warning-text/macro.njk" import govukWarningText %}
 {% set pageTitle = "What’s the name of the contact you want to link to the prisoner? - Add a contact - DPS" %}
 {% set title = "What’s the name of the contact you want to link to " + prisonerDetails | formatNameFirstNameFirst(excludeMiddleNames = true) + "?" %}
 {% set mainClasses = "app-container govuk-body" %}
@@ -11,6 +12,13 @@
         <div class="govuk-grid-column-two-thirds">
             <span class="govuk-caption-l">{{ caption }}</span>
             <h1 class="govuk-heading-l" data-qa="main-heading">{{ title }}</h1>
+            {% if not isGranted(PersonalRelationshipsPermission.edit_contact_restrictions, prisonerPermissions) %}
+             {{ govukWarningText({
+                html: "As a Contacts Administrator, you cannot approve this contact's visit to " + (prisonerDetails | formatNameFirstNameFirst(excludeMiddleNames = true)) + ". If you need to do this, ask for the Contacts Authoriser role.",
+                iconFallbackText: "Warning",
+                attributes: {"data-qa": "authoriser-permission-warning"}
+              }) }}
+            {% endif %}
             <form method='POST'>
                 <input type="hidden" name="_csrf" value="{{ csrfToken }}" />
 


### PR DESCRIPTION
AC:

1) On the Link a contact page, add a new warning text that says: As a Contacts Administrator, you cannot approve [contact] to visit [prisoner].  If you need to do this, ask for the Contacts Authoriser role.

2) On the first page of the add a new contact journey, add a warning text that reads: As a Contacts Administrator, you cannot approve this contact’s to visit [prisoner]. If you need to do this, ask for the Contacts Authoriser role.

3) Both messages are only shown to users who have the Contacts Administrator role and NOT the Contacts Authoriser role.

Test evidence : 

AC 1: 
<img width="586" height="319" alt="image" src="https://github.com/user-attachments/assets/466510b7-3944-4420-98ff-cd010935b34a" />

AC2:
<img width="639" height="321" alt="image" src="https://github.com/user-attachments/assets/82080183-11af-464b-8fad-11ff0c201583" />