### PR TITLE
PRC-945 : From 1st Oct- Add banner in DPS for all non pilot prisons about national rollout

### DIFF
--- a/server/utils/announcement.ts
+++ b/server/utils/announcement.ts
@@ -14,8 +14,7 @@ const getEnabledPrisons = () => {
 
 const LIMITED_ACCESS_ANNOUNCEMENT: Announcement = {
   title: 'You have limited access to the new Contacts service on DPS',
-  html: `While the new Contacts service is being piloted, your establishment has read-only access.</br>
-To request full access for your establishment, ask your Head of Operations or another appropriate staff member to email
+  html: `Your prison currently has read-only access and will receive full access on Tuesday 21 October. Prepare by reading our <a class="govuk-notification-sharepoint__link" href="https://justiceuk.sharepoint.com/:u:/r/sites/prisons-digital/SitePages/Managing%20Prisoner%20Contacts.aspx?csf=1&web=1&e=47P78C" target="_blank" rel="noopener noreferrer">Sharepoint site</a>.<br/>If you have any questions, please contact
 <a class="govuk-notification-banner__link" href="mailto:managingcontacts@justice.gov.uk">managingcontacts@justice.gov.uk</a>.
 
 <div class="govuk-notification-banner__content govuk-!-padding-left-0">

--- a/server/utils/announcements.test.ts
+++ b/server/utils/announcements.test.ts
@@ -2,8 +2,7 @@ import { getAnnouncement } from './announcement'
 
 describe('announcement', () => {
   const OLD_ENV = process.env
-  const INFO_TEXT = `While the new Contacts service is being piloted, your establishment has read-only access.</br>
-To request full access for your establishment, ask your Head of Operations or another appropriate staff member to email
+  const INFO_TEXT = `Your prison currently has read-only access and will receive full access on Tuesday 21 October. Prepare by reading our <a class="govuk-notification-sharepoint__link" href="https://justiceuk.sharepoint.com/:u:/r/sites/prisons-digital/SitePages/Managing%20Prisoner%20Contacts.aspx?csf=1&web=1&e=47P78C" target="_blank" rel="noopener noreferrer">Sharepoint site</a>.<br/>If you have any questions, please contact
 <a class="govuk-notification-banner__link" href="mailto:managingcontacts@justice.gov.uk">managingcontacts@justice.gov.uk</a>.
 
 <div class="govuk-notification-banner__content govuk-!-padding-left-0">


### PR DESCRIPTION
AC:
From 1st October, in all non-rollout prisons, the following should be true:

Banner retaining existing title, design, conditional reveal, and interaction should continue to display

Content should be updated to:
Your prison currently has read-only access and will receive full access on Tuesday 21 October. Prepare by reading our [SharePoint site](https://justiceuk.sharepoint.com/:u:/r/sites/prisons-digital/SitePages/Managing%20Prisoner%20Contacts.aspx?csf=1&web=1&e=J9TUP0).

If you have any questions, please contact [managingcontacts@justice.gov.uk](mailto:managingcontacts@justice.gov.uk)


Test evidence:
<img width="1109" height="586" alt="image" src="https://github.com/user-attachments/assets/39ecf7ae-3994-4ba1-bbba-40889af8982e" />
