### PR TITLE
VB-6518 Handle alerts or restrictions APIs being unavailable

### DIFF
--- a/assets/scss/components/_mini-profile.scss
+++ b/assets/scss/components/_mini-profile.scss
@@ -43,6 +43,17 @@
 .mini-profile-info li {
   margin-right: 25px;
   color: #0b0c0c;
+
+  &:last-child {
+    max-width: 30%;
+  }
+}
+
+.mini-profile .inset-api-error {
+  @include govuk-font($size: 16);
+  padding: 4px 8px;
+  border-left: $govuk-border-width solid govuk-colour('red');
+  margin-bottom: 4px;
 }
 
 /* Media query for larger screens */

--- a/assets/scss/components/_mini-profile.scss
+++ b/assets/scss/components/_mini-profile.scss
@@ -43,10 +43,10 @@
 .mini-profile-info li {
   margin-right: 25px;
   color: #0b0c0c;
+}
 
-  &:last-child {
-    max-width: 30%;
-  }
+.mini-profile-alerts-restrictions {
+  max-width: 30%;
 }
 
 .mini-profile .inset-api-error {

--- a/server/@types/journeys/index.d.ts
+++ b/server/@types/journeys/index.d.ts
@@ -150,8 +150,8 @@ export interface PrisonerDetails {
   prisonName?: string | undefined
   cellLocation?: string | undefined
   hasPrimaryAddress: boolean
-  alertsCount: number
-  restrictionsCount: number
+  alertsCount: number | null // null if alerts count failed to fetch
+  restrictionsCount: number | null // null if restrictions count failed to fetch
 }
 
 export interface EmploymentDetails {

--- a/server/middleware/populatePrisonerDetailsIfInCaseload.test.ts
+++ b/server/middleware/populatePrisonerDetailsIfInCaseload.test.ts
@@ -3,7 +3,7 @@ import populatePrisonerDetailsIfInCaseload from './populatePrisonerDetailsIfInCa
 import TestData from '../routes/testutils/testData'
 import RestrictionsTestData from '../routes/testutils/stubRestrictionsData'
 import { basicPrisonUser } from '../routes/testutils/appSetup'
-import { PrisonerSearchAddress } from '../data/prisonerOffenderSearchTypes'
+import { Prisoner, PrisonerSearchAddress } from '../data/prisonerOffenderSearchTypes'
 import { MockedService } from '../testutils/mockedServices'
 import { PrisonerDetails } from '../@types/journeys'
 import pagedPrisonerAlertsData from '../testutils/testPrisonerAlertsData'
@@ -19,16 +19,26 @@ const alertsService = MockedService.AlertsService()
 type Request = ExpressRequest<{ prisonerNumber: string }>
 
 describe('prisonerDetailsMiddleware', () => {
-  const prisoner = TestData.prisoner()
+  let prisoner: Prisoner
   const res = { locals: { user: basicPrisonUser }, render: jest.fn(), status: jest.fn() } as unknown as Response
 
   let req = {} as Request
+  const next = jest.fn()
 
   beforeEach(() => {
     delete res.locals.prisonerDetails
-    // provide a sensible default so middleware won't throw when awaiting restrictions
+
+    prisoner = TestData.prisoner()
+
+    prisonerSearchService.getByPrisonerNumber.mockResolvedValue(prisoner)
     contactsService.getPrisonerRestrictions.mockResolvedValue(RestrictionsTestData.stubRestrictionsData())
     alertsService.getAlerts.mockResolvedValue(pagedPrisonerAlertsData())
+
+    req = {
+      params: {
+        prisonerNumber: 'A1234BC',
+      },
+    } as Request
   })
 
   afterEach(() => {
@@ -36,15 +46,7 @@ describe('prisonerDetailsMiddleware', () => {
   })
 
   it('should add prisoner details and call next', async () => {
-    const next = jest.fn()
-    prisonerSearchService.getByPrisonerNumber.mockResolvedValue(prisoner)
     contactsService.getPrisonerRestrictions.mockResolvedValue(RestrictionsTestData.stubRestrictionsData())
-
-    req = {
-      params: {
-        prisonerNumber: 'A1234BC',
-      },
-    } as Request
 
     await populatePrisonerDetailsIfInCaseload(prisonerSearchService, contactsService, alertsService)(req, res, next)
 
@@ -65,15 +67,7 @@ describe('prisonerDetailsMiddleware', () => {
   })
 
   it('should add prisoner details if no addresses', async () => {
-    const next = jest.fn()
-    prisonerSearchService.getByPrisonerNumber.mockResolvedValue(prisoner)
     prisoner.addresses = []
-
-    req = {
-      params: {
-        prisonerNumber: 'A1234BC',
-      },
-    } as Request
 
     await populatePrisonerDetailsIfInCaseload(prisonerSearchService, contactsService, alertsService)(req, res, next)
 
@@ -92,19 +86,11 @@ describe('prisonerDetailsMiddleware', () => {
   })
 
   it('should add prisoner details if no primary addresses', async () => {
-    const next = jest.fn()
-    prisonerSearchService.getByPrisonerNumber.mockResolvedValue(prisoner)
     const prisonerAddress: PrisonerSearchAddress = {
       fullAddress: '12, my street, england',
       primaryAddress: false,
     }
     prisoner.addresses = [prisonerAddress]
-
-    req = {
-      params: {
-        prisonerNumber: 'A1234BC',
-      },
-    } as Request
 
     await populatePrisonerDetailsIfInCaseload(prisonerSearchService, contactsService, alertsService)(req, res, next)
 
@@ -123,19 +109,11 @@ describe('prisonerDetailsMiddleware', () => {
   })
 
   it('should add prisoner details if has a primary address', async () => {
-    const next = jest.fn()
-    prisonerSearchService.getByPrisonerNumber.mockResolvedValue(prisoner)
     const prisonerAddress: PrisonerSearchAddress = {
       fullAddress: '12, my street, england',
       primaryAddress: true,
     }
     prisoner.addresses = [prisonerAddress]
-
-    req = {
-      params: {
-        prisonerNumber: 'A1234BC',
-      },
-    } as Request
 
     await populatePrisonerDetailsIfInCaseload(prisonerSearchService, contactsService, alertsService)(req, res, next)
 
@@ -153,19 +131,21 @@ describe('prisonerDetailsMiddleware', () => {
     expect(res.locals.prisonerDetails).toStrictEqual(expectedPrisonerDetails)
   })
 
-  it('should deal with problems coming from the service without blowing up', async () => {
-    const next = jest.fn()
-    const error = new Error('Bang!')
-    prisonerSearchService.getByPrisonerNumber.mockRejectedValue(error)
-
-    req = {
-      params: {
-        prisonerNumber: 'A1234BC',
-      },
-    } as Request
+  it('should handle alerts API failure', async () => {
+    alertsService.getAlerts.mockRejectedValue(new Error())
 
     await populatePrisonerDetailsIfInCaseload(prisonerSearchService, contactsService, alertsService)(req, res, next)
 
-    expect(prisonerSearchService.getByPrisonerNumber).toHaveBeenCalledWith('A1234BC', basicPrisonUser)
+    expect(res.locals.prisonerDetails!.alertsCount).toBeNull()
+    expect(res.locals.prisonerDetails!.restrictionsCount).toBe(1)
+  })
+
+  it('should propagate errors (to be handled by the error middleware)', async () => {
+    const error = new Error('Bang!')
+    prisonerSearchService.getByPrisonerNumber.mockRejectedValue(error)
+
+    await expect(
+      populatePrisonerDetailsIfInCaseload(prisonerSearchService, contactsService, alertsService)(req, res, next),
+    ).rejects.toThrow(error)
   })
 })

--- a/server/middleware/populatePrisonerDetailsIfInCaseload.ts
+++ b/server/middleware/populatePrisonerDetailsIfInCaseload.ts
@@ -1,10 +1,7 @@
-import { Request, Response, NextFunction } from 'express'
+import { NextFunction, Request, Response } from 'express'
 import { PrisonerSearchService, ContactsService } from '../services'
 import { Prisoner } from '../data/prisonerOffenderSearchTypes'
 import { PrisonerDetails } from '../@types/journeys'
-import { PagedModelPrisonerRestrictionDetails } from '../@types/contactsApiClient'
-import logger from '../../logger'
-import { PageAlert } from '../data/alertsApiTypes'
 import AlertsService from '../services/alertsService'
 
 const populatePrisonerDetailsIfInCaseload = (
@@ -17,43 +14,32 @@ const populatePrisonerDetailsIfInCaseload = (
     const { prisonerNumber } = req.params
     const { user } = res.locals
 
-    try {
-      // get prisoner first - if prisoner lookup fails we won't attempt restrictions
-      const prisoner: Prisoner | undefined = await prisonerSearchService.getByPrisonerNumber(prisonerNumber, user)
+    // get prisoner first - if prisoner lookup fails we won't attempt restrictions
+    const prisoner = await prisonerSearchService.getByPrisonerNumber(prisonerNumber, user)
 
-      if (prisoner) {
-        // fetch restrictions count safely
-        let restrictionsCount = 0
-        let alertsCount = 0
-        try {
-          const restrictions: PagedModelPrisonerRestrictionDetails = await contactsService.getPrisonerRestrictions(
-            prisonerNumber,
-            0,
-            10,
-            user,
-            false,
-            false,
-          )
-          restrictionsCount = restrictions?.content?.length ?? 0
+    if (prisoner) {
+      // get restrictions and alerts in parallel - then if either fails set count to null so template can render API failure message
+      const [restrictionsPromise, alertsPromise] = await Promise.allSettled([
+        contactsService.getPrisonerRestrictions(prisonerNumber, 0, 10, user, false, false),
+        alertsService.getAlerts(prisonerNumber, user),
+      ])
 
-          const prisonerAlertsContent: PageAlert = await alertsService.getAlerts(prisonerNumber, user)
-          alertsCount = prisonerAlertsContent?.content?.length ?? 0
-        } catch (err) {
-          // do nothing if restrictions fetch fails - we can still show prisoner details
-          logger.error(err, `Failed to populate alerts and restrictions for prisoner: ${req.params.prisonerNumber}`)
-        }
+      const restrictionsCount =
+        restrictionsPromise.status === 'fulfilled' ? (restrictionsPromise.value?.content?.length ?? 0) : null
 
-        res.locals.prisonerDetails = toPrisonerDetails(prisoner, restrictionsCount, alertsCount)
-      }
-    } catch (err) {
-      logger.error(err, `Failed to populate prisoner details for prisoner: ${req.params.prisonerNumber}`)
-      next(err)
-    } finally {
-      next()
+      const alertsCount = alertsPromise.status === 'fulfilled' ? (alertsPromise.value?.content?.length ?? 0) : null
+
+      res.locals.prisonerDetails = toPrisonerDetails(prisoner, restrictionsCount, alertsCount)
     }
+
+    next()
   }
 
-  function toPrisonerDetails(prisoner: Prisoner, restrictionsCount: number, alertsCount: number): PrisonerDetails {
+  function toPrisonerDetails(
+    prisoner: Prisoner,
+    restrictionsCount: number | null,
+    alertsCount: number | null,
+  ): PrisonerDetails {
     const hasPrimaryAddress = !!(
       prisoner.addresses &&
       prisoner.addresses.length > 0 &&

--- a/server/routes/prisonerMiniProfile.test.ts
+++ b/server/routes/prisonerMiniProfile.test.ts
@@ -1,0 +1,195 @@
+import type { Express } from 'express'
+import request from 'supertest'
+import * as cheerio from 'cheerio'
+import { CorePersonRecordPermission } from '@ministryofjustice/hmpps-prison-permissions-lib'
+import { adminUserPermissions, appWithAllRoutes, basicPrisonUser, readOnlyPermissions } from './testutils/appSetup'
+import { MockedService } from '../testutils/mockedServices'
+import TestData from './testutils/testData'
+import { HmppsUser } from '../interfaces/hmppsUser'
+import mockPermissions from './testutils/mockPermissions'
+import config from '../config'
+import pagedPrisonerAlertsData from '../testutils/testPrisonerAlertsData'
+import RestrictionsTestData from './testutils/stubRestrictionsData'
+
+jest.mock('@ministryofjustice/hmpps-prison-permissions-lib')
+jest.mock('../services/auditService')
+jest.mock('../services/alertsService')
+jest.mock('../services/contactsService')
+jest.mock('../services/prisonerSearchService')
+
+const auditService = MockedService.AuditService()
+const alertsService = MockedService.AlertsService()
+const contactsService = MockedService.ContactsService()
+const prisonerSearchService = MockedService.PrisonerSearchService()
+
+const prisonerNumber = 'A1234BC'
+const prisoner = TestData.prisoner({ prisonerNumber })
+const contact = TestData.getPrisonerContact()
+
+let app: Express
+let currentUser: HmppsUser
+
+beforeEach(() => {
+  currentUser = basicPrisonUser
+
+  app = appWithAllRoutes({
+    services: {
+      auditService,
+      alertsService,
+      contactsService,
+      prisonerSearchService,
+    },
+    userSupplier: () => currentUser,
+  })
+
+  alertsService.getAlerts.mockResolvedValue(pagedPrisonerAlertsData())
+
+  contactsService.filterPrisonerContacts.mockResolvedValue({
+    content: [contact],
+    page: { totalElements: 1, totalPages: 1, size: 10, number: 0 },
+  })
+  contactsService.getPrisonerRestrictions.mockResolvedValue(RestrictionsTestData.stubRestrictionsData())
+
+  prisonerSearchService.getByPrisonerNumber.mockResolvedValue(prisoner)
+})
+
+afterEach(() => {
+  jest.resetAllMocks()
+})
+
+// Mini profile displayed on most contacts pages; testing here on
+// GET /prisoner/:prisonerNumber/contacts/list
+describe('Prisoner Mini Profile', () => {
+  it('should render prisoner mini profile for users with read contacts permission (no alerts/restrictions)', async () => {
+    mockPermissions(app, readOnlyPermissions)
+
+    return request(app)
+      .get(`/prisoner/${prisonerNumber}/contacts/list`)
+      .expect('Content-Type', /html/)
+      .expect(200)
+      .expect(res => {
+        const $ = cheerio.load(res.text)
+        expect($('[data-qa=mini-profile-person-profile-link]').text()).toBe('Smith, John')
+        expect($('[data-qa=mini-profile-person-profile-link]').attr('href')).toBe(
+          `${config.serviceUrls.digitalPrison}/prisoner/${prisonerNumber}`,
+        )
+        expect($('[data-qa=mini-profile-prisoner-number]').text()).toBe(prisonerNumber)
+        expect($('[data-qa=mini-profile-dob]').text()).toBe('2 April 1975')
+        expect($('[data-qa=mini-profile-prison-name]').text()).toBe('HMP Hewell')
+        expect($('[data-qa=mini-profile-cell-location]').text()).toBe('1-1-C-028')
+
+        // Need edit contacts permissions to view alerts and restrictions
+        expect($('[data-qa=mini-profile-alerts-restrictions]').length).toBe(0)
+        expect($('[data-qa=mini-profile-alerts-restrictions-unavailable]').length).toBe(0)
+      })
+  })
+
+  it('should render prisoner mini profile for users with edit contacts permission (with alerts/restrictions)', async () => {
+    mockPermissions(app, adminUserPermissions)
+
+    return request(app)
+      .get(`/prisoner/${prisonerNumber}/contacts/list`)
+      .expect('Content-Type', /html/)
+      .expect(200)
+      .expect(res => {
+        const $ = cheerio.load(res.text)
+        expect($('[data-qa=mini-profile-alerts-restrictions]').text()).toBe('1 restriction and 1 alert')
+        expect($('[data-qa=mini-profile-alerts-restrictions]').attr('href')).toBe(
+          `/prisoner/${prisonerNumber}/alerts-restrictions`,
+        )
+        expect($('[data-qa=mini-profile-alerts-restrictions-unavailable]').length).toBe(0)
+      })
+  })
+
+  it('should show prisoner image for user with permission', async () => {
+    mockPermissions(app, { ...readOnlyPermissions, [CorePersonRecordPermission.read_photo]: true })
+
+    return request(app)
+      .get(`/prisoner/${prisonerNumber}/contacts/list`)
+      .expect('Content-Type', /html/)
+      .expect(200)
+      .expect(res => {
+        const $ = cheerio.load(res.text)
+        expect($('[data-qa=mini-profile-person-img]').attr('src')).toBe(`/prisoner-image/${prisonerNumber}`)
+        expect($('[data-qa=mini-profile-person-img]').attr('alt')).toBe('Image of Smith, John')
+        expect($('[data-qa=mini-profile-person-img-unavailable]').length).toBe(0)
+      })
+  })
+
+  it('should show fallback prisoner image for user without permission', async () => {
+    mockPermissions(app, { ...readOnlyPermissions, [CorePersonRecordPermission.read_photo]: false })
+
+    return request(app)
+      .get(`/prisoner/${prisonerNumber}/contacts/list`)
+      .expect('Content-Type', /html/)
+      .expect(200)
+      .expect(res => {
+        const $ = cheerio.load(res.text)
+        expect($('[data-qa=mini-profile-person-img-unavailable]').attr('src')).toBe(
+          '/assets/images/prisoner-profile-image.png',
+        )
+        expect($('[data-qa=mini-profile-person-img-unavailable]').attr('alt')).toBe(
+          'Image of Smith, John is not available',
+        )
+        expect($('[data-qa=mini-profile-person-img]').length).toBe(0)
+      })
+  })
+
+  it('should handle error fetching alerts and show API error message', async () => {
+    mockPermissions(app, adminUserPermissions)
+    alertsService.getAlerts.mockRejectedValue(new Error('API error'))
+
+    return request(app)
+      .get(`/prisoner/${prisonerNumber}/contacts/list`)
+      .expect('Content-Type', /html/)
+      .expect(200)
+      .expect(res => {
+        const $ = cheerio.load(res.text)
+        expect($('[data-qa=mini-profile-alerts-restrictions]').text()).toBe('1 restriction')
+        expect($('[data-qa=mini-profile-alerts-restrictions]').attr('href')).toBe(
+          `/prisoner/${prisonerNumber}/alerts-restrictions`,
+        )
+        expect($('[data-qa=mini-profile-alerts-restrictions-unavailable]').text()).toContain(
+          'Alerts information is currently unavailable',
+        )
+      })
+  })
+
+  it('should handle error fetching restrictions and show API error message', async () => {
+    mockPermissions(app, adminUserPermissions)
+    contactsService.getPrisonerRestrictions.mockRejectedValue(new Error('API error'))
+
+    return request(app)
+      .get(`/prisoner/${prisonerNumber}/contacts/list`)
+      .expect('Content-Type', /html/)
+      .expect(200)
+      .expect(res => {
+        const $ = cheerio.load(res.text)
+        expect($('[data-qa=mini-profile-alerts-restrictions]').text()).toBe('1 alert')
+        expect($('[data-qa=mini-profile-alerts-restrictions]').attr('href')).toBe(
+          `/prisoner/${prisonerNumber}/alerts-restrictions`,
+        )
+        expect($('[data-qa=mini-profile-alerts-restrictions-unavailable]').text()).toContain(
+          'Restrictions information is currently unavailable',
+        )
+      })
+  })
+
+  it('should handle errors fetching both alerts and restrictions and show API error message', async () => {
+    mockPermissions(app, adminUserPermissions)
+    alertsService.getAlerts.mockRejectedValue(new Error('API error'))
+    contactsService.getPrisonerRestrictions.mockRejectedValue(new Error('API error'))
+
+    return request(app)
+      .get(`/prisoner/${prisonerNumber}/contacts/list`)
+      .expect('Content-Type', /html/)
+      .expect(200)
+      .expect(res => {
+        const $ = cheerio.load(res.text)
+        expect($('[data-qa=mini-profile-alerts-restrictions]').length).toBe(0)
+        expect($('[data-qa=mini-profile-alerts-restrictions-unavailable]').text()).toContain(
+          'Restrictions and alerts information is currently unavailable',
+        )
+      })
+  })
+})

--- a/server/routes/testutils/mockPermissions.ts
+++ b/server/routes/testutils/mockPermissions.ts
@@ -1,4 +1,5 @@
 import {
+  CorePersonRecordPermission,
   isGranted,
   PersonalRelationshipsPermission,
   PrisonerPermission,
@@ -16,7 +17,9 @@ export default function mockPermissions(app: Express, permissions: Partial<Recor
   isGrantedMock.mockImplementation((perm, _perms) => permissions[perm] || false)
   setupNunjucksPermissionsMock.mockImplementation(njkEnv => {
     njkEnv.addGlobal('isGranted', isGrantedMock)
-    Object.entries({ PersonalRelationshipsPermission }).forEach(([key, value]) => njkEnv.addGlobal(key, value))
+    Object.entries({ PersonalRelationshipsPermission, CorePersonRecordPermission }).forEach(([key, value]) =>
+      njkEnv.addGlobal(key, value),
+    )
   })
   prisonerPermissionsGuardMock.mockImplementation((_service, options) => async (_req, _res, next) => {
     return options.requestDependentOn.some(perm => !permissions[perm]) ? next(new Error('Permission denied')) : next()

--- a/server/views/partials/miniProfile/template.njk
+++ b/server/views/partials/miniProfile/template.njk
@@ -31,18 +31,38 @@
                 {% if isGranted(PersonalRelationshipsPermission.edit_contacts, prisonerPermissions) %}
                   <li>
                       <span class="govuk-heading-s govuk-!-margin-bottom-0 govuk-!-padding-0">Restrictions and Alerts</span>
-                      <p class="govuk-body govuk-!-margin-bottom-1">
-                         <a id="prisoner-alerts-restrictions-link"
+                      {% if prisonerDetails.restrictionsCount is not null or prisonerDetails.alertsCount is not null %}
+                        <p class="govuk-body govuk-!-margin-bottom-1">
+                          <a id="prisoner-alerts-restrictions-link"
                             class="govuk-link--no-visited-state"
                             href="/prisoner/{{ prisonerDetails.prisonerNumber }}/alerts-restrictions"
                             data-qa="contact-{{ prisonerDetails.prisonerNumber }}-alerts-restrictions">
-                           {{ prisonerDetails.restrictionsCount }}
-                           {% if prisonerDetails.restrictionsCount == 1 %}restriction{% else %}restrictions{% endif %}
-                           and
-                           {{ prisonerDetails.alertsCount }}
-                           {% if prisonerDetails.alertsCount == 1 %}alert{% else %}alerts{% endif %}
-                         </a>
-                      </p>
+                              {% if prisonerDetails.restrictionsCount is not null %}
+                                {{ prisonerDetails.restrictionsCount }}
+                                {% if prisonerDetails.restrictionsCount == 1 %}restriction{% else %}restrictions{% endif %}
+                              {% endif %}
+
+                              {{ "and" if prisonerDetails.restrictionsCount and prisonerDetails.alertsCount }}
+
+                              {% if prisonerDetails.alertsCount is not null %}
+                                {{ prisonerDetails.alertsCount }}
+                                {% if prisonerDetails.alertsCount == 1 %}alert{% else %}alerts{% endif %}
+                              {% endif %}
+                          </a>
+                        </p>
+                      {% endif %}
+
+                      {% if prisonerDetails.restrictionsCount is null or prisonerDetails.alertsCount is null %}
+                        <div>
+                          {%- if prisonerDetails.restrictionsCount is null %}Restrictions {% endif -%}
+                          {%- if prisonerDetails.restrictionsCount is null and prisonerDetails.alertsCount is null %}and {% endif -%}
+                          {%- if prisonerDetails.alertsCount is null and prisonerDetails.restrictionsCount is null -%}
+                            alerts
+                          {%- elseif prisonerDetails.alertsCount is null -%}
+                            Alerts
+                          {%- endif %} information is currently unavailable. Try again later.
+                        </div>
+                      {% endif %}
                   </li>
                 {% endif %}
             </ul>

--- a/server/views/partials/miniProfile/template.njk
+++ b/server/views/partials/miniProfile/template.njk
@@ -53,7 +53,7 @@
                       {% endif %}
 
                       {% if prisonerDetails.restrictionsCount is null or prisonerDetails.alertsCount is null %}
-                        <div>
+                        <p class="inset-api-error" data-qa="alerts-restrictions-unavailable">
                           {%- if prisonerDetails.restrictionsCount is null %}Restrictions {% endif -%}
                           {%- if prisonerDetails.restrictionsCount is null and prisonerDetails.alertsCount is null %}and {% endif -%}
                           {%- if prisonerDetails.alertsCount is null and prisonerDetails.restrictionsCount is null -%}
@@ -61,7 +61,7 @@
                           {%- elseif prisonerDetails.alertsCount is null -%}
                             Alerts
                           {%- endif %} information is currently unavailable. Try again later.
-                        </div>
+                        </p>
                       {% endif %}
                   </li>
                 {% endif %}

--- a/server/views/partials/miniProfile/template.njk
+++ b/server/views/partials/miniProfile/template.njk
@@ -39,7 +39,7 @@
                             data-qa="mini-profile-alerts-restrictions">
                               {%- if prisonerDetails.restrictionsCount is not null -%}
                                 {{- prisonerDetails.restrictionsCount -}}
-                                {%- if prisonerDetails.restrictionsCount == 1 %} restriction{% else %}restrictions {% endif -%}
+                                {%- if prisonerDetails.restrictionsCount == 1 %} restriction{% else %} restrictions{% endif -%}
                               {%- endif -%}
 
                               {%- if prisonerDetails.restrictionsCount is not null and prisonerDetails.alertsCount is not null %} and {% endif -%}

--- a/server/views/partials/miniProfile/template.njk
+++ b/server/views/partials/miniProfile/template.njk
@@ -29,33 +29,33 @@
                     <span class="govuk-body" data-qa="mini-profile-cell-location">{{ prisonerDetails.cellLocation }}</span>
                 </li>
                 {% if isGranted(PersonalRelationshipsPermission.edit_contacts, prisonerPermissions) %}
-                  <li>
+                  <li class="mini-profile-alerts-restrictions">
                       <span class="govuk-heading-s govuk-!-margin-bottom-0 govuk-!-padding-0">Restrictions and Alerts</span>
                       {% if prisonerDetails.restrictionsCount is not null or prisonerDetails.alertsCount is not null %}
                         <p class="govuk-body govuk-!-margin-bottom-1">
                           <a id="prisoner-alerts-restrictions-link"
                             class="govuk-link--no-visited-state"
                             href="/prisoner/{{ prisonerDetails.prisonerNumber }}/alerts-restrictions"
-                            data-qa="contact-{{ prisonerDetails.prisonerNumber }}-alerts-restrictions">
-                              {% if prisonerDetails.restrictionsCount is not null %}
-                                {{ prisonerDetails.restrictionsCount }}
-                                {% if prisonerDetails.restrictionsCount == 1 %}restriction{% else %}restrictions{% endif %}
-                              {% endif %}
+                            data-qa="mini-profile-alerts-restrictions">
+                              {%- if prisonerDetails.restrictionsCount is not null -%}
+                                {{- prisonerDetails.restrictionsCount -}}
+                                {%- if prisonerDetails.restrictionsCount == 1 %} restriction{% else %}restrictions {% endif -%}
+                              {%- endif -%}
 
-                              {{ "and" if prisonerDetails.restrictionsCount and prisonerDetails.alertsCount }}
+                              {%- if prisonerDetails.restrictionsCount is not null and prisonerDetails.alertsCount is not null %} and {% endif -%}
 
-                              {% if prisonerDetails.alertsCount is not null %}
-                                {{ prisonerDetails.alertsCount }}
-                                {% if prisonerDetails.alertsCount == 1 %}alert{% else %}alerts{% endif %}
-                              {% endif %}
+                              {%- if prisonerDetails.alertsCount is not null -%}
+                                {{- prisonerDetails.alertsCount -}}
+                                {%- if prisonerDetails.alertsCount == 1 %} alert{% else %} alerts{% endif -%}
+                              {%- endif -%}
                           </a>
                         </p>
                       {% endif %}
 
                       {% if prisonerDetails.restrictionsCount is null or prisonerDetails.alertsCount is null %}
-                        <p class="inset-api-error" data-qa="alerts-restrictions-unavailable">
-                          {%- if prisonerDetails.restrictionsCount is null %}Restrictions {% endif -%}
-                          {%- if prisonerDetails.restrictionsCount is null and prisonerDetails.alertsCount is null %}and {% endif -%}
+                        <p class="inset-api-error" data-qa="mini-profile-alerts-restrictions-unavailable">
+                          {%- if prisonerDetails.restrictionsCount is null %}Restrictions{% endif -%}
+                          {%- if prisonerDetails.restrictionsCount is null and prisonerDetails.alertsCount is null %} and {% endif -%}
                           {%- if prisonerDetails.alertsCount is null and prisonerDetails.restrictionsCount is null -%}
                             alerts
                           {%- elseif prisonerDetails.alertsCount is null -%}


### PR DESCRIPTION
The prisoner 'mini-profile' used throughout the service displays counts of alerts and restrictions. If API calls to get either of these fails the code would default to (incorrectly) rendering zero counts for alerts/restrictions.

This change improves handling of API failures by showing an inset error message explaining that alerts and/or restrictions information is unavailable.