### PR TITLE
Fix copy for Date of Birth sort-by option

### DIFF
--- a/server/views/pages/contacts/manage/enhancedContactSearch.njk
+++ b/server/views/pages/contacts/manage/enhancedContactSearch.njk
@@ -82,8 +82,8 @@
                         items: [
                             { value: "lastName,asc", text: "Last name (A–Z)", selected: (sort == 'lastName,asc') },
                             { value: "lastName,desc", text: "Last name (Z–A)" , selected: (sort == 'lastName,desc') },
-                            { value: "dateOfBirth,asc", text: "Date of birth (most recent)" , selected: (sort == 'dateOfBirth,asc') },
-                            { value: "dateOfBirth,desc", text: "Date of birth (oldest)" , selected: (sort == 'dateOfBirth,desc') }
+                            { value: "dateOfBirth,asc", text: "Date of birth (oldest first)" , selected: (sort == 'dateOfBirth,asc') },
+                            { value: "dateOfBirth,desc", text: "Date of birth (youngest first)" , selected: (sort == 'dateOfBirth,desc') }
                         ]
                     }) +
 

--- a/server/views/pages/contacts/view/directContactSearch.njk
+++ b/server/views/pages/contacts/view/directContactSearch.njk
@@ -76,8 +76,8 @@
                         items: [
                             { value: "lastName,asc", text: "Last name (A–Z)", selected: (sort == 'lastName,asc') },
                             { value: "lastName,desc", text: "Last name (Z–A)" , selected: (sort == 'lastName,desc') },
-                            { value: "dateOfBirth,asc", text: "Date of birth (most recent)" , selected: (sort == 'dateOfBirth,asc') },
-                            { value: "dateOfBirth,desc", text: "Date of birth (oldest)" , selected: (sort == 'dateOfBirth,desc') }
+                            { value: "dateOfBirth,asc", text: "Date of birth (oldest first)" , selected: (sort == 'dateOfBirth,asc') },
+                            { value: "dateOfBirth,desc", text: "Date of birth (youngest first)" , selected: (sort == 'dateOfBirth,desc') }
                         ]
                     }) +
 


### PR DESCRIPTION
Swapped "most recent" and "oldest" copy to correctly align with asc/desc sort-by-order for age. 

Also adjusted phrasing  to make it clearer.