### PR TITLE
schedule downtime in dev

### DIFF
--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -7,6 +7,9 @@ generic-service:
   ingress:
     host: contacts-dev.hmpps.service.justice.gov.uk
 
+  scheduledDowntime:
+    enabled: true
+
   env:
     INGRESS_URL: 'https://contacts-dev.hmpps.service.justice.gov.uk'
     HMPPS_AUTH_URL: 'https://sign-in-dev.hmpps.service.justice.gov.uk/auth'


### PR DESCRIPTION
I noticed contacts was throwing lots of errors overnight on the health endpoint because it depends on prisoner-search which is scheduled to be down.

so might as well shut contacts off at same time.